### PR TITLE
Modify BigQuerySinkTask to be able to handle null messages.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -239,6 +239,7 @@ public class BigQuerySinkTask extends SinkTask {
     for (SinkRecord record : records) {
       if (recordEmpty(record)) {
         // ignore it
+        logger.debug("ignoring empty record value for topic: " + record.topic());
         continue;
       }
       TableId tableId = getRecordTable(record);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -101,6 +101,25 @@ public class BigQuerySinkTaskTest {
   }
 
   @Test
+  public void testEmptyRecordPut() {
+    final String topic = "test_topic";
+    final Schema simpleSchema = SchemaBuilder
+        .struct()
+        .field("aField", Schema.STRING_SCHEMA)
+        .build();
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    BigQuery bigQuery = mock(BigQuery.class);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery);
+    testTask.start(properties);
+
+    SinkRecord emptyRecord = spoofSinkRecord(topic, simpleSchema, null);
+
+    testTask.put(Collections.singletonList(emptyRecord));
+  }
+
+  @Test
   public void testPartitioning() {
     final String dataset = "scratch";
     final String topic = "test_topic";


### PR DESCRIPTION
This is needed because debezium sends null messages when it is deleting messages in kafka.
We do nothing because we do not want hard deletes in BQ.