### PR TITLE
Fix dynamic batch writer

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -155,12 +155,12 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   /**
-   * A class for keeping track of the BatchWriters for each partitionedTableId.
+   * A class for keeping track of the BatchWriters for each base table.
    */
   private static class BatchWriterManager {
     private final BigQueryWriter bigQueryWriter;
     private final Class<BatchWriter<InsertAllRequest.RowToInsert>> batchWriterClass;
-    // map from base partitionedTableId id to the batchWriter for that base partitionedTableId
+    // map from base TableId to the batchWriter for that base table
     private Map<TableId, BatchWriter<RowToInsert>> baseTableBatchWriterMap;
 
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -1,0 +1,45 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.time.LocalDate;
+
+/**
+ * A TableId with separate partition information.
+ */
+public class PartitionedTableId {
+
+  public static final String PARTITION_DELIMITER = "$";
+
+  public PartitionedTableId(String dataset, String table, String partition) {
+
+  }
+
+  public PartitionedTableId(String project, String dataset, String table, String partition) {
+
+  }
+
+  public static String dateToDayPartition(LocalDate localDate) {
+    StringBuilder sb = new StringBuilder();
+    return sb.append(localDate.getYear())
+        .append(localDate.getMonthValue())
+        .append(localDate.getDayOfMonth())
+        .toString();
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -26,7 +26,7 @@ import java.time.LocalDate;
 /**
  * A TableId with separate base table name and partition information.
  */
-public class PartitionedTableId { // todo make tests for me
+public class PartitionedTableId {
 
   private static final String PARTITION_DELIMITER = "$";
   private static final Clock UTC_CLOCK = Clock.systemUTC();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -1,6 +1,5 @@
 package com.wepay.kafka.connect.bigquery.utils;
 
-
 /*
  * Copyright 2016 WePay, Inc.
  *
@@ -18,28 +17,179 @@ package com.wepay.kafka.connect.bigquery.utils;
  * under the License.
  */
 
+
+import com.google.cloud.bigquery.TableId;
+
 import java.time.LocalDate;
 
 /**
- * A TableId with separate partition information.
+ * A TableId with separate base table name and partition information.
  */
 public class PartitionedTableId {
 
-  public static final String PARTITION_DELIMITER = "$";
+  private static final String PARTITION_DELIMITER = "$";
 
-  public PartitionedTableId(String dataset, String table, String partition) {
+  private final String project;
+  private final String dataset;
+  private final String table;
+  private final String partition;
 
+  private final String fullTableName;
+
+  private final TableId partialTableId;
+  private final TableId fullTableId;
+
+  /**
+   * Create a new {@link PartitionedTableId}
+   *
+   * @param project The project name, if specified.
+   * @param dataset The dataset name.
+   * @param table The table name.
+   * @param partition The partition of the table, if any.
+   */
+  private PartitionedTableId(String project, String dataset, String table, String partition) {
+    this.project = project;
+    this.dataset = dataset;
+    this.table = table;
+    this.partition = partition;
+
+    fullTableName = createFullTableName(table, partition);
+
+    partialTableId = createTableId(project, dataset, table);
+    fullTableId = createTableId(project, dataset, fullTableName);
   }
 
-  public PartitionedTableId(String project, String dataset, String table, String partition) {
-
+  /**
+   * Create a full table name from a base table name and a partition.
+   * @param table the base table name.
+   * @param partition the partition, if any.
+   * @return
+   */
+  private static String createFullTableName(String table, String partition) {
+    if (partition == null) {
+      return table;
+    } else {
+      return table + PARTITION_DELIMITER + partition;
+    }
   }
 
-  public static String dateToDayPartition(LocalDate localDate) {
-    StringBuilder sb = new StringBuilder();
-    return sb.append(localDate.getYear())
-        .append(localDate.getMonthValue())
-        .append(localDate.getDayOfMonth())
-        .toString();
+  /**
+   * Convenience method for creating new TableIds.
+   * <p>
+   * {@link TableId#of(String, String, String)} will error if you pass in a null project, so this
+   * just checks if the project is null and calls the correct method.
+   *
+   * @param project the project name, or null
+   * @param dataset the dataset name
+   * @param table the table name
+   * @return a new TableId with the given project, dataset, and table.
+   */
+  private static TableId createTableId(String project, String dataset, String table) {
+    if (project == null) {
+      return TableId.of(dataset, table);
+    } else {
+      return TableId.of(project, dataset, table);
+    }
+  }
+
+  /**
+   * @return the project name, if any.
+   */
+  public String getProject() {
+    return project;
+  }
+
+  /**
+   * @return the dataset name.
+   */
+  public String getDataset() {
+    return dataset;
+  }
+
+  /**
+   * @return the base table name.
+   */
+  public String getBaseTableName() {
+    return table;
+  }
+
+  /**
+   * @return the partition, if any.
+   */
+  public String getPartition() {
+    return partition;
+  }
+
+  /**
+   * @return the full table name.
+   */
+  public String getFullTableName() {
+    return fullTableName;
+  }
+
+  /**
+   * @return the partial table id.
+   */
+  public TableId getPartialTableId() {
+    return partialTableId;
+  }
+
+  /**
+   * @return the full table id.
+   */
+  public TableId getFullTableId() {
+    return fullTableId;
+  }
+
+  public static class Builder {
+
+    private String project;
+    private final String dataset;
+    private final String baseTable;
+    private String partition;
+
+    public Builder(String dataset, String baseTable) {
+      this.project = null;
+      this.dataset = dataset;
+      this.baseTable = baseTable;
+      this.partition = null;
+    }
+
+    public Builder(TableId baseTableId) {
+      this.project = baseTableId.project();
+      this.dataset = baseTableId.dataset();
+      this.baseTable = baseTableId.table();
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setPartition(String partition) {
+      this.partition = partition;
+      return this;
+    }
+
+    public Builder setDayPartition(LocalDate localDate) {
+      return setPartition(dateToDayPartition(localDate));
+    }
+
+    /**
+     * @param localDate the localDate of the partition.
+     * @return The String representation of the partition.
+     */
+    private static String dateToDayPartition(LocalDate localDate) {
+      return "" + localDate.getYear() + localDate.getMonthValue() + localDate.getDayOfMonth();
+    }
+
+    /**
+     * Build the {@link PartitionedTableId}.
+     *
+     * @return a {@link PartitionedTableId}.
+     */
+    public PartitionedTableId build() {
+      return new PartitionedTableId(project, dataset, baseTable, partition);
+    }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -23,8 +23,6 @@ import com.google.cloud.bigquery.TableId;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import org.apache.kafka.common.config.ConfigException;
 
-import java.time.Clock;
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,9 +34,6 @@ import java.util.regex.Pattern;
  * capture groups.
  */
 public class TopicToTableResolver {
-
-  private static final String PARTITION_DELIMITER = "$";
-  private static final Clock UTC_CLOCK = Clock.systemUTC();
 
   /**
    * Return a Map detailing which BigQuery table each topic should write to.
@@ -88,91 +83,16 @@ public class TopicToTableResolver {
     return matches;
   }
 
-  // package private for testing
-  static TableId getPartitionedTableName(TableId baseTableId, LocalDate localDate) {
-    StringBuilder sb = new StringBuilder();
-    String baseTableName = baseTableId.table();
-    sb.append(baseTableName);
-    sb.append(PARTITION_DELIMITER);
-
-    int year = localDate.getYear();
-    int month = localDate.getMonthValue();
-    int day = localDate.getDayOfMonth();
-    sb.append(year);
-    sb.append(month);
-    sb.append(day);
-    String partitionedTableName = sb.toString();
-    if (baseTableId.project() == null) {
-      return TableId.of(baseTableId.dataset(), partitionedTableName);
-    } else {
-      return TableId.of(baseTableId.project(), baseTableId.dataset(), partitionedTableName);
-    }
-  }
-
   /**
-   * Create and return a TableId containing partition data for the current UTC date.
-   *
-   * @param baseTableId The tableId with no partition info.
-   * @return the tableId with the partition data for the current UTC date.
-   */
-  public static TableId getPartitionedTableName(TableId baseTableId) {
-    return getPartitionedTableName(baseTableId, LocalDate.now(UTC_CLOCK));
-  }
-
-  /**
-   * Create and return a TableId that does not contain any partition data.
-   * If the given table is not partitioned, returns the given table without changes.
-   *
-   * @param partitionedTableId TableId with partition data.
-   * @return a baseTableId
-   */
-  public static TableId getBaseTableName(TableId partitionedTableId) {
-    String partitionedTableName = partitionedTableId.table();
-    String[] splitTableName = partitionedTableName.split(PARTITION_DELIMITER);
-
-    if (splitTableName.length == 1) {
-      // table not partitioned
-      return partitionedTableId;
-    } else if (splitTableName.length == 2) {
-      return createTableId(partitionedTableId.project(),
-                           partitionedTableId.dataset(),
-                           splitTableName[0]);
-    } else {
-      // something has gone horribly wrong.
-      throw new IllegalArgumentException(
-          "Attempted to get the base table name of '" + partitionedTableName
-              + "', but that is not a legal table name.");
-    }
-  }
-
-  /**
-   * Convenience method for creating new TableIds.
-   * <p>
-   * {@link TableId#of(String, String, String)} will error if you pass in a null project, so this
-   * just checks if the project is null and calls the correct method.
-   *
-   * @param project the project name, or null
-   * @param dataset the dataset name
-   * @param table the table name
-   * @return a new TableId with the given project, dataset, and table.
-   */
-  private static TableId createTableId(String project, String dataset, String table) {
-    if (project == null) {
-      return TableId.of(dataset, table);
-    } else {
-      return TableId.of(project, dataset, table);
-    }
-  }
-
-  /**
-   * Return a Map detailing which topic each table corresponds to. If sanitization has been enabled,
-   * there is a possibility that there are multiple possible schemas a table could correspond to. In
-   * that case, each table must only be written to by one topic, or an exception is thrown.
+   * Return a Map detailing which topic each base table corresponds to. If sanitization has been
+   * enabled, there is a possibility that there are multiple possible schemas a table could
+   * correspond to. In that case, each table must only be written to by one topic, or an exception
+   * is thrown.
    *
    * @param config Config that contains properties used to generate the map
    * @return The resulting Map from TableId to topic name.
    */
-  public static Map<TableId, String> getTablesToTopics(BigQuerySinkConfig config) {
+  public static Map<TableId, String> getBaseTablesToTopics(BigQuerySinkConfig config) {
     Map<String, TableId> topicsToTableIds = getTopicsToTables(config);
     Map<TableId, String> tableIdsToTopics = new HashMap<>();
     for (Map.Entry<String, TableId> topicToTableId : topicsToTableIds.entrySet()) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/BatchWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/BatchWriter.java
@@ -21,6 +21,7 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 import org.apache.kafka.connect.data.Schema;
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableIdTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableIdTest.java
@@ -1,0 +1,85 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.TableId;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+public class PartitionedTableIdTest {
+
+  @Test
+  public void testBasicBuilder() {
+    final String dataset = "dataset";
+    final String table = "table";
+
+    final PartitionedTableId tableId = new PartitionedTableId.Builder(dataset, table).build();
+
+    Assert.assertEquals(dataset, tableId.getDataset());
+    Assert.assertEquals(table, tableId.getBaseTableName());
+    Assert.assertEquals(table, tableId.getFullTableName());
+
+    TableId expectedTableId = TableId.of(dataset, table);
+    Assert.assertEquals(expectedTableId, tableId.getBaseTableId());
+    Assert.assertEquals(expectedTableId, tableId.getFullTableId());
+  }
+
+  @Test
+  public void testTableIdBuilder() {
+    final String project = "project";
+    final String dataset = "dataset";
+    final String table = "table";
+    final TableId tableId = TableId.of(project, dataset, table);
+
+    final PartitionedTableId partitionedTableId = new PartitionedTableId.Builder(tableId).build();
+
+    Assert.assertEquals(project, partitionedTableId.getProject());
+    Assert.assertEquals(dataset, partitionedTableId.getDataset());
+    Assert.assertEquals(table, partitionedTableId.getBaseTableName());
+    Assert.assertEquals(table, partitionedTableId.getFullTableName());
+
+    Assert.assertEquals(tableId, partitionedTableId.getBaseTableId());
+    Assert.assertEquals(tableId, partitionedTableId.getFullTableId());
+  }
+
+  @Test
+  public void testWithPartition() {
+    final String dataset = "dataset";
+    final String table = "table";
+    final LocalDate partitionDate = LocalDate.of(2016, 10, 21);
+
+    final PartitionedTableId partitionedTableId =
+        new PartitionedTableId.Builder(dataset, table).setDayPartition(partitionDate).build();
+
+    final String expectedPartition = "20161021";
+
+    Assert.assertEquals(dataset, partitionedTableId.getDataset());
+    Assert.assertEquals(table, partitionedTableId.getBaseTableName());
+    Assert.assertEquals(table + "$" + expectedPartition, partitionedTableId.getFullTableName());
+
+    final TableId expectedBaseTableId = TableId.of(dataset, table);
+    final TableId expectedFullTableId = TableId.of(dataset, table + "$" + expectedPartition);
+
+    Assert.assertEquals(expectedBaseTableId, partitionedTableId.getBaseTableId());
+    Assert.assertEquals(expectedFullTableId, partitionedTableId.getFullTableId());
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -30,8 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.LocalDate;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -112,28 +110,14 @@ public class TopicToTableResolverTest {
   }
 
   @Test
-  public void testGetPartitionedTableNames() {
-    TableId baseTableId = TableId.of("dataset", "table");
-
-    LocalDate localDate = LocalDate.of(2016, 10, 14);
-
-    TableId partitionedTableId = TopicToTableResolver.getPartitionedTableName(baseTableId,
-                                                                              localDate);
-
-    String expectedTableName = "table" + "$" + "2016" + "10" + "14";
-    Assert.assertEquals(baseTableId.project(), partitionedTableId.project());
-    Assert.assertEquals(baseTableId.dataset(), partitionedTableId.dataset());
-    Assert.assertEquals(expectedTableName, partitionedTableId.table());
-  }
-
-  @Test
-  public void testTablesToTopics() {
+  public void testBaseTablesToTopics() {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
     configProperties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
     configProperties.put(BigQuerySinkConfig.TOPICS_CONFIG, "sanitize-me,leave_me_alone");
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    Map<TableId, String> testTablesToSchemas = TopicToTableResolver.getTablesToTopics(testConfig);
+    Map<TableId, String> testTablesToSchemas =
+        TopicToTableResolver.getBaseTablesToTopics(testConfig);
     Map<TableId, String> expectedTablesToSchemas = new HashMap<>();
     expectedTablesToSchemas.put(TableId.of("scratch", "sanitize_me"), "sanitize-me");
     expectedTablesToSchemas.put(TableId.of("scratch", "leave_me_alone"), "leave_me_alone");


### PR DESCRIPTION
Introduce a PartitionedTableId.  Like a TableId, but it stores the partition information of the table separately from the table.
Make DynamicBatchWriter work better with partitioned tables.
Remove potential for memory leak in how DynamicBatchWriters for tables are saved.
All writes to the same base table, irrespective of the partition, will use the same DynamicBatchWriter.

Add tests.