### PR TITLE
Updating Schemas for partitioned tables should no longer fail.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -148,7 +148,7 @@ public class BigQuerySinkTask extends SinkTask {
 
     @Override
     public Void call() throws InterruptedException {
-      batchWriter.writeAll(partitionedTableId.getFullTableId(), rows, topic, schemas);
+      batchWriter.writeAll(partitionedTableId, rows, topic, schemas);
       updateAllPartitions(baseTableIdsToTopics.get(partitionedTableId.getBaseTableId()), offsets);
       return null;
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/BatchWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/BatchWriter.java
@@ -18,8 +18,6 @@ package com.wepay.kafka.connect.bigquery.write.batch;
  */
 
 
-import com.google.cloud.bigquery.TableId;
-
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
@@ -37,7 +35,7 @@ public interface BatchWriter<E> {
 
   /**
    * Initialize this BatchWriter. Necessary before calling
-   * {@link #writeAll(TableId, List, String, Set)}
+   * {@link #writeAll(PartitionedTableId, List, String, Set)}
    *
    * @param writer the writer to use to write BigQuery requests.
    */
@@ -51,6 +49,6 @@ public interface BatchWriter<E> {
    * @throws BigQueryConnectException if we are unable to write to BigQuery
    * @throws InterruptedException if writing is interrupted
    */
-  void writeAll(TableId table, List<E> elements, String topic, Set<Schema> schemas)
+  void writeAll(PartitionedTableId table, List<E> elements, String topic, Set<Schema> schemas)
       throws BigQueryConnectException, InterruptedException;
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/DynamicBatchWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/DynamicBatchWriter.java
@@ -20,9 +20,9 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest;
-import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.apache.kafka.connect.data.Schema;
@@ -92,7 +92,7 @@ public class DynamicBatchWriter implements BatchWriter<InsertAllRequest.RowToIns
   }
 
   @Override
-  public synchronized void writeAll(TableId table,
+  public synchronized void writeAll(PartitionedTableId table,
                                     List<InsertAllRequest.RowToInsert> elements,
                                     String topic,
                                     Set<Schema> schemas) throws BigQueryConnectException,
@@ -115,7 +115,7 @@ public class DynamicBatchWriter implements BatchWriter<InsertAllRequest.RowToIns
    *   2. we write all the given elements in one batch request without error.
    *   3. we write MAXIMUM_BATCH_SIZE elements in one batch request without error. (unlikely)
    */
-  private void seekingWriteAll(TableId table,
+  private void seekingWriteAll(PartitionedTableId table,
                                List<InsertAllRequest.RowToInsert> elements,
                                String topic,
                                Set<Schema> schemas) throws BigQueryConnectException,
@@ -187,7 +187,7 @@ public class DynamicBatchWriter implements BatchWriter<InsertAllRequest.RowToIns
    * <p>Every {@link #CONT_SUCCESS_COUNT_BUMP} calls, if there have been no errors, we will bump up
    * the batch size.
    */
-  private void establishedWriteAll(TableId table,
+  private void establishedWriteAll(PartitionedTableId table,
                                    List<InsertAllRequest.RowToInsert> elements,
                                    String topic,
                                    Set<Schema> schemas) throws BigQueryConnectException,
@@ -263,12 +263,12 @@ public class DynamicBatchWriter implements BatchWriter<InsertAllRequest.RowToIns
     return false;
   }
 
-  private void increaseBatchSize(TableId tableId) {
+  private void increaseBatchSize(PartitionedTableId tableId) {
     currentBatchSize = Math.min(currentBatchSize * 2, MAXIMUM_BATCH_SIZE);
     logger.info("Increased batch size to {} for {}", currentBatchSize, tableId.toString());
   }
 
-  private void decreaseBatchSize(TableId tableId, Exception reason) {
+  private void decreaseBatchSize(PartitionedTableId tableId, Exception reason) {
     logger.debug("Decreasing batch size due to error: {}", reason.getMessage());
     if (currentBatchSize <= 1) {
       // kafka source must have a huge row in it; we can't get past it, just error.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/SingleBatchWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/SingleBatchWriter.java
@@ -20,9 +20,9 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest;
-import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.apache.kafka.connect.data.Schema;
@@ -45,7 +45,7 @@ public class SingleBatchWriter implements BatchWriter<InsertAllRequest.RowToInse
    * @param elements The list of elements to write in a single batch.
    */
   @Override
-  public void writeAll(TableId table,
+  public void writeAll(PartitionedTableId table,
                        List<InsertAllRequest.RowToInsert> elements,
                        String topic,
                        Set<Schema> schemas)

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -25,12 +25,14 @@ import com.google.cloud.bigquery.InsertAllResponse;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Set;
 
 
@@ -57,12 +59,17 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   /**
    * Sends the request to BigQuery, and throws an exception if any errors occur as a result of doing
    * so.
-   * @param request The request to send to BigQuery.
+   * @param tableId The PartitionedTableId.
+   * @param rows The rows to write.
    * @param topic The Kafka topic that the row data came from (ignored).
    * @param schemas The unique Schemas for the row data (ignored).
    */
   @Override
-  public void performWriteRequest(InsertAllRequest request, String topic, Set<Schema> schemas) {
+  public void performWriteRequest(PartitionedTableId tableId,
+                                  List<InsertAllRequest.RowToInsert> rows,
+                                  String topic,
+                                  Set<Schema> schemas) {
+    InsertAllRequest request = createInsertAllRequest(tableId, rows);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {
       logger.warn(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/batch/DynamicBatchWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/batch/DynamicBatchWriterTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.verify;
 
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest;
-import com.google.cloud.bigquery.TableId;
 
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.junit.Assert;
@@ -264,7 +264,8 @@ public class DynamicBatchWriterTest {
    */
   private void writeAll(DynamicBatchWriter dynamicBatchWriter, int numElements)
       throws InterruptedException {
-    TableId tableId = TableId.of("test_dataset", "test_table");
+    PartitionedTableId tableId =
+        new PartitionedTableId.Builder("test_dataset", "test_table").build();
     List<InsertAllRequest.RowToInsert> elements = new ArrayList<>();
     for (int i = 0; i < numElements; i++) {
       elements.add(null);


### PR DESCRIPTION
primarily pushing down switching from partitionedTableId to TableId further down the stack.