### PR TITLE
I-62: More logging when pausing partitions

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -476,7 +476,7 @@ public class BigQuerySinkTask extends SinkTask {
         if (topicStates.get(topicPartition) == State.PAUSED) {
           logger.info("Restarting topicPartition {} from pause after {}ms",
                       topicPartition,
-                      now - topicChangeMs.get(topicPartition);
+                      now - topicChangeMs.get(topicPartition));
           topicChangeMs.put(topicPartition, now);
         } else {
           logger.debug("'Restarting' already running partition {}",


### PR DESCRIPTION
Log how long a partition has been running when it has been paused, how long it has been paused when it is resumed, and the buffer size when it is paused.

The basic code functionality seems untouched (at least I was able to run kcbq locally without issue), but my own local changes don't seem to be triggering pauses, so I'm less able to see if the logging messages are correct.