### PR TITLE
Support decimal logical type in converters

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -51,6 +52,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
     LOGICAL_SCHEMA_NAMES = new HashSet<>();
     LOGICAL_SCHEMA_NAMES.add(Timestamp.LOGICAL_NAME);
     LOGICAL_SCHEMA_NAMES.add(Date.LOGICAL_NAME);
+    LOGICAL_SCHEMA_NAMES.add(Decimal.LOGICAL_NAME);
   }
 
   /**
@@ -171,6 +173,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         // of milliseconds since the Unix epoch divided by 1000. (BigQuery represents dates
         // identically to timestamps.)
         return kafkaConnectDate.getTime() / 1000.0;
+      case Decimal.LOGICAL_NAME:
+        java.math.BigDecimal kafkaConnectDecimal = (java.math.BigDecimal) kafkaConnectObject;
+        return kafkaConnectDecimal;
       default:
         throw new ConversionConnectException(
             "Unaccounted-for logical schema name: " + kafkaConnectSchema.name());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -21,6 +21,7 @@ package com.wepay.kafka.connect.bigquery.convert;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Timestamp;
@@ -56,6 +57,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
     LOGICAL_SCHEMA_NAMES = new HashSet<>();
     LOGICAL_SCHEMA_NAMES.add(Timestamp.LOGICAL_NAME);
     LOGICAL_SCHEMA_NAMES.add(Date.LOGICAL_NAME);
+    LOGICAL_SCHEMA_NAMES.add(Decimal.LOGICAL_NAME);
 
     PRIMITIVE_TYPE_MAP = new HashMap<>();
     PRIMITIVE_TYPE_MAP.put(
@@ -237,6 +239,14 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
           );
         }
         bigQueryType = com.google.cloud.bigquery.Field.Type.timestamp();
+        break;
+      case Decimal.LOGICAL_NAME:
+        if (kafkaConnectSchema.type() != Schema.Type.BYTES) {
+           throw new ConversionConnectException(
+              "Decimals must be encoded as bytes; instead, found " + kafkaConnectSchema.type()
+          );
+        }
+        bigQueryType = com.google.cloud.bigquery.Field.Type.floatingPoint();
         break;
       default:
         throw new ConversionConnectException(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -424,6 +425,33 @@ public class BigQueryRecordConverterTest {
     Schema kafkaConnectSchema = SchemaBuilder
         .struct()
         .field(fieldName, Date.SCHEMA)
+        .build();
+
+    Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);
+    kafkaConnectStruct.put(fieldName, fieldValueKafkaConnect);
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(kafkaConnectSchema, kafkaConnectStruct);
+
+    Map<String, Object> bigQueryTestRecord =
+        new BigQueryRecordConverter().convertRecord(kafkaConnectRecord);
+    assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
+  }
+
+  @Test
+  public void testDecimal() {
+    final String fieldName = "Decimal";
+    final byte[] fieldDecimal = java.math.BigDecimal.ONE.toBigInteger().toByteArray();
+    final java.math.BigDecimal fieldValueKafkaConnect = Decimal.toLogical(
+        Decimal.schema(0),
+        fieldDecimal
+    );
+    final java.math.BigDecimal fieldValueBigQuery = fieldValueKafkaConnect;
+
+    Map<String, Object> bigQueryExpectedRecord = new HashMap<>();
+    bigQueryExpectedRecord.put(fieldName, fieldValueBigQuery);
+
+    Schema kafkaConnectSchema = SchemaBuilder
+        .struct()
+        .field(fieldName, Decimal.schema(0))
         .build();
 
     Struct kafkaConnectStruct = new Struct(kafkaConnectSchema);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Timestamp;
@@ -456,6 +457,42 @@ public class BigQuerySchemaConverterTest {
     Schema kafkaConnectTestSchema = SchemaBuilder
         .struct()
         .field(fieldName, SchemaBuilder.int64().name(Date.LOGICAL_NAME))
+        .build();
+
+    new BigQuerySchemaConverter().convertSchema(kafkaConnectTestSchema);
+  }
+
+  @Test
+  public void testDecimal() {
+    final String fieldName = "Decimal";
+
+    com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
+        com.google.cloud.bigquery.Schema.of(
+            com.google.cloud.bigquery.Field.builder(
+                fieldName,
+                com.google.cloud.bigquery.Field.Type.floatingPoint()
+            ).mode(
+                com.google.cloud.bigquery.Field.Mode.REQUIRED
+            ).build()
+        );
+
+    Schema kafkaConnectTestSchema = SchemaBuilder
+        .struct()
+        .field(fieldName, Decimal.schema(0))
+        .build();
+
+    com.google.cloud.bigquery.Schema bigQueryTestSchema =
+        new BigQuerySchemaConverter().convertSchema(kafkaConnectTestSchema);
+    assertEquals(bigQueryExpectedSchema, bigQueryTestSchema);
+  }
+
+  @Test(expected = ConversionConnectException.class)
+  public void testBadDecimal() {
+    final String fieldName = "Decimal";
+
+    Schema kafkaConnectTestSchema = SchemaBuilder
+        .struct()
+        .field(fieldName, SchemaBuilder.bool().name(Decimal.LOGICAL_NAME))
         .build();
 
     new BigQuerySchemaConverter().convertSchema(kafkaConnectTestSchema);


### PR DESCRIPTION
The converters treat the decimal logical type as its primitive bytes
type. This commit adds support to convert such fields into Java BigDecimals.