### PR TITLE
Fix table sanitization for pattern-matched tables

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -242,7 +242,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
         break;
       case Decimal.LOGICAL_NAME:
         if (kafkaConnectSchema.type() != Schema.Type.BYTES) {
-           throw new ConversionConnectException(
+          throw new ConversionConnectException(
               "Decimals must be encoded as bytes; instead, found " + kafkaConnectSchema.type()
           );
         }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -75,7 +75,10 @@ public class TopicToTableResolver {
         }
       }
       if (match == null) {
-        match = (sanitize) ? sanitizeTableName(value) : value;
+        match = value;
+      }
+      if (sanitize) {
+        match = sanitizeTableName(match);
       }
       String dataset = topicsToDatasets.get(value);
       matches.put(value, TableId.of(dataset, match));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -52,7 +52,7 @@ public class TopicToTableResolverTest {
     );
     configProperties.put(
         BigQuerySinkConfig.TOPICS_CONFIG,
-        "sanitize-me,db_debezium_identity_profiles_info,db.core.cluster-0.users"
+        "sanitize-me,db_debezium_identity_profiles_info.foo,db.core.cluster-0.users"
     );
     configProperties.put(
         BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
@@ -60,7 +60,8 @@ public class TopicToTableResolverTest {
     );
     Map<String, TableId> expectedTopicsToTables = new HashMap<>();
     expectedTopicsToTables.put("sanitize-me", TableId.of("scratch", "sanitize_me"));
-    expectedTopicsToTables.put("db_debezium_identity_profiles_info", TableId.of("scratch", "info"));
+    expectedTopicsToTables.put("db_debezium_identity_profiles_info.foo",
+        TableId.of("scratch", "info_foo"));
     expectedTopicsToTables.put("db.core.cluster-0.users", TableId.of("scratch", "core_users"));
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -233,6 +233,7 @@ CONNECT_DOCKER_IMAGE='kcbq/connect'
 CONNECT_DOCKER_NAME='kcbq_test_connect'
 
 cp "$BASE_DIR"/../../bin/tar/kcbq-connector-*-confluent-dist.tar "$DOCKER_DIR/connect/kcbq.tar"
+cp "$BASE_DIR"/../../bin/tar/kcbq-connector-*-confluent-dist.tar "$DOCKER_DIR/connect/retriever.tar"
 cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
 
 if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then


### PR DESCRIPTION
We discovered an error recently where KCBQ would not apply sanitization logic to tables that were pattern matched with topicsToTables mappings. There appears to be an erroneous if statement.

I updated the unit test to verify that the logic works properly, and also verified that the integration tests still work.