### PR TITLE
Fix two issues around updating schemas:

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -11,8 +11,6 @@ import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import org.apache.kafka.connect.data.Schema;
 
-import java.util.Set;
-
 /**
  * Class for managing Schemas of BigQuery tables (creating and updating).
  */

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -98,7 +98,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
         throw new BigQueryConnectException(writeResponse.insertErrors());
       }
       attemptCount++;
-      if (attemptCount > AFTER_UPDATE_RETY_LIMIT) {
+      if (attemptCount >= AFTER_UPDATE_RETY_LIMIT) {
         throw new BigQueryConnectException("Failed to write rows after BQ schema update within "
                                            + AFTER_UPDATE_RETY_LIMIT + " attempts.");
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -111,22 +111,22 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
    * This is why we can't have nice things, Google.
    */
   private boolean onlyContainsInvalidSchemaErrors(Map<Long, List<BigQueryError>> errors) {
-    boolean hasInvalidSchemaErrors = false;
+    boolean invalidSchemaError = false;
     for (List<BigQueryError> errorList : errors.values()) {
       for (BigQueryError error : errorList) {
         if (error.reason().equals("invalid") && error.message().contains("no such field")) {
-          hasInvalidSchemaErrors = true;
-        } else if (hasInvalidSchemaErrors && error.reason().equals("stopped")) {
-          /* if some rows are in the old schema format, and others aren't, all the old schema formatted
-           * rows will show up as error: stopped. We still want to continue if this is the case, because
-           * these errors don't represent a new error.
+          invalidSchemaError = true;
+        } else if (!error.reason().equals("stopped")){
+          /* if some rows are in the old schema format, and others aren't, the old schema
+           * formatted rows will show up as error: stopped. We still want to continue if this is
+           * the case, because these errors don't represent a unique error if there are also
+           * invalidSchemaErrors.
            */
-          continue;
-        } else {
           return false;
         }
       }
     }
-    return true;
+    // if we only saw "stopped" errors, we want to return false. (otherwise, return true)
+    return invalidSchemaError;
   }
 }


### PR DESCRIPTION
1. Ignore error message "stopped" if we have previously seen schema invalid errors while checking if an error message is only about an invalid schema.
2. Set a limit on retrying row insertions after attempting to update the schema of a BQ table.