### PR TITLE
Support array of structs in conversion

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -88,16 +88,16 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
     }
     Schema.Type kafkaConnectSchemaType = kafkaConnectSchema.type();
     switch (kafkaConnectSchemaType) {
-      case STRUCT:
-        return convertStruct(kafkaConnectObject, kafkaConnectSchema);
+      case ARRAY:
+        return convertArray(kafkaConnectObject, kafkaConnectSchema);
       case MAP:
         return convertMap(kafkaConnectObject, kafkaConnectSchema);
+      case STRUCT:
+        return convertStruct(kafkaConnectObject, kafkaConnectSchema);
       case BYTES:
         ByteBuffer byteBuffer = (ByteBuffer) kafkaConnectObject;
         byte[] bytes = byteBuffer.array();
         return Base64.getEncoder().encodeToString(bytes);
-      case ARRAY:
-        return convertArray(kafkaConnectObject, kafkaConnectSchema);
       case BOOLEAN:
         return (Boolean) kafkaConnectObject;
       case FLOAT32:

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -97,7 +97,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         byte[] bytes = byteBuffer.array();
         return Base64.getEncoder().encodeToString(bytes);
       case ARRAY:
-        return (List<Object>) kafkaConnectObject;
+        return convertArray(kafkaConnectObject, kafkaConnectSchema);
       case BOOLEAN:
         return (Boolean) kafkaConnectObject;
       case FLOAT32:
@@ -134,6 +134,19 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       }
     }
     return bigQueryRecord;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> convertArray(Object kafkaConnectObject,
+                                    Schema kafkaConnectSchema) {
+    Schema kafkaConnectValueSchema = kafkaConnectSchema.valueSchema();
+    List<Object> bigQueryList = new ArrayList<>();
+    List<Object> kafkaConnectList = (List<Object>) kafkaConnectObject;
+    for (Object kafkaConnectElement : kafkaConnectList) {
+      Object bigQueryValue = convertObject(kafkaConnectElement, kafkaConnectValueSchema);
+      bigQueryList.add(bigQueryValue);
+    }
+    return bigQueryList;
   }
 
   @SuppressWarnings("unchecked")

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -208,7 +208,7 @@ public class BigQueryRecordConverterTest {
     final String innerFieldStructName = "InnerStruct";
     final String innerFieldStringName = "InnerString";
     final String innerFieldIntegerName = "InnerInt";
-    final String innerStringValue = "42";
+    final String innerStringValue = "forty two";
     final Integer innerIntegerValue = 42;
     final List<Float> middleArrayValue = Arrays.asList(42.0f, 42.4f, 42.42f, 42.424f, 42.4242f);
 


### PR DESCRIPTION
The record converter code previously assumed that an array value would
only be an array of primitives. This is not true as there can be Kafka
records with arrays of records. In this case, we should call the convert
method on every object in the array.

Resolves https://github.com/wepay/kafka-connect-bigquery/issues/82.