### PR TITLE
Add support for debezium logical types (& related work)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,6 @@ project(':kcbq-connector') {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
     }
 
@@ -181,7 +180,7 @@ project(':kcbq-connector') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
         compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.6.0'
 
         compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
@@ -223,7 +222,6 @@ project('kcbq-api') {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
     }
 
@@ -233,7 +231,7 @@ project('kcbq-api') {
     }
 
     dependencies {
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
 
         compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.0'
     }
@@ -265,7 +263,6 @@ project('kcbq-confluent') {
     }
 
     repositories {
-        mavenLocal()
         mavenCentral()
         maven {
             url 'http://packages.confluent.io/maven'
@@ -281,7 +278,7 @@ project('kcbq-confluent') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
 
         compile group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '3.2.0'
         compile group: 'io.confluent', name: 'kafka-schema-registry-client', version: '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,9 @@ project(':kcbq-connector') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'gcloud-java', version: '0.2.7'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
+
+        compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
 
         compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.0'
         compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.2.0'
@@ -228,7 +230,7 @@ project('kcbq-api') {
     }
 
     dependencies {
-        compile group: 'com.google.cloud', name: 'gcloud-java', version: '0.2.7'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
 
         compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.0'
     }
@@ -276,7 +278,7 @@ project('kcbq-confluent') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'gcloud-java', version: '0.2.7'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
 
         compile group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '3.2.0'
         compile group: 'io.confluent', name: 'kafka-schema-registry-client', version: '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ project(':kcbq-connector') {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
     }
 
@@ -180,7 +181,7 @@ project(':kcbq-connector') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
         compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.6.0'
 
         compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
@@ -222,6 +223,7 @@ project('kcbq-api') {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
     }
 
@@ -231,7 +233,7 @@ project('kcbq-api') {
     }
 
     dependencies {
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
 
         compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.0'
     }
@@ -279,7 +281,7 @@ project('kcbq-confluent') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.9.4-alpha-SNAPSHOT'
 
         compile group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '3.2.0'
         compile group: 'io.confluent', name: 'kafka-schema-registry-client', version: '3.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ project(':kcbq-connector') {
         compile project(':kcbq-api')
 
         compile group: 'com.google.cloud', name: 'google-cloud', version: '0.8.2-alpha'
+        compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.6.0'
 
         compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
 

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -5,7 +5,6 @@ import com.google.cloud.bigquery.TableId;
 import org.apache.kafka.connect.data.Schema;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Interface for retrieving the most up-to-date schemas for a given BigQuery table. Used in

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.

--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
@@ -114,38 +114,38 @@ public class BigQueryConnectorIntegrationTest {
     if (field.isNull()) {
       return null;
     }
-    switch (field.attribute()) {
+    switch (field.getAttribute()) {
       case PRIMITIVE:
-        switch (fieldSchema.type().value()) {
+        switch (fieldSchema.getType().getValue()) {
           case BOOLEAN:
-            return field.booleanValue();
+            return field.getBooleanValue();
           case BYTES:
             // Do this in order for assertEquals() to work when this is an element of two compared
             // lists
-            return boxByteArray(field.bytesValue());
+            return boxByteArray(field.getBytesValue());
           case FLOAT:
-            return field.doubleValue();
+            return field.getDoubleValue();
           case INTEGER:
-            return field.longValue();
+            return field.getLongValue();
           case STRING:
-            return field.stringValue();
+            return field.getStringValue();
           case TIMESTAMP:
-            return field.timestampValue();
+            return field.getTimestampValue();
           default:
-            throw new RuntimeException("Cannot convert primitive field type " + fieldSchema.type());
+            throw new RuntimeException("Cannot convert primitive field type " + fieldSchema.getType());
         }
       case REPEATED:
         List<Object> result = new ArrayList<>();
-        for (FieldValue arrayField : field.repeatedValue()) {
+        for (FieldValue arrayField : field.getRepeatedValue()) {
           result.add(convertField(fieldSchema, arrayField));
         }
         return result;
       case RECORD:
-        List<Field> recordSchemas = fieldSchema.fields();
-        List<FieldValue> recordFields = field.recordValue();
+        List<Field> recordSchemas = fieldSchema.getFields();
+        List<FieldValue> recordFields = field.getRecordValue();
         return convertRow(recordSchemas, recordFields);
       default:
-        throw new RuntimeException("Unknown field attribute: " + field.attribute());
+        throw new RuntimeException("Unknown field attribute: " + field.getAttribute());
     }
   }
 
@@ -162,15 +162,15 @@ public class BigQueryConnectorIntegrationTest {
 
   private List<List<Object>> readAllRows(String tableName) {
     Table table = bigQuery.getTable(dataset, tableName);
-    Schema schema = table.definition().schema();
+    Schema schema = table.getDefinition().getSchema();
     Page<List<FieldValue>> page = table.list();
 
     List<List<Object>> rows = new ArrayList<>();
     while (page != null) {
-      for (List<FieldValue> row : page.values()) {
-        rows.add(convertRow(schema.fields(), row));
+      for (List<FieldValue> row : page.getValues()) {
+        rows.add(convertRow(schema.getFields(), row));
       }
-      page = page.nextPage();
+      page = page.getNextPage();
     }
     return rows;
   }

--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
@@ -132,7 +132,8 @@ public class BigQueryConnectorIntegrationTest {
           case TIMESTAMP:
             return field.getTimestampValue();
           default:
-            throw new RuntimeException("Cannot convert primitive field type " + fieldSchema.getType());
+            throw new RuntimeException("Cannot convert primitive field type "
+                                       + fieldSchema.getType());
         }
       case REPEATED:
         List<Object> result = new ArrayList<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
@@ -17,9 +17,7 @@ package com.wepay.kafka.connect.bigquery;
  * under the License.
  */
 
-
-import com.google.cloud.AuthCredentials;
-
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 
@@ -55,12 +53,12 @@ public class BigQueryHelper {
     }
 
     logger.debug("Attempting to open file {} for service account json key", keyFilename);
-    try (InputStream accountKey = new FileInputStream(keyFilename)) {
+    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
       logger.debug("Attempting to authenticate with BigQuery using provided json key");
       return new BigQueryOptions.DefaultBigqueryFactory().create(
-          BigQueryOptions.builder()
-          .projectId(projectName)
-          .authCredentials(AuthCredentials.createForJson(accountKey))
+          BigQueryOptions.newBuilder()
+          .setProjectId(projectName)
+          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
           .build()
       );
     } catch (IOException err) {
@@ -79,8 +77,8 @@ public class BigQueryHelper {
   public BigQuery connect(String projectName) {
     logger.debug("Attempting to access BigQuery without authentication");
     return new BigQueryOptions.DefaultBigqueryFactory().create(
-        BigQueryOptions.builder()
-        .projectId(projectName)
+        BigQueryOptions.newBuilder()
+        .setProjectId(projectName)
         .build()
     );
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -58,14 +58,14 @@ public class SchemaManager {
   TableInfo constructTableInfo(TableId table, Schema kafkaConnectSchema) {
     com.google.cloud.bigquery.Schema bigQuerySchema =
         schemaConverter.convertSchema(kafkaConnectSchema);
-    StandardTableDefinition tableDefinition = StandardTableDefinition.builder()
-        .schema(bigQuerySchema)
-        .timePartitioning(TimePartitioning.of(TimePartitioning.Type.DAY))
+    StandardTableDefinition tableDefinition = StandardTableDefinition.newBuilder()
+        .setSchema(bigQuerySchema)
+        .setTimePartitioning(TimePartitioning.of(TimePartitioning.Type.DAY))
         .build();
     TableInfo.Builder tableInfoBuilder =
-        TableInfo.builder(table, tableDefinition);
+        TableInfo.newBuilder(table, tableDefinition);
     if (kafkaConnectSchema.doc() != null) {
-      tableInfoBuilder.description(kafkaConnectSchema.doc());
+      tableInfoBuilder.setDescription(kafkaConnectSchema.doc());
     }
     return tableInfoBuilder.build();
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -20,6 +20,8 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
@@ -51,6 +53,10 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   private static final Set<String> LOGICAL_SCHEMA_NAMES;
 
   static {
+    // force registration
+    new DebeziumLogicalConverters();
+    new KafkaLogicalConverters();
+
     LOGICAL_SCHEMA_NAMES = new HashSet<>();
     LOGICAL_SCHEMA_NAMES.add(Timestamp.LOGICAL_NAME);
     LOGICAL_SCHEMA_NAMES.add(Date.LOGICAL_NAME);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -178,6 +178,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
     switch (kafkaConnectSchema.name()) {
       case Timestamp.LOGICAL_NAME:
       case Date.LOGICAL_NAME:
+        // how do we actually end up with this as a Date in the first place?
+        // I suspect this is special because these are kafka logical types.  I don't think dbz logical types will
+        // work so nicely.
         java.util.Date kafkaConnectDate = (java.util.Date) kafkaConnectObject;
         // BigQuery timestamps are represented as floating points of seconds since the Unix epoch,
         // with up to six digits of precision after the decimal. The logical representation for the

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -177,7 +177,8 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
 
   private Object convertLogical(Object kafkaConnectObject,
                                 Schema kafkaConnectSchema) {
-    LogicalTypeConverter converter = LogicalConverterRegistry.getConverter(kafkaConnectSchema.name());
+    LogicalTypeConverter converter =
+        LogicalConverterRegistry.getConverter(kafkaConnectSchema.name());
     return converter.convert(kafkaConnectObject);
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -174,7 +174,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   }
 
   private Object convertLogical(Object kafkaConnectObject,
-                                Schema kafkaConnectSchema) {
+                                Schema kafkaConnectSchema) { // todo fixme!
     switch (kafkaConnectSchema.name()) {
       case Timestamp.LOGICAL_NAME:
       case Date.LOGICAL_NAME:

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -202,7 +202,8 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
 
   private com.google.cloud.bigquery.Field.Builder convertLogical(Schema kafkaConnectSchema,
                                                                  String fieldName) {
-    LogicalTypeConverter converter = LogicalConverterRegistry.getConverter(kafkaConnectSchema.name());
+    LogicalTypeConverter converter =
+        LogicalConverterRegistry.getConverter(kafkaConnectSchema.name());
     converter.checkEncodingType(kafkaConnectSchema.type());
     return com.google.cloud.bigquery.Field.newBuilder(fieldName, converter.getBQSchemaType());
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -61,7 +61,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   private static final Map<String, com.google.cloud.bigquery.Field.Type> LOGICAL_TO_BQ_TYPE;
 
   static {
-    // todo remove me and stuff
+    // todo fixme and remove uses and stuff
     LOGICAL_ENCODING_TYPES = new HashMap<>();
 
     LOGICAL_ENCODING_TYPES.put(Timestamp.LOGICAL_NAME, Schema.Type.INT64);
@@ -84,7 +84,6 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
     LOGICAL_TO_BQ_TYPE.put(Decimal.LOGICAL_NAME,
                            com.google.cloud.bigquery.Field.Type.floatingPoint());
 
-    /*
     LOGICAL_TO_BQ_TYPE.put(io.debezium.time.Date.SCHEMA_NAME,
                            com.google.cloud.bigquery.Field.Type.date());
     LOGICAL_TO_BQ_TYPE.put(MicroTime.SCHEMA_NAME,
@@ -97,7 +96,6 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
                            com.google.cloud.bigquery.Field.Type.datetime());
     LOGICAL_TO_BQ_TYPE.put(ZonedTimestamp.SCHEMA_NAME,
                            com.google.cloud.bigquery.Field.Type.timestamp());
-                           */
 
     PRIMITIVE_TYPE_MAP = new HashMap<>();
     PRIMITIVE_TYPE_MAP.put(Schema.Type.BOOLEAN,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -18,6 +18,8 @@ package com.wepay.kafka.connect.bigquery.convert;
  */
 
 
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
@@ -57,6 +59,10 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   private static final Map<Schema.Type, com.google.cloud.bigquery.Field.Type> PRIMITIVE_TYPE_MAP;
 
   static {
+    // force registration
+    new DebeziumLogicalConverters();
+    new KafkaLogicalConverters();
+
     PRIMITIVE_TYPE_MAP = new HashMap<>();
     PRIMITIVE_TYPE_MAP.put(Schema.Type.BOOLEAN,
                            com.google.cloud.bigquery.Field.Type.bool());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverter.java
@@ -55,17 +55,17 @@ public class KafkaDataBQSchemaConverter extends BigQuerySchemaConverter {
     Field topicField = Field.of(KAFKA_DATA_TOPIC_FIELD_NAME, Field.Type.string());
     Field partitionField = Field.of(KAFKA_DATA_PARTITION_FIELD_NAME, Field.Type.integer());
     Field offsetField = Field.of(KAFKA_DATA_OFFSET_FIELD_NAME, Field.Type.integer());
-    Field.Builder insertTimeBuilder = Field.builder(KAFKA_DATA_INSERT_TIME_FIELD_NAME,
+    Field.Builder insertTimeBuilder = Field.newBuilder(KAFKA_DATA_INSERT_TIME_FIELD_NAME,
                                                     Field.Type.timestamp())
-                                           .mode(Field.Mode.NULLABLE);
+                                           .setMode(Field.Mode.NULLABLE);
     Field insertTimeField = insertTimeBuilder.build();
 
     Field.Builder kafkaDataFieldBuilder =
-        Field.builder(KAFKA_DATA_FIELD_NAME, Field.Type.record(topicField,
+        Field.newBuilder(KAFKA_DATA_FIELD_NAME, Field.Type.record(topicField,
                                                                partitionField,
                                                                offsetField,
                                                                insertTimeField))
-             .mode(Field.Mode.NULLABLE);
+             .setMode(Field.Mode.NULLABLE);
 
     schemaBuilder.addField(kafkaDataFieldBuilder.build());
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -30,6 +30,8 @@ import io.debezium.time.ZonedTimestamp;
 import org.apache.kafka.connect.data.Schema;
 
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
 
 /**
@@ -120,7 +122,7 @@ public class DebeziumLogicalConverters {
     @Override
     public String convert(Object kafkaConnectObject) {
       java.util.Date date = new java.util.Date((Long) kafkaConnectObject);
-      return getBQDatetimeFormat().format(date);
+      return getBQTimeFormat().format(date);
     }
   }
 
@@ -148,7 +150,13 @@ public class DebeziumLogicalConverters {
     @Override
     public String convert(Object kafkaConnectObject) {
       TemporalAccessor parsedTime = ZonedTimestamp.FORMATTER.parse((String) kafkaConnectObject);
-      return getBqTimestampFormat().format(parsedTime);
+      DateTimeFormatter bqZonedTimestampFormat =
+          new DateTimeFormatterBuilder()
+              .append(DateTimeFormatter.ISO_LOCAL_DATE)
+              .appendLiteral(' ')
+              .append(DateTimeFormatter.ISO_TIME)
+              .toFormatter();
+      return bqZonedTimestampFormat.format(parsedTime);
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -92,6 +92,7 @@ public class DebeziumLogicalConverters {
       java.util.Date date = new java.util.Date(milliTimestamp);
 
       SimpleDateFormat bqTimeSecondsFormat = new SimpleDateFormat("HH:mm:ss");
+      bqTimeSecondsFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
       String formattedSecondsTimestamp = bqTimeSecondsFormat.format(date);
 
       Long microRemainder = microTimestamp % MICROS_IN_SEC;
@@ -110,7 +111,7 @@ public class DebeziumLogicalConverters {
     public MicroTimestampConverter() {
       super(MicroTimestamp.SCHEMA_NAME,
             Schema.Type.INT64,
-            Field.Type.datetime());
+            Field.Type.timestamp());
     }
 
     @Override
@@ -121,7 +122,8 @@ public class DebeziumLogicalConverters {
       Long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
       java.util.Date date = new java.util.Date(milliTimestamp);
 
-      SimpleDateFormat bqDatetimeSecondsFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+      SimpleDateFormat bqDatetimeSecondsFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+      bqDatetimeSecondsFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
       String formattedSecondsTimestamp = bqDatetimeSecondsFormat.format(date);
 
       Long microRemainder = microTimestamp % MICROS_IN_SEC;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -35,7 +35,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
 
 /**
- * Class containing all the Debezium logical type converters
+ * Class containing all the Debezium logical type converters.
  */
 public class DebeziumLogicalConverters {
 
@@ -50,7 +50,13 @@ public class DebeziumLogicalConverters {
   private static final int MICROS_IN_SEC = 1000000;
   private static final int MICROS_IN_MILLI = 1000;
 
+  /**
+   * Class for converting Debezium date logical types to BigQuery dates.
+   */
   public static class DateConverter extends LogicalTypeConverter {
+    /**
+     * Create a new DateConverter.
+     */
     public DateConverter() {
       super(Date.SCHEMA_NAME,
             Schema.Type.INT32,
@@ -64,7 +70,13 @@ public class DebeziumLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Debezium micro time logical types to BigQuery times.
+   */
   public static class MicroTimeConverter extends LogicalTypeConverter {
+    /**
+     * Create a new MicroTimeConverter.
+     */
     public MicroTimeConverter() {
       super(MicroTime.SCHEMA_NAME,
             Schema.Type.INT64,
@@ -88,7 +100,13 @@ public class DebeziumLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Debezium micro timestamp logical types to BigQuery datetimes.
+   */
   public static class MicroTimestampConverter extends LogicalTypeConverter {
+    /**
+     * Create a new MicroTimestampConverter.
+     */
     public MicroTimestampConverter() {
       super(MicroTimestamp.SCHEMA_NAME,
             Schema.Type.INT64,
@@ -112,7 +130,13 @@ public class DebeziumLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Debezium time logical types to BigQuery times.
+   */
   public static class TimeConverter extends LogicalTypeConverter {
+    /**
+     * Create a new TimeConverter.
+     */
     public TimeConverter() {
       super(Time.SCHEMA_NAME,
             Schema.Type.INT32,
@@ -126,7 +150,13 @@ public class DebeziumLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Debezium timestamp logical types to BigQuery timestamps.
+   */
   public static class TimestampConverter extends LogicalTypeConverter {
+    /**
+     * Create a new TimestampConverter.
+     */
     public TimestampConverter() {
       super(Timestamp.SCHEMA_NAME,
             Schema.Type.INT64,
@@ -140,7 +170,13 @@ public class DebeziumLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Debezium zoned timestamp logical types to BigQuery timestamps.
+   */
   public static class ZonedTimestampConverter extends LogicalTypeConverter {
+    /**
+     * Create a new ZoneTimestampConverter.
+     */
     public ZonedTimestampConverter() {
       super(ZonedTimestamp.SCHEMA_NAME,
             Schema.Type.STRING,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -1,0 +1,154 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.Field;
+
+import io.debezium.time.Date;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.Time;
+import io.debezium.time.Timestamp;
+import io.debezium.time.ZonedTimestamp;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.text.SimpleDateFormat;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Class containing all the Debezium logical type converters
+ */
+public class DebeziumLogicalConverters {
+
+  static {
+    LogicalConverterRegistry.register(Date.SCHEMA_NAME, new DateConverter());
+    LogicalConverterRegistry.register(MicroTime.SCHEMA_NAME, new MicroTimeConverter());
+    LogicalConverterRegistry.register(MicroTimestamp.SCHEMA_NAME, new MicroTimestampConverter());
+    LogicalConverterRegistry.register(Time.SCHEMA_NAME, new TimeConverter());
+    LogicalConverterRegistry.register(ZonedTimestamp.SCHEMA_NAME, new ZonedTimestampConverter());
+  }
+
+  private static final int MICROS_IN_SEC = 1000000;
+  private static final int MICROS_IN_MILLI = 1000;
+
+  public static class DateConverter extends LogicalTypeConverter {
+    public DateConverter() {
+      super(Date.SCHEMA_NAME,
+            Schema.Type.INT32,
+            Field.Type.date());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      java.util.Date date = new java.util.Date((Long) kafkaConnectObject);
+      return getBQDateFormat().format(date);
+    }
+  }
+
+  public static class MicroTimeConverter extends LogicalTypeConverter {
+    public MicroTimeConverter() {
+      super(MicroTime.SCHEMA_NAME,
+            Schema.Type.INT64,
+            Field.Type.time());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      // We want to maintain the micro second info, but date only supports up to milli.
+      Long microTimestamp = (Long) kafkaConnectObject;
+
+      Long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
+      java.util.Date date = new java.util.Date(milliTimestamp);
+
+      SimpleDateFormat bqTimeSecondsFormat = new SimpleDateFormat("HH:mm:ss");
+      String formattedSecondsTimestamp = bqTimeSecondsFormat.format(date);
+
+      Long microRemainder = microTimestamp % MICROS_IN_SEC;
+
+      return formattedSecondsTimestamp + "." + microRemainder;
+    }
+  }
+
+  public static class MicroTimestampConverter extends LogicalTypeConverter {
+    public MicroTimestampConverter() {
+      super(MicroTimestamp.SCHEMA_NAME,
+            Schema.Type.INT64,
+            Field.Type.datetime());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      // We want to maintain the micro second info, but date only supports up to milli.
+      Long microTimestamp = (Long) kafkaConnectObject;
+
+      Long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
+      java.util.Date date = new java.util.Date(milliTimestamp);
+
+      SimpleDateFormat bqDatetimeSecondsFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+      String formattedSecondsTimestamp = bqDatetimeSecondsFormat.format(date);
+
+      Long microRemainder = microTimestamp % MICROS_IN_SEC;
+
+      return formattedSecondsTimestamp + "." + microRemainder;
+    }
+  }
+
+  public static class TimeConverter extends LogicalTypeConverter {
+    public TimeConverter() {
+      super(Time.SCHEMA_NAME,
+            Schema.Type.INT32,
+            Field.Type.time());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      java.util.Date date = new java.util.Date((Long) kafkaConnectObject);
+      return getBQDatetimeFormat().format(date);
+    }
+  }
+
+  public static class TimestampConverter extends LogicalTypeConverter {
+    public TimestampConverter() {
+      super(Timestamp.SCHEMA_NAME,
+            Schema.Type.INT64,
+            Field.Type.timestamp());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      java.util.Date date = new java.util.Date((Long) kafkaConnectObject);
+      return getBqTimestampFormat().format(date);
+    }
+  }
+
+  public static class ZonedTimestampConverter extends LogicalTypeConverter {
+    public ZonedTimestampConverter() {
+      super(ZonedTimestamp.SCHEMA_NAME,
+            Schema.Type.STRING,
+            Field.Type.timestamp());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      TemporalAccessor parsedTime = ZonedTimestamp.FORMATTER.parse((String) kafkaConnectObject);
+      return getBqTimestampFormat().format(parsedTime);
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -1,0 +1,81 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.Field;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Timestamp;
+
+import java.math.BigDecimal;
+
+/**
+ * Class containing all the Kafka logical type converters.
+ */
+public class KafkaLogicalConverters {
+
+  static {
+    LogicalConverterRegistry.register(Timestamp.LOGICAL_NAME, new TimestampConverter());
+    LogicalConverterRegistry.register(Date.LOGICAL_NAME, new DateConverter());
+    LogicalConverterRegistry.register(Decimal.LOGICAL_NAME, new DecimalConverter());
+
+  }
+
+  public static class TimestampConverter extends LogicalTypeConverter {
+    public TimestampConverter() {
+      super(Timestamp.LOGICAL_NAME,
+            Schema.Type.INT64,
+            Field.Type.timestamp());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      return getBqTimestampFormat().format((java.util.Date) kafkaConnectObject);
+    }
+  }
+
+  public static class DateConverter extends LogicalTypeConverter {
+    public DateConverter() {
+      super(Date.LOGICAL_NAME,
+            Schema.Type.INT32,
+            Field.Type.date());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      return getBQDateFormat().format((java.util.Date) kafkaConnectObject);
+    }
+  }
+
+  public static class DecimalConverter extends LogicalTypeConverter {
+    public DecimalConverter() {
+      super(Decimal.LOGICAL_NAME,
+            Schema.Type.BYTES,
+            Field.Type.floatingPoint());
+    }
+
+    @Override
+    public BigDecimal convert(Object kafkaConnectObject) {
+      // cast to get ClassCastException
+      return (BigDecimal) kafkaConnectObject;
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -33,26 +33,18 @@ import java.math.BigDecimal;
 public class KafkaLogicalConverters {
 
   static {
-    LogicalConverterRegistry.register(Timestamp.LOGICAL_NAME, new TimestampConverter());
     LogicalConverterRegistry.register(Date.LOGICAL_NAME, new DateConverter());
     LogicalConverterRegistry.register(Decimal.LOGICAL_NAME, new DecimalConverter());
-
+    LogicalConverterRegistry.register(Timestamp.LOGICAL_NAME, new TimestampConverter());
   }
 
-  public static class TimestampConverter extends LogicalTypeConverter {
-    public TimestampConverter() {
-      super(Timestamp.LOGICAL_NAME,
-            Schema.Type.INT64,
-            Field.Type.timestamp());
-    }
-
-    @Override
-    public String convert(Object kafkaConnectObject) {
-      return getBqTimestampFormat().format((java.util.Date) kafkaConnectObject);
-    }
-  }
-
+  /**
+   * Class for converting Kafka date logical types to Bigquery dates.
+   */
   public static class DateConverter extends LogicalTypeConverter {
+    /**
+     * Create a new DateConverter.
+     */
     public DateConverter() {
       super(Date.LOGICAL_NAME,
             Schema.Type.INT32,
@@ -65,7 +57,13 @@ public class KafkaLogicalConverters {
     }
   }
 
+  /**
+   * Class for converting Kafka decimal logical types to Bigquery floating points.
+   */
   public static class DecimalConverter extends LogicalTypeConverter {
+    /**
+     * Create a new DecimalConverter.
+     */
     public DecimalConverter() {
       super(Decimal.LOGICAL_NAME,
             Schema.Type.BYTES,
@@ -76,6 +74,25 @@ public class KafkaLogicalConverters {
     public BigDecimal convert(Object kafkaConnectObject) {
       // cast to get ClassCastException
       return (BigDecimal) kafkaConnectObject;
+    }
+  }
+
+  /**
+   * Class for converting Kafka timestamp logical types to BigQuery timestamps.
+   */
+  public static class TimestampConverter extends LogicalTypeConverter {
+    /**
+     * Create a new TimestampConverter.
+     */
+    public TimestampConverter() {
+      super(Timestamp.LOGICAL_NAME,
+        Schema.Type.INT64,
+        Field.Type.timestamp());
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      return getBqTimestampFormat().format((java.util.Date) kafkaConnectObject);
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Created by moirat on 3/1/17.
+ * Registry for finding and accessing {@link LogicalTypeConverter}s.
  */
 public class LogicalConverterRegistry {
 
@@ -34,5 +34,9 @@ public class LogicalConverterRegistry {
 
   public static LogicalTypeConverter getConverter(String logicalTypeName) {
     return converterMap.get(logicalTypeName);
+  }
+
+  public static boolean isRegisteredLogicalType(String typeName) {
+    return converterMap.containsKey(typeName);
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
@@ -1,0 +1,38 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by moirat on 3/1/17.
+ */
+public class LogicalConverterRegistry {
+
+  private static Map<String, LogicalTypeConverter> converterMap = new HashMap<>();
+
+  public static void register(String logicalTypeName, LogicalTypeConverter converter) {
+    converterMap.put(logicalTypeName, converter);
+  }
+
+  public static LogicalTypeConverter getConverter(String logicalTypeName) {
+    return converterMap.get(logicalTypeName);
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
@@ -20,13 +20,14 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Registry for finding and accessing {@link LogicalTypeConverter}s.
  */
 public class LogicalConverterRegistry {
 
-  private static Map<String, LogicalTypeConverter> converterMap = new HashMap<>();
+  private static Map<String, LogicalTypeConverter> converterMap = new ConcurrentHashMap<>();
 
   public static void register(String logicalTypeName, LogicalTypeConverter converter) {
     converterMap.put(logicalTypeName, converter);
@@ -37,6 +38,6 @@ public class LogicalConverterRegistry {
   }
 
   public static boolean isRegisteredLogicalType(String typeName) {
-    return converterMap.containsKey(typeName);
+    return typeName != null && converterMap.containsKey(typeName);
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -1,0 +1,96 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.Field;
+import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
+import org.apache.kafka.connect.data.Schema;
+
+import java.text.SimpleDateFormat;
+
+/**
+ * Abstract class for logical type converters.
+ * Contains logic for both schema and record conversions.
+ */
+public abstract class LogicalTypeConverter {
+
+  private String logicalName;
+  private Schema.Type encodingType;
+  private Field.Type bqSchemaType;
+
+  /**
+   * Create a new LogicalConverter.
+   *
+   * @param logicalName The name of the logical type.
+   * @param encodingType The encoding type of the logical type.
+   * @param bqSchemaType The corresponding BigQuery Schema type of the logical type.
+   */
+  public LogicalTypeConverter(String logicalName,
+                              Schema.Type encodingType,
+                              Field.Type bqSchemaType) {
+    this.logicalName = logicalName;
+    this.encodingType = encodingType;
+    this.bqSchemaType = bqSchemaType;
+  }
+
+  /**
+   * Checks if the given schema encoding type is the same as the expected encoding type.
+   * Throws an {@link ConversionConnectException} if not.
+   *
+   * @param encodingType the encoding type to check.
+   * @throws ConversionConnectException
+   */
+  public void checkEncodingType(Schema.Type encodingType) throws ConversionConnectException {
+    if (encodingType != this.encodingType) {
+      throw new ConversionConnectException(
+        "Logical Type " + logicalName + " must be encoded as " + this.encodingType + "; "
+          + "instead, found " + encodingType
+      );
+    }
+  }
+
+  public Field.Type getBQSchemaType() {
+    return bqSchemaType;
+  }
+
+  /**
+   * Convert the given KafkaConnect Record Object to a BigQuery Record Object.
+   *
+   * @param kafkaConnectObject the kafkaConnectObject
+   * @return the converted Object
+   */
+  public abstract Object convert(Object kafkaConnectObject);
+
+  protected static SimpleDateFormat getBqTimestampFormat() {
+    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  }
+
+  protected static SimpleDateFormat getBQDatetimeFormat() {
+    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+  }
+
+  protected static SimpleDateFormat getBQDateFormat() {
+    return new SimpleDateFormat("yyyy-MM-dd");
+  }
+
+  protected static SimpleDateFormat getBQTimeFormat() {
+    return new SimpleDateFormat("HH:mm:ss.SSS");
+  }
+
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -25,12 +25,16 @@ import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import org.apache.kafka.connect.data.Schema;
 
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 /**
  * Abstract class for logical type converters.
  * Contains logic for both schema and record conversions.
  */
 public abstract class LogicalTypeConverter {
+
+  // BigQuery uses UTC timezone by default
+  protected final static TimeZone utcTimeZone = TimeZone.getTimeZone("UTC");
 
   private String logicalName;
   private Schema.Type encodingType;
@@ -78,19 +82,27 @@ public abstract class LogicalTypeConverter {
   public abstract Object convert(Object kafkaConnectObject);
 
   protected static SimpleDateFormat getBqTimestampFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    SimpleDateFormat bqTimestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    bqTimestampFormat.setTimeZone(utcTimeZone);
+    return bqTimestampFormat;
   }
 
   protected static SimpleDateFormat getBQDatetimeFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    SimpleDateFormat bqDateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    bqDateTimeFormat.setTimeZone(utcTimeZone);
+    return bqDateTimeFormat;
   }
 
   protected static SimpleDateFormat getBQDateFormat() {
-    return new SimpleDateFormat("yyyy-MM-dd");
+    SimpleDateFormat bqDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    bqDateFormat.setTimeZone(utcTimeZone);
+    return bqDateFormat;
   }
 
   protected static SimpleDateFormat getBQTimeFormat() {
-    return new SimpleDateFormat("HH:mm:ss.SSS");
+    SimpleDateFormat bqTimeFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    bqTimeFormat.setTimeZone(utcTimeZone);
+    return bqTimeFormat;
   }
 
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -19,7 +19,9 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
 
 import com.google.cloud.bigquery.Field;
+
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
+
 import org.apache.kafka.connect.data.Schema;
 
 import java.text.SimpleDateFormat;
@@ -50,11 +52,9 @@ public abstract class LogicalTypeConverter {
   }
 
   /**
-   * Checks if the given schema encoding type is the same as the expected encoding type.
-   * Throws an {@link ConversionConnectException} if not.
-   *
    * @param encodingType the encoding type to check.
-   * @throws ConversionConnectException
+   * @throws ConversionConnectException if the given schema encoding type is not the same as the
+   *                                    expected encoding type.
    */
   public void checkEncodingType(Schema.Type encodingType) throws ConversionConnectException {
     if (encodingType != this.encodingType) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -54,8 +54,8 @@ public class BigQueryConnectException extends ConnectException {
         messageBuilder.append(String.format(
             "%n\t[row index %d]: %s: %s",
             errorsEntry.getKey(),
-            error.reason(),
-            error.message()
+            error.getReason(),
+            error.getMessage()
         ));
       }
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -178,7 +178,7 @@ public class PartitionedTableId {
      * @param baseTableId existing TableId with a base table name (no partition information).
      */
     public Builder(TableId baseTableId) {
-      this(baseTableId.project(), baseTableId.dataset(), baseTableId.table(), null);
+      this(baseTableId.getProject(), baseTableId.getDataset(), baseTableId.getTable(), null);
     }
 
     private Builder(String project, String dataset, String baseTable, String partition) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -115,9 +115,9 @@ public class TableWriter implements Runnable {
    *         size, or false otherwise.
    */
   private static boolean isBatchSizeError(BigQueryException exception) {
-    if (exception.code() == BAD_REQUEST_CODE
-        && exception.error() == null
-        && exception.reason() == null) {
+    if (exception.getCode() == BAD_REQUEST_CODE
+        && exception.getError() == null
+        && exception.getReason() == null) {
       /*
        * 400 with no error or reason represents a request that is more than 10MB. This is not
        * documented but is referenced slightly under "Error codes" here:
@@ -125,7 +125,7 @@ public class TableWriter implements Runnable {
        * (by decreasing the batch size we can eventually expect to end up with a request under 10MB)
        */
       return true;
-    } else if (exception.code() == BAD_REQUEST_CODE && INVALID_REASON.equals(exception.reason())) {
+    } else if (exception.getCode() == BAD_REQUEST_CODE && INVALID_REASON.equals(exception.getReason())) {
       /*
        * this is the error that the documentation claims google will return if a request exceeds
        * 10MB. if this actually ever happens...

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -125,7 +125,8 @@ public class TableWriter implements Runnable {
        * (by decreasing the batch size we can eventually expect to end up with a request under 10MB)
        */
       return true;
-    } else if (exception.getCode() == BAD_REQUEST_CODE && INVALID_REASON.equals(exception.getReason())) {
+    } else if (exception.getCode() == BAD_REQUEST_CODE
+               && INVALID_REASON.equals(exception.getReason())) {
       /*
        * this is the error that the documentation claims google will return if a request exceeds
        * 10MB. if this actually ever happens...

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -79,7 +79,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     // Should only perform one schema update attempt; may have to continue insert attempts due to
     // BigQuery schema updates taking up to two minutes to take effect
     if (writeResponse.hasErrors()
-        && onlyContainsInvalidSchemaErrors(writeResponse.insertErrors())) {
+        && onlyContainsInvalidSchemaErrors(writeResponse.getInsertErrors())) {
       try {
         schemaManager.updateSchema(tableId.getBaseTableId(), topic);
       } catch (BigQueryException exception) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -91,11 +91,11 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     int attemptCount = 0;
     while (writeResponse.hasErrors()) {
       logger.trace("insertion failed");
-      if (onlyContainsInvalidSchemaErrors(writeResponse.insertErrors())) {
+      if (onlyContainsInvalidSchemaErrors(writeResponse.getInsertErrors())) {
         logger.debug("re-attempting insertion");
         writeResponse = bigQuery.insertAll(request);
       } else {
-        throw new BigQueryConnectException(writeResponse.insertErrors());
+        throw new BigQueryConnectException(writeResponse.getInsertErrors());
       }
       attemptCount++;
       if (attemptCount >= AFTER_UPDATE_RETY_LIMIT) {
@@ -119,9 +119,9 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     boolean invalidSchemaError = false;
     for (List<BigQueryError> errorList : errors.values()) {
       for (BigQueryError error : errorList) {
-        if (error.reason().equals("invalid") && error.message().contains("no such field")) {
+        if (error.getReason().equals("invalid") && error.getMessage().contains("no such field")) {
           invalidSchemaError = true;
-        } else if (!error.reason().equals("stopped")) {
+        } else if (!error.getReason().equals("stopped")) {
           /* if some rows are in the old schema format, and others aren't, the old schema
            * formatted rows will show up as error: stopped. We still want to continue if this is
            * the case, because these errors don't represent a unique error if there are also

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -83,9 +83,9 @@ public abstract class BigQueryWriter {
    */
   protected InsertAllRequest createInsertAllRequest(PartitionedTableId tableId,
                                                     List<InsertAllRequest.RowToInsert> rows) {
-    return InsertAllRequest.builder(tableId.getFullTableId(), rows)
-        .ignoreUnknownValues(false)
-        .skipInvalidRows(false)
+    return InsertAllRequest.newBuilder(tableId.getFullTableId(), rows)
+        .setIgnoreUnknownValues(false)
+        .setSkipInvalidRows(false)
         .build();
   }
 
@@ -113,25 +113,25 @@ public abstract class BigQueryWriter {
         return;
       } catch (BigQueryException err) {
         mostRecentException = err;
-        if (err.code() == INTERNAL_SERVICE_ERROR
-            || err.code() == SERVICE_UNAVAILABLE
-            || err.code() == BAD_GATEWAY) {
+        if (err.getCode() == INTERNAL_SERVICE_ERROR
+            || err.getCode() == SERVICE_UNAVAILABLE
+            || err.getCode() == BAD_GATEWAY) {
           // backend error: https://cloud.google.com/bigquery/troubleshooting-errors
           /* for BAD_GATEWAY: https://cloud.google.com/storage/docs/json_api/v1/status-codes
              todo possibly this page is inaccurate for bigquery, but the message we are getting
              suggest it's an internal backend error and we should retry, so lets take that at face
              value. */
-          logger.warn("BQ backend error: {}, attempting retry", err.code());
+          logger.warn("BQ backend error: {}, attempting retry", err.getCode());
           retryCount++;
-        } else if (err.code() == FORBIDDEN
-                   && err.error() != null
-                   && QUOTA_EXCEEDED_REASON.equals(err.reason())) {
+        } else if (err.getCode() == FORBIDDEN
+                   && err.getError() != null
+                   && QUOTA_EXCEEDED_REASON.equals(err.getReason())) {
           // quota exceeded error
           logger.warn("Quota exceeded for table {}, attempting retry", table);
           retryCount++;
-        } else if (err.code() == FORBIDDEN
-                   && err.error() != null
-                   && RATE_LIMIT_EXCEEDED_REASON.equals(err.reason())) {
+        } else if (err.getCode() == FORBIDDEN
+                   && err.getError() != null
+                   && RATE_LIMIT_EXCEEDED_REASON.equals(err.getReason())) {
           // rate limit exceeded error
           logger.warn("Rate limit exceeded for table {}, attempting retry", table);
           retryCount++;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -70,7 +70,7 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
           + "{}=true in the properties file",
           BigQuerySinkTaskConfig.SCHEMA_UPDATE_CONFIG
       );
-      throw new BigQueryConnectException(writeResponse.insertErrors());
+      throw new BigQueryConnectException(writeResponse.getInsertErrors());
     } else {
       logger.debug("table insertion completed with no reported errors");
     }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -49,7 +49,6 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class BigQuerySinkConnectorTest {
   private static SinkConnectorPropertiesFactory propertiesFactory;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -265,7 +265,7 @@ public class BigQuerySinkTaskTest {
     BigQuery bigQuery  = mock(BigQuery.class);
     InsertAllResponse fakeResponse = mock(InsertAllResponse.class);
     when(fakeResponse.hasErrors()).thenReturn(false);
-    when(fakeResponse.insertErrors()).thenReturn(Collections.emptyMap());
+    when(fakeResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
     when(bigQuery.insertAll(any(InsertAllRequest.class))).thenReturn(fakeResponse);
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
@@ -312,9 +312,9 @@ public class BigQuerySinkTaskTest {
   public static InsertAllRequest buildExpectedInsertAllRequest(
       TableId table,
       InsertAllRequest.RowToInsert... rows) {
-    return InsertAllRequest.builder(table, rows)
-        .ignoreUnknownValues(false)
-        .skipInvalidRows(false)
+    return InsertAllRequest.newBuilder(table, rows)
+        .setIgnoreUnknownValues(false)
+        .setSkipInvalidRows(false)
         .build();
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -64,6 +64,6 @@ public class SchemaManagerTest {
     TableInfo tableInfo = schemaManager.constructTableInfo(tableId, mockKafkaSchema);
 
     Assert.assertEquals("Kafka doc does not match BigQuery table description",
-                        testDoc, tableInfo.description());
+                        testDoc, tableInfo.getDescription());
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -42,6 +42,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class BigQueryRecordConverterTest {
 
@@ -440,8 +441,10 @@ public class BigQueryRecordConverterTest {
         fieldTime
     );
     java.util.Date date = new java.util.Date(fieldValueKafkaConnect.getTime());
+    SimpleDateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    timestampFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     final String fieldValueBigQuery =
-        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(date);
+        timestampFormat.format(date);
 
     Map<String, Object> bigQueryExpectedRecord = new HashMap<>();
     bigQueryExpectedRecord.put(fieldName, fieldValueBigQuery);
@@ -469,7 +472,9 @@ public class BigQueryRecordConverterTest {
         fieldDate
     );
     java.util.Date date = new java.util.Date(fieldValueKafkaConnect.getTime());
-    final String fieldValueBigQuery = new SimpleDateFormat("yyyy-MM-dd").format(date);
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    final String fieldValueBigQuery = dateFormat.format(date);
 
     Map<String, Object> bigQueryExpectedRecord = new HashMap<>();
     bigQueryExpectedRecord.put(fieldName, fieldValueBigQuery);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -20,6 +20,8 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.Assert.assertEquals;
 
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -35,6 +37,7 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -43,6 +46,13 @@ import java.util.List;
 import java.util.Map;
 
 public class BigQueryRecordConverterTest {
+
+  static {
+    // force Converter Registry initialization
+    new DebeziumLogicalConverters();
+    new KafkaLogicalConverters();
+  }
+
   @Test(expected = ConversionConnectException.class)
   public void testTopLevelRecord() {
     SinkRecord kafkaConnectRecord = spoofSinkRecord(Schema.BOOLEAN_SCHEMA, false);
@@ -437,7 +447,9 @@ public class BigQueryRecordConverterTest {
         Timestamp.SCHEMA,
         fieldTime
     );
-    final double fieldValueBigQuery = fieldValueKafkaConnect.getTime() / 1000.0;
+    java.util.Date date = new java.util.Date(fieldValueKafkaConnect.getTime());
+    final String fieldValueBigQuery =
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(date);
 
     Map<String, Object> bigQueryExpectedRecord = new HashMap<>();
     bigQueryExpectedRecord.put(fieldName, fieldValueBigQuery);
@@ -464,7 +476,8 @@ public class BigQueryRecordConverterTest {
         Date.SCHEMA,
         fieldDate
     );
-    final double fieldValueBigQuery = fieldValueKafkaConnect.getTime() / 1000.0;
+    java.util.Date date = new java.util.Date(fieldValueKafkaConnect.getTime());
+    final String fieldValueBigQuery = new SimpleDateFormat("yyyy-MM-dd").format(date);
 
     Map<String, Object> bigQueryExpectedRecord = new HashMap<>();
     bigQueryExpectedRecord.put(fieldName, fieldValueBigQuery);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -20,8 +20,6 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.Assert.assertEquals;
 
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -46,12 +44,6 @@ import java.util.List;
 import java.util.Map;
 
 public class BigQueryRecordConverterTest {
-
-  static {
-    // force Converter Registry initialization
-    new DebeziumLogicalConverters();
-    new KafkaLogicalConverters();
-  }
 
   @Test(expected = ConversionConnectException.class)
   public void testTopLevelRecord() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -20,6 +20,8 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.Assert.assertEquals;
 
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -31,6 +33,13 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 public class BigQuerySchemaConverterTest {
+
+  static {
+    // force Converter Registry initialization
+    new DebeziumLogicalConverters();
+    new KafkaLogicalConverters();
+  }
+
   @Test(expected = ConversionConnectException.class)
   public void testTopLevelSchema() {
     new BigQuerySchemaConverter().convertSchema(Schema.BOOLEAN_SCHEMA);
@@ -42,10 +51,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.bool()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -66,10 +75,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.integer()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -117,10 +126,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.floatingPoint()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -149,10 +158,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.string()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -177,23 +186,23 @@ public class BigQuerySchemaConverterTest {
     final String innerFieldIntegerName = "InnerInt";
 
     com.google.cloud.bigquery.Field bigQueryInnerRecord =
-        com.google.cloud.bigquery.Field.builder(
+        com.google.cloud.bigquery.Field.newBuilder(
             innerFieldStructName,
             com.google.cloud.bigquery.Field.Type.record(
-                com.google.cloud.bigquery.Field.builder(
+                com.google.cloud.bigquery.Field.newBuilder(
                     innerFieldStringName,
                     com.google.cloud.bigquery.Field.Type.string()
-                ).mode(
+                ).setMode(
                     com.google.cloud.bigquery.Field.Mode.REQUIRED
                 ).build(),
-                com.google.cloud.bigquery.Field.builder(
+                com.google.cloud.bigquery.Field.newBuilder(
                     innerFieldIntegerName,
                     com.google.cloud.bigquery.Field.Type.integer()
-                ).mode(
+                ).setMode(
                     com.google.cloud.bigquery.Field.Mode.REQUIRED
                 ).build()
             )
-        ).mode(
+        ).setMode(
             com.google.cloud.bigquery.Field.Mode.REQUIRED
         ).build();
 
@@ -215,16 +224,16 @@ public class BigQuerySchemaConverterTest {
     assertEquals(bigQueryExpectedInnerSchema, bigQueryTestInnerSchema);
 
     com.google.cloud.bigquery.Field bigQueryMiddleRecord =
-        com.google.cloud.bigquery.Field.builder(
+        com.google.cloud.bigquery.Field.newBuilder(
             middleFieldStructName,
             com.google.cloud.bigquery.Field.Type.record(
                 bigQueryInnerRecord,
-                com.google.cloud.bigquery.Field.builder(
+                com.google.cloud.bigquery.Field.newBuilder(
                     middleFieldArrayName,
                     com.google.cloud.bigquery.Field.Type.floatingPoint()
-                ).mode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
+                ).setMode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
             )
-        ).mode(
+        ).setMode(
             com.google.cloud.bigquery.Field.Mode.REQUIRED
         ).build();
 
@@ -246,13 +255,13 @@ public class BigQuerySchemaConverterTest {
     assertEquals(bigQueryExpectedMiddleSchema, bigQueryTestMiddleSchema);
 
     com.google.cloud.bigquery.Field bigQueryOuterRecord =
-        com.google.cloud.bigquery.Field.builder(
+        com.google.cloud.bigquery.Field.newBuilder(
             outerFieldStructName,
             com.google.cloud.bigquery.Field.Type.record(
                 bigQueryInnerRecord,
                 bigQueryMiddleRecord
             )
-        ).mode(
+        ).setMode(
             com.google.cloud.bigquery.Field.Mode.REQUIRED
         ).build();
 
@@ -282,26 +291,26 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Field.Type bigQueryMapEntryType =
         com.google.cloud.bigquery.Field.Type.record(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 keyName,
                 com.google.cloud.bigquery.Field.Type.floatingPoint()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build(),
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 valueName,
                 com.google.cloud.bigquery.Field.Type.string()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 bigQueryMapEntryType
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REPEATED
             ).build()
         );
@@ -326,10 +335,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.integer()
-            ).mode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
+            ).setMode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
         );
 
     Schema kafkaConnectArraySchema = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
@@ -349,10 +358,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.string()
-            ).mode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
+            ).setMode(com.google.cloud.bigquery.Field.Mode.REPEATED).build()
         );
 
     Schema kafkaConnectArraySchema = SchemaBuilder.array(Schema.STRING_SCHEMA).build();
@@ -372,10 +381,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.bytes()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -396,10 +405,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.timestamp()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -432,10 +441,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
-                com.google.cloud.bigquery.Field.Type.timestamp()
-            ).mode(
+                com.google.cloud.bigquery.Field.Type.date()
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -468,10 +477,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 fieldName,
                 com.google.cloud.bigquery.Field.Type.floatingPoint()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -505,16 +514,16 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 nullableFieldName,
                 com.google.cloud.bigquery.Field.Type.integer()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.NULLABLE
             ).build(),
-            com.google.cloud.bigquery.Field.builder(
+            com.google.cloud.bigquery.Field.newBuilder(
                 requiredFieldName,
                 com.google.cloud.bigquery.Field.Type.integer()
-            ).mode(
+            ).setMode(
                 com.google.cloud.bigquery.Field.Mode.REQUIRED
             ).build()
         );
@@ -537,10 +546,10 @@ public class BigQuerySchemaConverterTest {
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(
-            com.google.cloud.bigquery.Field.builder(fieldName,
+            com.google.cloud.bigquery.Field.newBuilder(fieldName,
                 com.google.cloud.bigquery.Field.Type.string())
-                .mode(com.google.cloud.bigquery.Field.Mode.REQUIRED)
-                .description(fieldDoc)
+                .setMode(com.google.cloud.bigquery.Field.Mode.REQUIRED)
+                .setDescription(fieldDoc)
                 .build()
         );
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -20,8 +20,6 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.Assert.assertEquals;
 
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 
 import org.apache.kafka.connect.data.Date;
@@ -33,12 +31,6 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 public class BigQuerySchemaConverterTest {
-
-  static {
-    // force Converter Registry initialization
-    new DebeziumLogicalConverters();
-    new KafkaLogicalConverters();
-  }
 
   @Test(expected = ConversionConnectException.class)
   public void testTopLevelSchema() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverterTest.java
@@ -50,14 +50,16 @@ public class KafkaDataBQSchemaConverterTest {
     Field topicField = Field.of("topic", Field.Type.string());
     Field partitionField = Field.of("partition", Field.Type.integer());
     Field offsetField = Field.of("offset", Field.Type.integer());
-    Field insertTimeField = Field.builder("insertTime",Field.Type.timestamp())
-                                 .mode(Field.Mode.NULLABLE)
+    Field insertTimeField = Field.newBuilder("insertTime",Field.Type.timestamp())
+                                 .setMode(Field.Mode.NULLABLE)
                                  .build();
 
-    return Field.builder("kafkaData",
-                         Field.Type.record(topicField,
-                                           partitionField,
-                                           offsetField,
-                                           insertTimeField)).mode(Field.Mode.NULLABLE).build();
+    return Field.newBuilder("kafkaData",
+                            Field.Type.record(topicField,
+                                              partitionField,
+                                              offsetField,
+                                              insertTimeField))
+                .setMode(Field.Mode.NULLABLE)
+                .build();
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/kafkadata/KafkaDataBQSchemaConverterTest.java
@@ -36,8 +36,8 @@ public class KafkaDataBQSchemaConverterTest {
 
 
     Field kafkaDataField = getKafkaDataField();
-    Field baseField = Field.builder("base",
-                                    Field.Type.string()).mode(Field.Mode.REQUIRED).build();
+    Field baseField = Field.newBuilder("base",
+                                    Field.Type.string()).setMode(Field.Mode.REQUIRED).build();
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(baseField, kafkaDataField);
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -1,0 +1,135 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.DateConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.MicroTimeConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.MicroTimestampConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimeConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimestampConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.ZonedTimestampConverter;
+
+public class DebeziumLogicalConvertersTest {
+
+  //corresponds to March 1 2017, 14:20:38.808(123)
+  private static final Long MILLI_TIMESTAMP = 1488406838808L;
+  private static final Long MICRO_TIMESTAMP = 1488406838808123L;
+
+  @Test
+  public void testDateConversion() {
+    DateConverter converter = new DateConverter();
+
+    Assert.assertEquals(Field.Type.date(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedDate = converter.convert(MILLI_TIMESTAMP);
+    Assert.assertEquals("2017-03-01", formattedDate);
+  }
+
+  @Test
+  public void testMicroTimeConversion() {
+    MicroTimeConverter converter = new MicroTimeConverter();
+
+    Assert.assertEquals(Field.Type.time(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedMicroTime = converter.convert(MICRO_TIMESTAMP);
+    Assert.assertEquals("14:20:38.808123", formattedMicroTime);
+  }
+
+  @Test
+  public void testMicroTimestampConversion() {
+    MicroTimestampConverter converter = new MicroTimestampConverter();
+
+    Assert.assertEquals(Field.Type.datetime(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedMicroTimestamp = converter.convert(MICRO_TIMESTAMP);
+    Assert.assertEquals("2017-03-01T14:20:38.808123", formattedMicroTimestamp);
+  }
+
+  @Test
+  public void testTimeConversion() {
+    TimeConverter converter = new TimeConverter();
+
+    Assert.assertEquals(Field.Type.time(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedTime = converter.convert(MILLI_TIMESTAMP);
+    Assert.assertEquals("14:20:38.808", formattedTime);
+  }
+
+  @Test
+  public void testTimestampConversion() {
+    TimestampConverter converter = new TimestampConverter();
+
+    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedTimestamp = converter.convert(MILLI_TIMESTAMP);
+    Assert.assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+  }
+
+  @Test
+  public void testZonedTimestampConversion() {
+    ZonedTimestampConverter converter = new ZonedTimestampConverter();
+
+    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.STRING);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
+    // todo I think this is what will happen...; I think the timestamp ends up in UTC?
+    Assert.assertEquals("2017-03-01 06:20:38.808", formattedTimestamp);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -18,10 +18,10 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
  */
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import com.google.cloud.bigquery.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.junit.Assert;
-import org.junit.Test;
 
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.DateConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.MicroTimeConverter;
@@ -29,6 +29,10 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConve
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimeConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimestampConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.ZonedTimestampConverter;
+
+import org.apache.kafka.connect.data.Schema;
+
+import org.junit.Test;
 
 public class DebeziumLogicalConvertersTest {
 
@@ -40,95 +44,95 @@ public class DebeziumLogicalConvertersTest {
   public void testDateConversion() {
     DateConverter converter = new DateConverter();
 
-    Assert.assertEquals(Field.Type.date(), converter.getBQSchemaType());
+    assertEquals(Field.Type.date(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT32);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedDate = converter.convert(MILLI_TIMESTAMP);
-    Assert.assertEquals("2017-03-01", formattedDate);
+    assertEquals("2017-03-01", formattedDate);
   }
 
   @Test
   public void testMicroTimeConversion() {
     MicroTimeConverter converter = new MicroTimeConverter();
 
-    Assert.assertEquals(Field.Type.time(), converter.getBQSchemaType());
+    assertEquals(Field.Type.time(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT64);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedMicroTime = converter.convert(MICRO_TIMESTAMP);
-    Assert.assertEquals("14:20:38.808123", formattedMicroTime);
+    assertEquals("14:20:38.808123", formattedMicroTime);
   }
 
   @Test
   public void testMicroTimestampConversion() {
     MicroTimestampConverter converter = new MicroTimestampConverter();
 
-    Assert.assertEquals(Field.Type.datetime(), converter.getBQSchemaType());
+    assertEquals(Field.Type.datetime(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT64);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedMicroTimestamp = converter.convert(MICRO_TIMESTAMP);
-    Assert.assertEquals("2017-03-01T14:20:38.808123", formattedMicroTimestamp);
+    assertEquals("2017-03-01T14:20:38.808123", formattedMicroTimestamp);
   }
 
   @Test
   public void testTimeConversion() {
     TimeConverter converter = new TimeConverter();
 
-    Assert.assertEquals(Field.Type.time(), converter.getBQSchemaType());
+    assertEquals(Field.Type.time(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT32);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedTime = converter.convert(MILLI_TIMESTAMP);
-    Assert.assertEquals("14:20:38.808", formattedTime);
+    assertEquals("14:20:38.808", formattedTime);
   }
 
   @Test
   public void testTimestampConversion() {
     TimestampConverter converter = new TimestampConverter();
 
-    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+    assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT64);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedTimestamp = converter.convert(MILLI_TIMESTAMP);
-    Assert.assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+    assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
   }
 
   @Test
   public void testZonedTimestampConversion() {
     ZonedTimestampConverter converter = new ZonedTimestampConverter();
 
-    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+    assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.STRING);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
-    Assert.assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
+    assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -129,7 +129,6 @@ public class DebeziumLogicalConvertersTest {
     }
 
     String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
-    // todo I think this is what will happen...; I think the timestamp ends up in UTC?
-    Assert.assertEquals("2017-03-01 06:20:38.808", formattedTimestamp);
+    Assert.assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -36,7 +36,8 @@ import org.junit.Test;
 
 public class DebeziumLogicalConvertersTest {
 
-  //corresponds to March 1 2017, 14:20:38.808(123)
+  //corresponds to March 1 2017, 22:20:38.808(123) UTC
+  //              (March 1 2017, 14:20:38.808(123)-8:00)
   private static final Long MILLI_TIMESTAMP = 1488406838808L;
   private static final Long MICRO_TIMESTAMP = 1488406838808123L;
 
@@ -69,14 +70,14 @@ public class DebeziumLogicalConvertersTest {
     }
 
     String formattedMicroTime = converter.convert(MICRO_TIMESTAMP);
-    assertEquals("14:20:38.808123", formattedMicroTime);
+    assertEquals("22:20:38.808123", formattedMicroTime);
   }
 
   @Test
   public void testMicroTimestampConversion() {
     MicroTimestampConverter converter = new MicroTimestampConverter();
 
-    assertEquals(Field.Type.datetime(), converter.getBQSchemaType());
+    assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT64);
@@ -85,7 +86,7 @@ public class DebeziumLogicalConvertersTest {
     }
 
     String formattedMicroTimestamp = converter.convert(MICRO_TIMESTAMP);
-    assertEquals("2017-03-01T14:20:38.808123", formattedMicroTimestamp);
+    assertEquals("2017-03-01 22:20:38.808123", formattedMicroTimestamp);
   }
 
   @Test
@@ -101,7 +102,7 @@ public class DebeziumLogicalConvertersTest {
     }
 
     String formattedTime = converter.convert(MILLI_TIMESTAMP);
-    assertEquals("14:20:38.808", formattedTime);
+    assertEquals("22:20:38.808", formattedTime);
   }
 
   @Test
@@ -117,7 +118,7 @@ public class DebeziumLogicalConvertersTest {
     }
 
     String formattedTimestamp = converter.convert(MILLI_TIMESTAMP);
-    assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+    assertEquals("2017-03-01 22:20:38.808", formattedTimestamp);
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -1,0 +1,100 @@
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimestampConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DateConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DecimalConverter;
+
+public class KafkaLogicalConvertersTest {
+
+  //corresponds to March 1 2017, 14:20:38.808
+  private static final Long TIMESTAMP = 1488406838808L;
+
+  @Test
+  public void testTimestampConversion() {
+    TimestampConverter converter = new TimestampConverter();
+
+    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+      Assert.fail("Expected encoding type check to fail");
+    } catch (Exception ex) {
+      // continue
+    }
+
+    Date date = new Date(TIMESTAMP);
+    String formattedTimestamp = converter.convert(date);
+
+    Assert.assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+  }
+
+  @Test
+  public void testDateConversion() {
+    DateConverter converter = new DateConverter();
+
+    Assert.assertEquals(Field.Type.date(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    Date date = new Date(TIMESTAMP);
+    String formattedDate = converter.convert(date);
+    Assert.assertEquals("2017-03-01", formattedDate);
+  }
+
+  @Test
+  public void testDecimalConversion() {
+    DecimalConverter converter = new DecimalConverter();
+
+    Assert.assertEquals(Field.Type.floatingPoint(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.BYTES);
+    } catch (Exception ex) {
+      Assert.fail("Expected encoding type check to succeed.");
+    }
+
+    BigDecimal bigDecimal = new BigDecimal("3.14159");
+
+    BigDecimal convertedDecimal = converter.convert(bigDecimal);
+
+    // expecting no-op
+    Assert.assertEquals(bigDecimal, convertedDecimal);
+  }
+
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -18,17 +18,21 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
  */
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import com.google.cloud.bigquery.Field;
+
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DateConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DecimalConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimestampConverter;
+
 import org.apache.kafka.connect.data.Schema;
-import org.junit.Assert;
+
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.Date;
-
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimestampConverter;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DateConverter;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DecimalConverter;
 
 public class KafkaLogicalConvertersTest {
 
@@ -36,57 +40,32 @@ public class KafkaLogicalConvertersTest {
   private static final Long TIMESTAMP = 1488406838808L;
 
   @Test
-  public void testTimestampConversion() {
-    TimestampConverter converter = new TimestampConverter();
-
-    Assert.assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
-
-    try {
-      converter.checkEncodingType(Schema.Type.INT64);
-    } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
-    }
-
-    try {
-      converter.checkEncodingType(Schema.Type.INT32);
-      Assert.fail("Expected encoding type check to fail");
-    } catch (Exception ex) {
-      // continue
-    }
-
-    Date date = new Date(TIMESTAMP);
-    String formattedTimestamp = converter.convert(date);
-
-    Assert.assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
-  }
-
-  @Test
   public void testDateConversion() {
     DateConverter converter = new DateConverter();
 
-    Assert.assertEquals(Field.Type.date(), converter.getBQSchemaType());
+    assertEquals(Field.Type.date(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.INT32);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     Date date = new Date(TIMESTAMP);
     String formattedDate = converter.convert(date);
-    Assert.assertEquals("2017-03-01", formattedDate);
+    assertEquals("2017-03-01", formattedDate);
   }
 
   @Test
   public void testDecimalConversion() {
     DecimalConverter converter = new DecimalConverter();
 
-    Assert.assertEquals(Field.Type.floatingPoint(), converter.getBQSchemaType());
+    assertEquals(Field.Type.floatingPoint(), converter.getBQSchemaType());
 
     try {
       converter.checkEncodingType(Schema.Type.BYTES);
     } catch (Exception ex) {
-      Assert.fail("Expected encoding type check to succeed.");
+      fail("Expected encoding type check to succeed.");
     }
 
     BigDecimal bigDecimal = new BigDecimal("3.14159");
@@ -94,7 +73,31 @@ public class KafkaLogicalConvertersTest {
     BigDecimal convertedDecimal = converter.convert(bigDecimal);
 
     // expecting no-op
-    Assert.assertEquals(bigDecimal, convertedDecimal);
+    assertEquals(bigDecimal, convertedDecimal);
   }
 
+  @Test
+  public void testTimestampConversion() {
+    TimestampConverter converter = new TimestampConverter();
+
+    assertEquals(Field.Type.timestamp(), converter.getBQSchemaType());
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT64);
+    } catch (Exception ex) {
+      fail("Expected encoding type check to succeed.");
+    }
+
+    try {
+      converter.checkEncodingType(Schema.Type.INT32);
+      fail("Expected encoding type check to fail");
+    } catch (Exception ex) {
+      // continue
+    }
+
+    Date date = new Date(TIMESTAMP);
+    String formattedTimestamp = converter.convert(date);
+
+    assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+  }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -36,7 +36,7 @@ import java.util.Date;
 
 public class KafkaLogicalConvertersTest {
 
-  //corresponds to March 1 2017, 14:20:38.808
+  //corresponds to March 1 2017, 22:20:38.808
   private static final Long TIMESTAMP = 1488406838808L;
 
   @Test
@@ -98,6 +98,6 @@ public class KafkaLogicalConvertersTest {
     Date date = new Date(TIMESTAMP);
     String formattedTimestamp = converter.convert(date);
 
-    assertEquals("2017-03-01 14:20:38.808", formattedTimestamp);
+    assertEquals("2017-03-01 22:20:38.808", formattedTimestamp);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -25,11 +25,9 @@ import com.wepay.kafka.connect.bigquery.SinkPropertiesFactory;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
 import org.apache.kafka.common.config.ConfigException;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
Refactor and reorganize logical type handling.

Add support for debezium logical types

Slightly alter support for one kafka logical type (a kafka date is now a BigQuery date, rather than a timestamp)

Fix deprecation errors / change library usage where necessary from upgrading from gcloud-java to google-cloud.