### PR TITLE
Implement message time partitioning

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -83,7 +83,7 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
       "The minimum amount of time, in milliseconds, to wait between BigQuery backend or quota "
       +  "exceeded error retry attempts.";
 
-  public static final String BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG = "bigQueryMessageTimeDatePartitioning";
+  public static final String BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG = "bigQueryMessageTimePartitioning";
   private static final ConfigDef.Type BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE = ConfigDef.Type.BOOLEAN;
   public static final Boolean BIGQUERY_MESSAGE_TIME_PARTITIONING_DEFAULT =                   false;
   private static final ConfigDef.Importance BIGQUERY_MESSAGE_TIME_PARTITIONING_IMPORTANCE =  ConfigDef.Importance.HIGH;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -83,6 +83,13 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
       "The minimum amount of time, in milliseconds, to wait between BigQuery backend or quota "
       +  "exceeded error retry attempts.";
 
+  public static final String BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG = "bigQueryMessageTimeDatePartitioning";
+  private static final ConfigDef.Type BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE = ConfigDef.Type.BOOLEAN;
+  public static final Boolean BIGQUERY_MESSAGE_TIME_PARTITIONING_DEFAULT =                   false;
+  private static final ConfigDef.Importance BIGQUERY_MESSAGE_TIME_PARTITIONING_IMPORTANCE =  ConfigDef.Importance.HIGH;
+  private static final String BIGQUERY_MESSAGE_TIME_PARTITIONING_DOC =
+          "Whether or not to use the message time when inserting records. Default uses the connector processing time.";
+
   static {
     config = BigQuerySinkConfig.getConfig()
         .define(
@@ -119,6 +126,12 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
             BIGQUERY_RETRY_WAIT_VALIDATOR,
             BIGQUERY_RETRY_WAIT_IMPORTANCE,
             BIGQUERY_RETRY_WAIT_DOC
+        ).define(
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG,
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE,
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_DEFAULT,
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_IMPORTANCE,
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_DOC
         );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -198,6 +198,10 @@ public class PartitionedTableId {
       return this;
     }
 
+    public Builder setDayPartition(long utcTime) {
+      return setDayPartition(LocalDate.ofEpochDay(utcTime / 86400000L));
+    }
+
     public Builder setDayPartition(LocalDate localDate) {
       return setPartition(dateToDayPartition(localDate));
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableId.java
@@ -31,6 +31,7 @@ public class PartitionedTableId {
 
   private static final String PARTITION_DELIMITER = "$";
   private static final Clock UTC_CLOCK = Clock.systemUTC();
+  private static final Long MILLIS_IN_DAY = 86400000L;
 
   private final String project;
   private final String dataset;
@@ -199,7 +200,7 @@ public class PartitionedTableId {
     }
 
     public Builder setDayPartition(long utcTime) {
-      return setDayPartition(LocalDate.ofEpochDay(utcTime / 86400000L));
+      return setDayPartition(LocalDate.ofEpochDay(utcTime / MILLIS_IN_DAY));
     }
 
     public Builder setDayPartition(LocalDate localDate) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -141,7 +141,7 @@ public class BigQuerySinkTaskTest {
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
-    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "message text", TimestampType.CREATE_TIME, 1509007584334L)));
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "value", "message text", TimestampType.CREATE_TIME, 1509007584334L)));
     testTask.flush(Collections.emptyMap());
     ArgumentCaptor<InsertAllRequest> argument = ArgumentCaptor.forClass(InsertAllRequest.class);
 
@@ -170,7 +170,7 @@ public class BigQuerySinkTaskTest {
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
-    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "message text", TimestampType.NO_TIMESTAMP_TYPE, null)));
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "value", "message text", TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
   // It's important that the buffer be completely wiped after a call to flush, since any execption
@@ -384,8 +384,7 @@ public class BigQuerySinkTaskTest {
    * @param timestamp The timestamp in milliseconds
    * @return The spoofed SinkRecord.
    */
-  public static SinkRecord spoofSinkRecord(String topic, String value, TimestampType timestampType, Long timestamp) {
-    String field = "value";
+  public static SinkRecord spoofSinkRecord(String topic, String field, String value, TimestampType timestampType, Long timestamp) {
     Schema basicRowSchema = SchemaBuilder
             .struct()
             .field(field, Schema.STRING_SCHEMA)
@@ -415,13 +414,7 @@ public class BigQuerySinkTaskTest {
    * @return The spoofed SinkRecord.
    */
   public static SinkRecord spoofSinkRecord(String topic, String field, String value) {
-    Schema basicRowSchema = SchemaBuilder
-        .struct()
-        .field(field, Schema.STRING_SCHEMA)
-        .build();
-    Struct basicRowValue = new Struct(basicRowSchema);
-    basicRowValue.put(field, value);
-    return spoofSinkRecord(topic, basicRowSchema, basicRowValue);
+    return spoofSinkRecord(topic, field, value, TimestampType.NO_TIMESTAMP_TYPE, null);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -34,11 +35,13 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
 
+import com.google.cloud.bigquery.TableInfo;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -48,6 +51,8 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -113,6 +118,59 @@ public class BigQuerySinkTaskTest {
     SinkRecord emptyRecord = spoofSinkRecord(topic, simpleSchema, null);
 
     testTask.put(Collections.singletonList(emptyRecord));
+  }
+
+  @Captor ArgumentCaptor<InsertAllRequest> captor;
+  @Test
+  public void testPutWhenPartitioningOnMessageTime() {
+    final String topic = "test-topic";
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+
+    when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "message text", TimestampType.CREATE_TIME, 1509007584334L)));
+    testTask.flush(Collections.emptyMap());
+    ArgumentCaptor<InsertAllRequest> argument = ArgumentCaptor.forClass(InsertAllRequest.class);
+
+    verify(bigQuery, times(1)).insertAll(argument.capture());
+    assertEquals("test-topic$20171026", argument.getValue().getTable().getTable());
+  }
+
+  // Make sure a connect exception is thrown when the message has no timestamp type
+  @Test(expected = ConnectException.class)
+  public void testPutWhenPartitioningOnMessageTimeWhenNoTimestampType() {
+    final String topic = "test-topic";
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+
+    when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, "message text", TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
   // It's important that the buffer be completely wiped after a call to flush, since any execption
@@ -316,6 +374,25 @@ public class BigQuerySinkTaskTest {
         .setIgnoreUnknownValues(false)
         .setSkipInvalidRows(false)
         .build();
+  }
+
+  /**
+   * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+   * @param topic The topic of the record.
+   * @param value The content of the record.
+   * @param timestampType The type of timestamp embedded in the message
+   * @param timestamp The timestamp in milliseconds
+   * @return The spoofed SinkRecord.
+   */
+  public static SinkRecord spoofSinkRecord(String topic, String value, TimestampType timestampType, Long timestamp) {
+    String field = "value";
+    Schema basicRowSchema = SchemaBuilder
+            .struct()
+            .field(field, Schema.STRING_SCHEMA)
+            .build();
+    Struct basicRowValue = new Struct(basicRowSchema);
+    basicRowValue.put(field, value);
+    return new SinkRecord(topic, 0, null, null, basicRowSchema, basicRowValue, 0, timestamp, timestampType);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableIdTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/PartitionedTableIdTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.TableId;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 public class PartitionedTableIdTest {
@@ -71,6 +72,29 @@ public class PartitionedTableIdTest {
         new PartitionedTableId.Builder(dataset, table).setDayPartition(partitionDate).build();
 
     final String expectedPartition = "20160921";
+
+    Assert.assertEquals(dataset, partitionedTableId.getDataset());
+    Assert.assertEquals(table, partitionedTableId.getBaseTableName());
+    Assert.assertEquals(table + "$" + expectedPartition, partitionedTableId.getFullTableName());
+
+    final TableId expectedBaseTableId = TableId.of(dataset, table);
+    final TableId expectedFullTableId = TableId.of(dataset, table + "$" + expectedPartition);
+
+    Assert.assertEquals(expectedBaseTableId, partitionedTableId.getBaseTableId());
+    Assert.assertEquals(expectedFullTableId, partitionedTableId.getFullTableId());
+  }
+
+  @Test
+  public void testWithEpochTimePartition() {
+    final String dataset = "dataset";
+    final String table = "table";
+
+    final long utcTime = 1509007584334L;
+
+    final PartitionedTableId partitionedTableId =
+            new PartitionedTableId.Builder(dataset, table).setDayPartition(utcTime).build();
+
+    final String expectedPartition = "20171026";
 
     Assert.assertEquals(dataset, partitionedTableId.getDataset());
     Assert.assertEquals(table, partitionedTableId.getBaseTableName());


### PR DESCRIPTION
This change adds a configuration option, `bigQueryMessageTimePartitioning`, that allows inserting into a BigQuery partition based on the message time instead of the connector processing time. 

The default behavior is still partitioning on the connector processing time.