### PR TITLE
Fix dependencies so connect-api is a provided dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,8 +186,7 @@ project(':kcbq-connector') {
 
         compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
-        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.2.1'
+        compileOnly group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
 
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
         compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.1'
@@ -234,7 +233,7 @@ project('kcbq-api') {
     dependencies {
         compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
+        compileOnly group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
     }
 
     artifacts {
@@ -286,13 +285,13 @@ project('kcbq-confluent') {
 
         compile group: 'org.apache.avro', name: 'avro', version: '1.8.1'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
-        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.2.1'
+        compileOnly group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
 
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
 
         testCompile group: 'junit', name: 'junit', version: '4.12'
         testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+        testCompile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
     }
 
     artifacts {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6148 is an example where using plugin.path for loading can cause conflicts because connect-api pulls in kafka-clients and a single class was missing special handling to force it to be loaded by the system classloader.

However, connect-api shouldn't be included in packaged versions of connectors anyway, even with CLASSPATH loading, because that could cause potential conflicts between the framework's version and the version the plugin is compiled against. Connect takes great pain to remain backwards compatible so connectors can continue to work with newer versions of the Connect framework without recompiling / changing dependencies.