### PR TITLE
Add null BigQueryException reason check

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -65,7 +65,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
   private boolean isTableMissingSchema(BigQueryException e) {
     // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
     // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors
-    return e.getReason().equalsIgnoreCase("invalid");
+    return e.getReason() != null && e.getReason().equalsIgnoreCase("invalid");
   }
 
   /**


### PR DESCRIPTION
The `BigQueryException` reason can be null which caused a NullPointerException for us the other day