### PR TITLE
Add additional logging info for diagnosing BigQueryWriter failures.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -9,12 +9,17 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
+import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
 import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for managing Schemas of BigQuery tables (creating and updating).
  */
 public class SchemaManager {
+  private static final Logger logger = LoggerFactory.getLogger(SchemaManager.class);
+
   private final SchemaRetriever schemaRetriever;
   private final SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter;
   private final BigQuery bigQuery;
@@ -51,6 +56,7 @@ public class SchemaManager {
    */
   public void updateSchema(TableId table, String topic) {
     Schema kafkaConnectSchema = schemaRetriever.retrieveSchema(table, topic);
+    logger.info("Attempting to update table `{}` with schema {}", table, kafkaConnectSchema);
     bigQuery.update(constructTableInfo(table, kafkaConnectSchema));
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -66,6 +66,7 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
       logger.error("Task failed with {} error: {}",
                    throwable.getClass().getName(),
                    throwable.getMessage());
+      logger.debug("Error Task Stacktrace:", throwable);
       encounteredErrors.add(throwable);
     }
   }


### PR DESCRIPTION
We've had a lot of issues diagnosing BigQueryExceptions from the writer threads, since we only see the top-level error, and not the full stack trace (and thus no info from BigQuery itself). This adds the stack trace to the logs for the DEBUG level.

Also adds an INFO level logging message to attempts to update table schemas.