### PR TITLE
Update build.gradle dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,13 +181,13 @@ project(':kcbq-connector') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
-        compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.6.0'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.25.0-alpha'
+        compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.9.0'
 
         compile group: 'io.debezium', name: 'debezium-core',  version:'0.4.0'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
-        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.2.1'
+        compile group: 'org.apache.kafka', name: 'connect-api', version: '1.0.0'
+        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '1.0.0'
 
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
         compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.1'
@@ -232,9 +232,9 @@ project('kcbq-api') {
     }
 
     dependencies {
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.25.0-alpha'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
+        compile group: 'org.apache.kafka', name: 'connect-api', version: '1.0.0'
     }
 
     artifacts {
@@ -279,15 +279,15 @@ project('kcbq-confluent') {
     dependencies {
         compile project(':kcbq-api')
 
-        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.10.0-alpha'
+        compile group: 'com.google.cloud', name: 'google-cloud', version: '0.25.0-alpha'
 
         compile group: 'io.confluent', name: 'kafka-connect-avro-converter', version: '3.2.0'
         compile group: 'io.confluent', name: 'kafka-schema-registry-client', version: '3.2.0'
 
         compile group: 'org.apache.avro', name: 'avro', version: '1.8.1'
 
-        compile group: 'org.apache.kafka', name: 'connect-api', version: '0.10.2.1'
-        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.10.2.1'
+        compile group: 'org.apache.kafka', name: 'connect-api', version: '1.0.0'
+        compile group: 'org.apache.kafka', name: 'kafka-clients', version: '1.0.0'
 
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
 


### PR DESCRIPTION
In order to start kcbq connector, changes should be made:

1. Updated google related version to use guava version > 20.0
https://github.com/confluentinc/kafka-connect-elasticsearch/issues/143

2. Update kafka version to get rid of java.lang.NoSuchMethodError: org.apache.kafka.common.utils.AppInfoParser.registerAppInfo