### PR TITLE
Deal with partial bigquery failure

### DIFF
--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
@@ -18,9 +18,10 @@ package com.wepay.kafka.connect.bigquery.it;
  */
 
 
+import static com.google.cloud.bigquery.LegacySQLTypeName.*;
 import static org.junit.Assert.assertEquals;
 
-import com.google.cloud.Page;
+import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldValue;
@@ -116,24 +117,23 @@ public class BigQueryConnectorIntegrationTest {
     }
     switch (field.getAttribute()) {
       case PRIMITIVE:
-        switch (fieldSchema.getType().getValue()) {
-          case BOOLEAN:
-            return field.getBooleanValue();
-          case BYTES:
-            // Do this in order for assertEquals() to work when this is an element of two compared
-            // lists
-            return boxByteArray(field.getBytesValue());
-          case FLOAT:
-            return field.getDoubleValue();
-          case INTEGER:
-            return field.getLongValue();
-          case STRING:
-            return field.getStringValue();
-          case TIMESTAMP:
-            return field.getTimestampValue();
-          default:
-            throw new RuntimeException("Cannot convert primitive field type "
-                                       + fieldSchema.getType());
+        if (fieldSchema.getType().getValue().equals(BOOLEAN)) {
+          return field.getBooleanValue();
+        } else if (fieldSchema.getType().getValue().equals(BYTES)) {
+          // Do this in order for assertEquals() to work when this is an element of two compared
+          // lists
+          return boxByteArray(field.getBytesValue());
+        } else if (fieldSchema.getType().getValue().equals(FLOAT)) {
+          return field.getDoubleValue();
+        } else if (fieldSchema.getType().getValue().equals(INTEGER)) {
+          return field.getLongValue();
+        } else if (fieldSchema.getType().getValue().equals(STRING)) {
+          return field.getStringValue();
+        } else if (fieldSchema.getType().getValue().equals(TIMESTAMP)) {
+          return field.getTimestampValue();
+        } else {
+          throw new RuntimeException("Cannot convert primitive field type "
+                  + fieldSchema.getType());
         }
       case REPEATED:
         List<Object> result = new ArrayList<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -86,7 +86,7 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   // For testing purposes only; will never be called by the Kafka Connect framework
-  BigQuerySinkTask(BigQuery testBigQuery, SchemaRetriever schemaRetriever) {
+  public BigQuerySinkTask(BigQuery testBigQuery, SchemaRetriever schemaRetriever) {
     this.testBigQuery = testBigQuery;
     this.schemaRetriever = schemaRetriever;
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -19,18 +19,19 @@ package com.wepay.kafka.connect.bigquery.write.row;
 
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
-
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A simple BigQueryWriter implementation. Sends the request to BigQuery, and throws an exception if
@@ -52,16 +53,14 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   }
 
   /**
-   * Sends the request to BigQuery, and throws an exception if any errors occur as a result of doing
-   * so.
-   * @param tableId The PartitionedTableId.
-   * @param rows The rows to write.
-   * @param topic The Kafka topic that the row data came from (ignored).
+   * Sends the request to BigQuery, and return a map of insertErrors in case of partial failure.
+   * Throws an exception if any other errors occur as a result of doing so.
+   * @see BigQueryWriter#performWriteRequest(PartitionedTableId, List, String)
    */
   @Override
-  public void performWriteRequest(PartitionedTableId tableId,
-                                  List<InsertAllRequest.RowToInsert> rows,
-                                  String topic) {
+  public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
+                                                            List<InsertAllRequest.RowToInsert> rows,
+                                                            String topic) {
     InsertAllRequest request = createInsertAllRequest(tableId, rows);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {
@@ -70,9 +69,10 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
           + "{}=true in the properties file",
           BigQuerySinkTaskConfig.SCHEMA_UPDATE_CONFIG
       );
-      throw new BigQueryConnectException(writeResponse.getInsertErrors());
+      return writeResponse.getInsertErrors();
     } else {
       logger.debug("table insertion completed with no reported errors");
+      return new HashMap<>();
     }
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -1,0 +1,216 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.wepay.kafka.connect.bigquery.BigQuerySinkTask;
+import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BigQueryWriterTest {
+    private static SinkTaskPropertiesFactory propertiesFactory;
+
+    @BeforeClass
+    public static void initializePropertiesFactory() {
+        propertiesFactory = new SinkTaskPropertiesFactory();
+    }
+
+    @Test
+    public void testBigQueryNoFailure() {
+        final String topic = "test_topic";
+        final String dataset = "scratch";
+        final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+        BigQuery bigQuery = mock(BigQuery.class);
+        Map<Long, List<BigQueryError>> emptyMap = mock(Map.class);
+        when(emptyMap.isEmpty()).thenReturn(true);
+
+        InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+        when(insertAllResponse.hasErrors()).thenReturn(false);
+        when(insertAllResponse.getInsertErrors()).thenReturn(emptyMap);
+
+        //first attempt (success)
+        when(bigQuery.insertAll(anyObject()))
+                .thenReturn(insertAllResponse);
+
+        SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        testTask.initialize(sinkTaskContext);
+        testTask.start(properties);
+        testTask.put(Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+        testTask.flush(Collections.emptyMap());
+
+        verify(bigQuery, times(1)).insertAll(anyObject());
+    }
+
+    @Test
+    public void testBigQueryPartialFailure() {
+        final String topic = "test_topic";
+        final String dataset = "scratch";
+        final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+        final Set<Long> failedRowSet = new HashSet<>();
+        failedRowSet.add(1L);
+
+        Map<Long, List<BigQueryError>> insertErrorMap = mock(Map.class);
+        when(insertErrorMap.isEmpty()).thenReturn(false);
+        when(insertErrorMap.size()).thenReturn(1);
+        when(insertErrorMap.keySet()).thenReturn(failedRowSet);
+
+        InsertAllResponse insertAllResponseWithError = mock(InsertAllResponse.class);
+        when(insertAllResponseWithError.hasErrors()).thenReturn(true);
+        when(insertAllResponseWithError.getInsertErrors()).thenReturn(insertErrorMap);
+
+        Map<Long, List<BigQueryError>> emptyMap = mock(Map.class);
+        when(emptyMap.isEmpty()).thenReturn(true);
+
+        InsertAllResponse insertAllResponseNoError = mock(InsertAllResponse.class);
+        when(insertAllResponseNoError.hasErrors()).thenReturn(true);
+        when(insertAllResponseNoError.getInsertErrors()).thenReturn(emptyMap);
+
+        BigQuery bigQuery = mock(BigQuery.class);
+
+        //first attempt (partial failure); second attempt (success)
+        when(bigQuery.insertAll(anyObject()))
+                .thenReturn(insertAllResponseWithError)
+                .thenReturn(insertAllResponseNoError);
+
+        List<SinkRecord> sinkRecordList = new ArrayList<>();
+        sinkRecordList.add(spoofSinkRecord(topic, 0, 0, "some_field", "some_value"));
+        sinkRecordList.add(spoofSinkRecord(topic, 1, 1, "some_field", "some_value"));
+
+        SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        testTask.initialize(sinkTaskContext);
+        testTask.start(properties);
+        testTask.put(sinkRecordList);
+        testTask.flush(Collections.emptyMap());
+
+        ArgumentCaptor<InsertAllRequest> varArgs = ArgumentCaptor.forClass(InsertAllRequest.class);
+        verify(bigQuery, times(2)).insertAll(varArgs.capture());
+
+        assertEquals(2, varArgs.getAllValues().get(0).getRows().size());
+        //second insertAll is called with just the failed rows
+        assertEquals(1, varArgs.getAllValues().get(1).getRows().size());
+        assertEquals("test_topic-1-1", varArgs.getAllValues().get(1).getRows().get(0).getId());
+    }
+
+    @Test(expected = BigQueryConnectException.class)
+    public void testBigQueryCompleteFailure() {
+        final String topic = "test_topic";
+        final String dataset = "scratch";
+        final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+        Map<Long, List<BigQueryError>> insertErrorMap = mock(Map.class);
+        when(insertErrorMap.isEmpty()).thenReturn(false);
+        when(insertErrorMap.size()).thenReturn(2);
+
+        InsertAllResponse insertAllResponseWithError = mock(InsertAllResponse.class);
+        when(insertAllResponseWithError.hasErrors()).thenReturn(true);
+        when(insertAllResponseWithError.getInsertErrors()).thenReturn(insertErrorMap);
+
+        Map<Long, List<BigQueryError>> emptyMap = mock(Map.class);
+        when(emptyMap.isEmpty()).thenReturn(true);
+
+        InsertAllResponse insertAllResponseNoError = mock(InsertAllResponse.class);
+        when(insertAllResponseNoError.hasErrors()).thenReturn(true);
+        when(insertAllResponseNoError.getInsertErrors()).thenReturn(emptyMap);
+
+        BigQuery bigQuery = mock(BigQuery.class);
+
+        //first attempt (complete failure); second attempt (not expected)
+        when(bigQuery.insertAll(anyObject()))
+                .thenReturn(insertAllResponseWithError);
+
+        List<SinkRecord> sinkRecordList = new ArrayList<>();
+        sinkRecordList.add(spoofSinkRecord(topic, 0, 0, "some_field", "some_value"));
+        sinkRecordList.add(spoofSinkRecord(topic, 1, 1, "some_field", "some_value"));
+
+        SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        testTask.initialize(sinkTaskContext);
+        testTask.start(properties);
+        testTask.put(sinkRecordList);
+        testTask.flush(Collections.emptyMap());
+    }
+
+    /**
+     * Utility method for making and retrieving properties based on provided parameters.
+     * @param bigqueryRetry The number of retries.
+     * @param bigqueryRetryWait The wait time for each retry.
+     * @param topic The topic of the record.
+     * @param dataset The dataset of the record.
+     * @return The map of bigquery sink configurations.
+     */
+    private Map<String,String> makeProperties(String bigqueryRetry, String bigqueryRetryWait, String topic, String dataset) {
+        Map<String, String> properties = propertiesFactory.getProperties();
+        properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
+        properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+        properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+        properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+        return properties;
+    }
+
+    /**
+     * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+     * @param topic The topic of the record.
+     * @param partition The partition of the record.
+     * @param field The name of the field in the record's struct.
+     * @param value The content of the field.
+     * @return The spoofed SinkRecord.
+     */
+    private SinkRecord spoofSinkRecord(String topic, int partition, long kafkaOffset, String field, String value) {
+        Schema basicRowSchema = SchemaBuilder
+                .struct()
+                .field(field, Schema.STRING_SCHEMA)
+                .build();
+        Struct basicRowValue = new Struct(basicRowSchema);
+        basicRowValue.put(field, value);
+        return new SinkRecord(topic, partition, null, null, basicRowSchema, basicRowValue, kafkaOffset, null, null);
+    }
+}


### PR DESCRIPTION
Change has been made based on ticket: https://github.com/wepay/kafka-connect-bigquery/issues/53
1. Added an updateRowsBaseOnFailure method to filter out "succeeded rows" in partial failure to eliminate duplicate write during retry. (Design explain, remove row from the back of row list iterator because we delete based on index)
2. Added unit test regarding new method.
