### PR TITLE
Fix logging message for table update attempts

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -56,8 +56,9 @@ public class SchemaManager {
    */
   public void updateSchema(TableId table, String topic) {
     Schema kafkaConnectSchema = schemaRetriever.retrieveSchema(table, topic);
-    logger.info("Attempting to update table `{}` with schema {}", table, kafkaConnectSchema);
-    bigQuery.update(constructTableInfo(table, kafkaConnectSchema));
+    TableInfo tableInfo = constructTableInfo(table, kafkaConnectSchema);
+    logger.info("Attempting to update table `{}` with schema {}", table, tableInfo.getDefinition().getSchema());
+    bigQuery.update(tableInfo);
   }
 
   // package private for testing.


### PR DESCRIPTION
The logging message should now properly display the schema that was used in the failed table update.