### PR TITLE
Fix checkstyle warnings

### DIFF
--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
@@ -18,7 +18,14 @@ package com.wepay.kafka.connect.bigquery.it;
  */
 
 
-import static com.google.cloud.bigquery.LegacySQLTypeName.*;
+import static com.google.cloud.bigquery.LegacySQLTypeName.BOOLEAN;
+import static com.google.cloud.bigquery.LegacySQLTypeName.BYTES;
+import static com.google.cloud.bigquery.LegacySQLTypeName.DATE;
+import static com.google.cloud.bigquery.LegacySQLTypeName.FLOAT;
+import static com.google.cloud.bigquery.LegacySQLTypeName.INTEGER;
+import static com.google.cloud.bigquery.LegacySQLTypeName.STRING;
+import static com.google.cloud.bigquery.LegacySQLTypeName.TIMESTAMP;
+
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.gax.paging.Page;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
@@ -1,13 +1,15 @@
 package com.wepay.kafka.connect.bigquery.retrieve;
 
-import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.TableId;
+
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -63,10 +63,10 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     this.schemaManager = schemaManager;
   }
 
-  private boolean isTableMissingSchema(BigQueryException e) {
+  private boolean isTableMissingSchema(BigQueryException exception) {
     // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
     // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors
-    return e.getReason() != null && e.getReason().equalsIgnoreCase("invalid");
+    return exception.getReason() != null && exception.getReason().equalsIgnoreCase("invalid");
   }
 
   /**
@@ -92,11 +92,11 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
               && onlyContainsInvalidSchemaErrors(writeResponse.getInsertErrors())) {
         attemptSchemaUpdate(tableId, topic);
       }
-    } catch (BigQueryException e) {
-      if (isTableMissingSchema(e)) {
+    } catch (BigQueryException exception) {
+      if (isTableMissingSchema(exception)) {
         attemptSchemaUpdate(tableId, topic);
       } else {
-        throw e;
+        throw exception;
       }
     }
 
@@ -110,7 +110,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
           // If the table was missing its schema, we never received a writeResponse
           logger.debug("re-attempting insertion");
           writeResponse = bigQuery.insertAll(request);
-        } catch (BigQueryException e) {
+        } catch (BigQueryException exception) {
           // no-op, we want to keep retrying the insert
         }
       } else {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -127,8 +127,8 @@ public abstract class BigQueryWriter {
           mostRecentException = new BigQueryConnectException(failedRowsMap);
           retryCount++;
         } else {
-            // throw an exception in case of complete failure
-            throw new BigQueryConnectException(failedRowsMap);
+          // throw an exception in case of complete failure
+          throw new BigQueryConnectException(failedRowsMap);
         }
       } catch (BigQueryException err) {
         mostRecentException = err;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -35,14 +35,12 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
 
-import com.google.cloud.bigquery.TableInfo;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 
-import com.wepay.kafka.connect.bigquery.retrieve.MemorySchemaRetriever;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,11 +51,11 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public class BigQuerySinkTaskTest {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
@@ -2,10 +2,12 @@ package com.wepay.kafka.connect.bigquery.retrieve;
 
 
 import com.google.cloud.bigquery.TableId;
+
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.errors.ConnectException;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -18,22 +18,33 @@ package com.wepay.kafka.connect.bigquery.write.row;
  */
 
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
+
 import com.wepay.kafka.connect.bigquery.BigQuerySinkTask;
 import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
@@ -43,13 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+@SuppressWarnings("unchecked")
 public class BigQueryWriterTest {
   private static SinkTaskPropertiesFactory propertiesFactory;
 


### PR DESCRIPTION
Fix the last bunch of checkstyle warnings.

`./gradlew clean build` now builds without checkstyle warnings.