### PR TITLE
Finished new table writer, implemented batch load flow

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -22,6 +22,8 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.TableId;
 
+import com.google.cloud.storage.Storage;
+
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
@@ -35,11 +37,13 @@ import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.TopicToTableResolver;
 import com.wepay.kafka.connect.bigquery.utils.Version;
 
+import com.wepay.kafka.connect.bigquery.write.batch.GCSBatchTableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
+import com.wepay.kafka.connect.bigquery.write.row.GCSWriter;
 import com.wepay.kafka.connect.bigquery.write.row.SimpleBigQueryWriter;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -70,8 +74,10 @@ public class BigQuerySinkTask extends SinkTask {
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkTask.class);
 
   private final BigQuery testBigQuery;
+  private final Storage testGCS;
   private SchemaRetriever schemaRetriever;
   private BigQueryWriter bigQueryWriter;
+  private GCSWriter gcsWriter;
   private BigQuerySinkTaskConfig config;
   private RecordConverter<Map<String, Object>> recordConverter;
   private Map<String, TableId> topicsToBaseTableIds;
@@ -84,12 +90,14 @@ public class BigQuerySinkTask extends SinkTask {
   public BigQuerySinkTask() {
     testBigQuery = null;
     schemaRetriever = null;
+    testGCS = null;
   }
 
   // For testing purposes only; will never be called by the Kafka Connect framework
-  public BigQuerySinkTask(BigQuery testBigQuery, SchemaRetriever schemaRetriever) {
+  public BigQuerySinkTask(BigQuery testBigQuery, SchemaRetriever schemaRetriever, Storage testGCS) {
     this.testBigQuery = testBigQuery;
     this.schemaRetriever = schemaRetriever;
+    this.testGCS = testGCS;
   }
 
   @Override
@@ -131,6 +139,17 @@ public class BigQuerySinkTask extends SinkTask {
     return builder.build();
   }
 
+  private RowToInsert getRecordRow(SinkRecord record) {
+    return RowToInsert.of(getRowId(record), recordConverter.convertRecord(record));
+  }
+
+  private String getRowId(SinkRecord record) {
+    return String.format("%s-%d-%d",
+        record.topic(),
+        record.kafkaPartition(),
+        record.kafkaOffset());
+  }
+
   @Override
   public void put(Collection<SinkRecord> records) {
 
@@ -145,11 +164,19 @@ public class BigQuerySinkTask extends SinkTask {
         }
 
         if (!tableWriterBuilders.containsKey(table)) {
-          TableWriter.Builder tableWriterBuilder =
-              new TableWriter.Builder(bigQueryWriter, table, record.topic(), recordConverter);
+          TableWriterBuilder tableWriterBuilder;
+          if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
+            tableWriterBuilder = new GCSBatchTableWriter.Builder(
+                gcsWriter,
+                table.getBaseTableId(),
+                config.getString(config.GCS_BUCKET_NAME_CONFIG),
+                recordConverter);
+          } else {
+            tableWriterBuilder = new TableWriter.Builder(bigQueryWriter, table, record.topic(), recordConverter);
+          }
           tableWriterBuilders.put(table, tableWriterBuilder);
         }
-        tableWriterBuilders.get(table).addRecord(record);
+        tableWriterBuilders.get(table).addRow(getRecordRow(record));
       }
     }
 
@@ -206,6 +233,25 @@ public class BigQuerySinkTask extends SinkTask {
     }
   }
 
+  private Storage getGCS() {
+    if (testGCS != null) {
+      return testGCS;
+    }
+    String projectName = config.getString(config.PROJECT_CONFIG);
+    String keyFilename = config.getString(config.KEYFILE_CONFIG);
+    return new GCSHelper().connect(projectName, keyFilename);
+  }
+
+  private GCSWriter getGCSWriter() {
+    BigQuery bigQuery = getBigQuery();
+    int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
+    long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
+    return new GCSWriter(getGCS(),
+                         bigQuery,
+                         retry,
+                         retryWait);
+  }
+
   @Override
   public void start(Map<String, String> properties) {
     logger.trace("task.start()");
@@ -219,6 +265,7 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     bigQueryWriter = getBigQueryWriter();
+    gcsWriter = getGCSWriter();
     topicsToBaseTableIds = TopicToTableResolver.getTopicsToTables(config);
     recordConverter = getConverter();
     executor = new KCBQThreadPoolExecutor(config, new LinkedBlockingQueue<>());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -73,8 +73,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class BigQuerySinkTask extends SinkTask {
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkTask.class);
 
-  private final BigQuery testBigQuery;
-  private final Storage testGCS;
   private SchemaRetriever schemaRetriever;
   private BigQueryWriter bigQueryWriter;
   private GCSWriter gcsWriter;
@@ -86,6 +84,10 @@ public class BigQuerySinkTask extends SinkTask {
   private TopicPartitionManager topicPartitionManager;
 
   private KCBQThreadPoolExecutor executor;
+
+  private final BigQuery testBigQuery;
+  private final Storage testGCS;
+
 
   public BigQuerySinkTask() {
     testBigQuery = null;
@@ -239,7 +241,7 @@ public class BigQuerySinkTask extends SinkTask {
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
     String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new GCSHelper().connect(projectName, keyFilename);
+    return new GCSBuilder(projectName).setKeyFileName(keyFilename).build();
   }
 
   private GCSWriter getGCSWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSBuilder.java
@@ -32,8 +32,25 @@ import java.io.InputStream;
 /**
  * Convenience class for creating a {@link com.google.cloud.storage.Storage} instance
  */
-public class GCSHelper {
-  private static final Logger logger = LoggerFactory.getLogger(GCSHelper.class);
+public class GCSBuilder {
+  private static final Logger logger = LoggerFactory.getLogger(GCSBuilder.class);
+
+  private final String projectName;
+  private String keyFileName;
+
+  public GCSBuilder(String projectName) {
+    this.projectName = projectName;
+    this.keyFileName = null;
+  }
+
+  public GCSBuilder setKeyFileName(String keyFileName) {
+    this.keyFileName = keyFileName;
+    return this;
+  }
+
+  public Storage build() {
+    return connect(projectName, keyFileName);
+  }
 
   /**
    * Returns a default {@link Storage} instance for the specified project with credentials provided
@@ -44,7 +61,7 @@ public class GCSHelper {
    *                    credentials to GCS, or null if no authentication should be performed.
    * @return The resulting Storage object.
    */
-  public Storage connect(String projectName, String keyFilename) {
+  private Storage connect(String projectName, String keyFilename) {
     if (keyFilename == null) {
       return connect(projectName);
     }
@@ -69,7 +86,7 @@ public class GCSHelper {
    * @param projectName The name of the GCS project to work with
    * @return The resulting Storage object.
    */
-  public Storage connect(String projectName) {
+  private Storage connect(String projectName) {
     logger.debug("Attempting to access BigQuery without authentication");
     return StorageOptions.newBuilder()
         .setProjectId(projectName)

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSHelper.java
@@ -1,0 +1,79 @@
+package com.wepay.kafka.connect.bigquery;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Convenience class for creating a {@link com.google.cloud.storage.Storage} instance
+ */
+public class GCSHelper {
+  private static final Logger logger = LoggerFactory.getLogger(GCSHelper.class);
+
+  /**
+   * Returns a default {@link Storage} instance for the specified project with credentials provided
+   * in the specified file.
+   *
+   * @param projectName The name of the GCS project to work with
+   * @param keyFilename The name of a file containing a JSON key that can be used to provide
+   *                    credentials to GCS, or null if no authentication should be performed.
+   * @return The resulting Storage object.
+   */
+  public Storage connect(String projectName, String keyFilename) {
+    if (keyFilename == null) {
+      return connect(projectName);
+    }
+
+    logger.debug("Attempting to open file {} for service account json key", keyFilename);
+    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
+      logger.debug("Attempting to authenticate with GCS using provided json key");
+      return StorageOptions.newBuilder()
+          .setProjectId(projectName)
+          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
+          .build()
+          .getService();
+    } catch (IOException err) {
+      throw new GCSConnectException("Failed to access json key file", err);
+    }
+  }
+
+  /**
+   * Returns a default {@link Storage} instance for the specified project with no authentication
+   * credentials.
+   *
+   * @param projectName The name of the GCS project to work with
+   * @return The resulting Storage object.
+   */
+  public Storage connect(String projectName) {
+    logger.debug("Attempting to access BigQuery without authentication");
+    return StorageOptions.newBuilder()
+        .setProjectId(projectName)
+        .build()
+        .getService();
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -465,8 +465,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
   /**
    * Verifies that the current config is valid. Throws an exception if it is not
    * @throws ConfigException Exception thrown in case the config is not valid
+   * Verifies that a bucket is specified if GCS batch loading is enabled
+   * @throws ConfigException Exception thrown if no bucket is specified and batch loading is on
    */
-  private void verifyConfig() throws ConfigException {
+  private void verifyBucketSpecified() throws ConfigException {
     // Throw an exception if GCS Batch loading will be used but no bucket is specified
     if (getString(GCS_BUCKET_NAME_CONFIG).equals("")
         && !getList(ENABLE_BATCH_CONFIG).isEmpty()) {
@@ -485,11 +487,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
-    verifyConfig();
+    verifyBucketSpecified();
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
     super(config, properties);
-    verifyConfig();
+    verifyBucketSpecified();
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -463,8 +463,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   }
 
   /**
-   * Verifies that the current config is valid. Throws an exception if it is not
-   * @throws ConfigException Exception thrown in case the config is not valid
    * Verifies that a bucket is specified if GCS batch loading is enabled
    * @throws ConfigException Exception thrown if no bucket is specified and batch loading is on
    */

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -61,11 +61,19 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "A list of Kafka topics to read from";
 
   public static final String ENABLE_BATCH_CONFIG =                         "enableBatchLoad";
-  public static final ConfigDef.Type ENABLE_BATCH_TYPE =                   ConfigDef.Type.LIST;
-  public static final List<String> ENABLE_BATCH_DEFAULT =                  Collections.emptyList();
-  public static final ConfigDef.Importance ENABLE_BATCH_IMPORTANCE =       ConfigDef.Importance.LOW;
-  public static final String ENABLE_BATCH_DOC =
+  private static final ConfigDef.Type ENABLE_BATCH_TYPE =                  ConfigDef.Type.LIST;
+  private static final List<String> ENABLE_BATCH_DEFAULT =                 Collections.emptyList();
+  private static final ConfigDef.Importance ENABLE_BATCH_IMPORTANCE =      ConfigDef.Importance.LOW;
+  private static final String ENABLE_BATCH_DOC =
       "The sublist of topics to be batch loaded through GCS";
+
+  public static final String GCS_BUCKET_NAME_CONFIG =                     "gcsBucketName";
+  private static final ConfigDef.Type GCS_BUCKET_NAME_TYPE =              ConfigDef.Type.STRING;
+  private static final Object GCS_BUCKET_NAME_DEFAULT =                   "";
+  private static final ConfigDef.Importance GCS_BUCKET_NAME_IMPORTANCE =  ConfigDef.Importance.HIGH;
+  private static final String GCS_BUCKET_NAME_DOC =
+      "The name of the bucket in which gcs blobs used to batch load to BigQuery " +
+          "should be located.";
 
   public static final String TOPICS_TO_TABLES_CONFIG =                     "topicsToTables";
   private static final ConfigDef.Type TOPICS_TO_TABLES_TYPE =              ConfigDef.Type.LIST;
@@ -157,6 +165,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ENABLE_BATCH_DEFAULT,
             ENABLE_BATCH_IMPORTANCE,
             ENABLE_BATCH_DOC
+        ).define(
+            GCS_BUCKET_NAME_CONFIG,
+            GCS_BUCKET_NAME_TYPE,
+            GCS_BUCKET_NAME_DEFAULT,
+            GCS_BUCKET_NAME_IMPORTANCE,
+            GCS_BUCKET_NAME_DOC
         ).define(
             TOPICS_TO_TABLES_CONFIG,
             TOPICS_TO_TABLES_TYPE,
@@ -449,6 +463,18 @@ public class BigQuerySinkConfig extends AbstractConfig {
   }
 
   /**
+   * Verifies that the current config is valid. Throws an exception if it is not
+   * @throws ConfigException Exception thrown in case the config is not valid
+   */
+  private void verifyConfig() throws ConfigException {
+    // Throw an exception if GCS Batch loading will be used but no bucket is specified
+    if (getString(GCS_BUCKET_NAME_CONFIG).equals("")
+        && !getList(ENABLE_BATCH_CONFIG).isEmpty()) {
+      throw new ConfigException("Batch loading enabled for some topics, but no bucket specified");
+    }
+  }
+
+  /**
    * Return the ConfigDef object used to define this config's fields.
    *
    * @return The ConfigDef object used to define this config's fields.
@@ -459,9 +485,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
+    verifyConfig();
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
     super(config, properties);
+    verifyConfig();
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/GCSConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/GCSConnectException.java
@@ -1,4 +1,4 @@
-package com.wepay.kafka.connect.bigquery.write.batch;
+package com.wepay.kafka.connect.bigquery.exception;
 
 /*
  * Copyright 2016 WePay, Inc.
@@ -18,22 +18,17 @@ package com.wepay.kafka.connect.bigquery.write.batch;
  */
 
 
-import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import org.apache.kafka.connect.errors.ConnectException;
 
 /**
- * Interface for building a {@link TableWriter} or TableWriterGCS.
+ * Class for exceptions that occur while interacting with Google Cloud Storage, such as login failures
  */
-public interface TableWriterBuilder {
+public class GCSConnectException extends ConnectException {
+  public GCSConnectException(String msg) {
+    super(msg);
+  }
 
-  /**
-   * Add a record to the builder.
-   * @param rowToInsert the row to add.
-   */
-  void addRow(RowToInsert rowToInsert);
-
-  /**
-   * Create a {@link TableWriter} from this builder.
-   * @return a TableWriter containing the given writer, table, topic, and all added rows.
-   */
-  Runnable build();
+  public GCSConnectException(String msg, Throwable thr) {
+    super(msg, thr);
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -23,7 +23,7 @@ import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 
-import com.wepay.kafka.connect.bigquery.write.row.GCSWriter;
+import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import org.slf4j.Logger;
@@ -46,17 +46,17 @@ public class GCSBatchTableWriter implements Runnable {
   private final String blobName;
 
   private final List<RowToInsert> rows;
-  private final GCSWriter writer;
+  private final GCSToBQWriter writer;
 
   /**
    * @param rows The list of rows that should be written through GCS
-   * @param writer {@link GCSWriter} to use
+   * @param writer {@link GCSToBQWriter} to use
    * @param tableId the BigQuery table id of the table to write to
    * @param bucketName the name of the GCS bucket where the blob should be uploaded
    * @param blobName the name of the blob in which the serialized rows should be uploaded
    */
   private GCSBatchTableWriter(List<RowToInsert> rows,
-                              GCSWriter writer,
+                              GCSToBQWriter writer,
                               TableId tableId,
                               String bucketName,
                               String blobName) {
@@ -85,17 +85,16 @@ public class GCSBatchTableWriter implements Runnable {
 
     private List<RowToInsert> rows;
     private final RecordConverter<Map<String, Object>> recordConverter;
-    private final GCSWriter writer;
-
-    private static final String DEFAULT_BLOB_NAME = "kcbq_GCS_Batch_Load_Blob";
-
-    public Builder(GCSWriter writer,
+    private final GCSToBQWriter writer;
+    
+    public Builder(GCSToBQWriter writer,
                    TableId tableId,
-                   String GcsBucketName,
+                   String gcsBucketName,
+                   String gcsBlobName,
                    RecordConverter<Map<String, Object>> recordConverter) {
 
-      this.bucketName = GcsBucketName;
-      this.blobName = DEFAULT_BLOB_NAME;
+      this.bucketName = gcsBucketName;
+      this.blobName = gcsBlobName;
 
       this.tableId = tableId;
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -172,10 +172,9 @@ public class TableWriter implements Runnable {
 
     /**
      * Add a record to the builder.
-     * @param recordToInsert the record to add.
+     * @param rowToInsert the row to add
      */
-    public void addRecord(SinkRecord recordToInsert) {
-      RowToInsert rowToInsert = getRecordRow(recordToInsert);
+    public void addRow(RowToInsert rowToInsert) {
       rows.add(rowToInsert);
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -47,8 +47,8 @@ import java.util.Random;
 /**
  * A class for batch writing list of rows to BigQuery through GCS
  */
-public class GCSWriter {
-  private static final Logger logger = LoggerFactory.getLogger(GCSWriter.class);
+public class GCSToBQWriter {
+  private static final Logger logger = LoggerFactory.getLogger(GCSToBQWriter.class);
 
   private static Gson gson = new Gson();
 
@@ -69,10 +69,10 @@ public class GCSWriter {
    * @param storage GCS Storage
    * @param bigQuery {@link BigQuery} Object used to perform upload
    */
-  public GCSWriter(Storage storage,
-                   BigQuery bigQuery,
-                   int retries,
-                   long retryWaitMs) {
+  public GCSToBQWriter(Storage storage,
+                       BigQuery bigQuery,
+                       int retries,
+                       long retryWaitMs) {
     this.storage = storage;
     this.bigQuery = bigQuery;
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSWriter.java
@@ -1,0 +1,178 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.LoadJobConfiguration;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.gson.Gson;
+
+import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * A class for batch writing list of rows to BigQuery through GCS
+ */
+public class GCSWriter {
+  private static final Logger logger = LoggerFactory.getLogger(GCSWriter.class);
+
+  private static Gson gson = new Gson();
+
+  private final Storage storage;
+
+  private final BigQuery bigQuery;
+  private LoadJobConfiguration loadJobConfiguration;
+
+  private static final int WAIT_MAX_JITTER = 1000;
+
+  private static final Random random = new Random();
+
+  private int retries;
+  private long retryWaitMs;
+
+  /**
+   * Initializes a batch GCS writer with a full list of rows to write.
+   * @param storage GCS Storage
+   * @param bigQuery {@link BigQuery} Object used to perform upload
+   */
+  public GCSWriter(Storage storage,
+                   BigQuery bigQuery,
+                   int retries,
+                   long retryWaitMs) {
+    this.storage = storage;
+    this.bigQuery = bigQuery;
+
+    this.retries = retries;
+    this.retryWaitMs = retryWaitMs;
+  }
+
+  public void writeRows(List<RowToInsert> rows,
+                        TableId tableId,
+                        String bucketName,
+                        String blobName)
+      throws InterruptedException {
+
+    // Get Source URI
+    BlobId blobId = BlobId.of(bucketName, blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/json").build();
+    String sourceUri = String.format("gs://%s/%s", bucketName, blobName);
+
+    // Check if the table specified exists
+    // This error shouldn't be thrown. All tables should be created by the connector at startup
+    if (bigQuery.getTable(tableId) == null) {
+      throw new ConnectException(
+          String.format("Table with TableId %s does not exist.", tableId.getTable()));
+    }
+
+    // Create a job configuration
+    this.loadJobConfiguration =
+        LoadJobConfiguration.builder(tableId, sourceUri)
+            .setFormatOptions(FormatOptions.json())
+            .setCreateDisposition(JobInfo.CreateDisposition.CREATE_IF_NEEDED)
+            .build();
+
+    int retryCount = 0;
+    boolean exceptionsOccurred;
+    do {
+      if (retryCount > 0) {
+        waitRandomTime();
+      }
+      exceptionsOccurred = false;
+      // Perform GCS Upload and BQ Transfer
+      try {
+        uploadRowsToGcs(rows, blobInfo);
+        triggerBigQueryLoadJob();
+      } catch (ConnectException ce) {
+        exceptionsOccurred = true;
+        logger.warn("Exceptions occurred for table {}, attempting retry", tableId.getTable());
+      }
+      retryCount++;
+    } while (exceptionsOccurred && (retryCount < retries));
+
+    logger.info("Batch loaded {} rows", rows.size());
+  }
+
+  /**
+   * Triggers a load job to transfer JSON records from a GCS blob to a BigQuery table.
+   */
+  private void triggerBigQueryLoadJob() {
+    bigQuery.create(JobInfo.of(loadJobConfiguration));
+  }
+
+  /**
+   * Creates a JSON string containing all records and uploads it as a blob to GCS
+   * @return The blob uploaded to GCS
+   */
+  private Blob uploadRowsToGcs(List<RowToInsert> rows, BlobInfo blobInfo) {
+    try {
+      Blob resultBlob = uploadBlobToGcs(
+          new ByteArrayInputStream(toJson(rows).getBytes("UTF-8")), blobInfo);
+      return resultBlob;
+    } catch (UnsupportedEncodingException uee) {
+      throw new GCSConnectException("Failed to upload blob to GCS", uee);
+    }
+  }
+
+  private Blob uploadBlobToGcs(InputStream blobContent, BlobInfo blobInfo) {
+    // todo look into creating from a string because this is depreciated - input stream cannot retry
+    // todo consider if it would be worth it to switch to a resumable method of uploading
+    return storage.create(blobInfo, blobContent);
+  }
+
+  /**
+   * Converts a list of rows to a serialized JSON string of records
+   * @param rows rows to be serialized
+   * @return The resulting newline delimited JSON string containing all records in the original list
+   */
+  private String toJson(List<RowToInsert> rows) {
+    StringBuilder jsonRecordsBuilder = new StringBuilder("");
+    for (RowToInsert row : rows) {
+      Map<String, Object> record = row.getContent();
+      jsonRecordsBuilder.append(gson.toJson(record));
+      jsonRecordsBuilder.append("\n");
+    }
+    return jsonRecordsBuilder.toString();
+  }
+
+  /**
+   * Wait at least {@link #retryWaitMs}, with up to an additional 1 second of random jitter.
+   * @throws InterruptedException if interrupted.
+   */
+  private void waitRandomTime() throws InterruptedException {
+    Thread.sleep(retryWaitMs + random.nextInt(WAIT_MAX_JITTER));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
 
 import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.storage.Storage;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
@@ -77,13 +78,15 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
+
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
 
     when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
     when(insertAllResponse.hasErrors()).thenReturn(false);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -101,6 +104,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
 
@@ -109,7 +113,7 @@ public class BigQuerySinkTaskTest {
 
     SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -123,8 +127,9 @@ public class BigQuerySinkTaskTest {
   public void testEmptyPut() {
     Map<String, String> properties = propertiesFactory.getProperties();
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.start(properties);
 
     testTask.put(Collections.emptyList());
@@ -141,8 +146,9 @@ public class BigQuerySinkTaskTest {
 
     Map<String, String> properties = propertiesFactory.getProperties();
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.start(properties);
 
     SinkRecord emptyRecord = spoofSinkRecord(topic, simpleSchema, null);
@@ -161,13 +167,14 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
 
     when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
     when(insertAllResponse.hasErrors()).thenReturn(false);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -190,13 +197,14 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
 
     when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
     when(insertAllResponse.hasErrors()).thenReturn(false);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -216,11 +224,12 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
     when(bigQuery.insertAll(any(InsertAllRequest.class)))
         .thenThrow(new RuntimeException("This is a test"));
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -238,9 +247,10 @@ public class BigQuerySinkTaskTest {
   public void testEmptyFlush() {
     Map<String, String> properties = propertiesFactory.getProperties();
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -259,6 +269,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
     when(bigQuery.insertAll(anyObject()))
@@ -270,7 +281,7 @@ public class BigQuerySinkTaskTest {
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -291,6 +302,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
     BigQueryError quotaExceededError = new BigQueryError("quotaExceeded", null, null);
@@ -303,7 +315,7 @@ public class BigQuerySinkTaskTest {
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -324,6 +336,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
 
     BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
 
     InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
     BigQueryError quotaExceededError = new BigQueryError("quotaExceeded", null, null);
@@ -333,7 +346,7 @@ public class BigQuerySinkTaskTest {
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
     testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
@@ -351,13 +364,14 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
 
     BigQuery bigQuery  = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
     InsertAllResponse fakeResponse = mock(InsertAllResponse.class);
     when(fakeResponse.hasErrors()).thenReturn(false);
     when(fakeResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
     when(bigQuery.insertAll(any(InsertAllRequest.class))).thenReturn(fakeResponse);
 
     SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
-    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
@@ -375,7 +389,8 @@ public class BigQuerySinkTaskTest {
     Map<String, String> badProperties = propertiesFactory.getProperties();
     badProperties.remove(BigQuerySinkConfig.TOPICS_CONFIG);
 
-    BigQuerySinkTask testTask = new BigQuerySinkTask(mock(BigQuery.class), null);
+    BigQuerySinkTask testTask =
+        new BigQuerySinkTask(mock(BigQuery.class), null, mock(Storage.class));
     testTask.start(badProperties);
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -22,11 +22,14 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.storage.Storage;
+
 import com.wepay.kafka.connect.bigquery.BigQuerySinkTask;
 import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -65,6 +68,7 @@ public class BigQueryWriterTest {
         final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
 
         BigQuery bigQuery = mock(BigQuery.class);
+        Storage storage = mock(Storage.class);
         Map<Long, List<BigQueryError>> emptyMap = mock(Map.class);
         when(emptyMap.isEmpty()).thenReturn(true);
 
@@ -78,7 +82,7 @@ public class BigQueryWriterTest {
 
         SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
         testTask.initialize(sinkTaskContext);
         testTask.start(properties);
         testTask.put(Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
@@ -112,6 +116,7 @@ public class BigQueryWriterTest {
         when(insertAllResponseNoError.getInsertErrors()).thenReturn(emptyMap);
 
         BigQuery bigQuery = mock(BigQuery.class);
+        Storage storage = mock(Storage.class);
 
         //first attempt (partial failure); second attempt (success)
         when(bigQuery.insertAll(anyObject()))
@@ -124,7 +129,7 @@ public class BigQueryWriterTest {
 
         SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
         testTask.initialize(sinkTaskContext);
         testTask.start(properties);
         testTask.put(sinkRecordList);
@@ -161,6 +166,7 @@ public class BigQueryWriterTest {
         when(insertAllResponseNoError.getInsertErrors()).thenReturn(emptyMap);
 
         BigQuery bigQuery = mock(BigQuery.class);
+        Storage storage = mock(Storage.class);
 
         //first attempt (complete failure); second attempt (not expected)
         when(bigQuery.insertAll(anyObject()))
@@ -172,7 +178,7 @@ public class BigQueryWriterTest {
 
         SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
 
-        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null);
+        BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
         testTask.initialize(sinkTaskContext);
         testTask.start(properties);
         testTask.put(sinkRecordList);


### PR DESCRIPTION
Finished the new table writer and altered it to work similarly to the normal table writer.
Introduced a GCS writer.
Added a configuration for the name of the bucket where GCS blobs should be uploaded.
Altered the flow of BigQuerySinkTask to batch process records in topics configured to be batch loaded