### PR TITLE
Fix tar creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ ./gradlew clean distTar
 And then extract its contents:
 
 ```bash
-$ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar
+$ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kcbq-confluent-*.tar
 ```
 
 ### Setting-Up Background Processes

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ $ cd /path/to/kafka-connect-bigquery/
 Begin by creating a tarball of the connector with the Confluent Schema Retriever included:
 
 ```bash
-$ ./gradlew clean confluentTarBall
+$ ./gradlew clean distTar
 ```
 
 And then extract its contents:
 
 ```bash
-$ mkdir bin/jar/ && tar -C bin/jar/ -xf bin/tar/kcbq-connector-*-confluent-dist.tar
+$ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar
 ```
 
 ### Setting-Up Background Processes

--- a/build.gradle
+++ b/build.gradle
@@ -7,24 +7,6 @@ allprojects {
 // for some reason this does not work if applied in allprojects.
 apply plugin: 'distribution'
 
-configurations.all {
-
-    /*
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.apache.kafka') {
-            details.useVersion '1.1.1'
-            // force our kafka version.
-        }
-    }
-    */
-    resolutionStrategy {
-        // none of this seems to be working =/
-        force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
-        //forcedModules = ['org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1']
-        //preferProjectModules()
-    }
-}
-
 // END ALL PROJECTS
 
 // BEGIN SUBPROJECTS //
@@ -115,10 +97,6 @@ subprojects { subproject ->
 }
 // END SUBPROJECTS
 
-// BEGIN ROOT PROJECT
-
-// END ROOT PROJECT
-
 // BEGIN INDIVIDUAL PROJECTS
 project(':kcbq-connector') {
     apply plugin: 'jacoco'
@@ -203,7 +181,7 @@ project(':kcbq-connector') {
     }
 
     artifacts {
-        archives javadocJar, sourcesJar
+        archives javadocJar, sourcesJar, distTar
     }
 
     uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ project('kcbq-confluent') {
 
     distributions {
         main {
-            baseName = 'someName'
+            baseName = 'kafka-connect-bigquery'
             contents {
                 from configurations.runtime
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,30 @@
 // BEGIN ALL PROJECTS //
 allprojects {
     apply plugin: 'java'
+    apply plugin: 'project-report' // todo delete me
 }
+
+// for some reason this does not work if applied in allprojects.
+apply plugin: 'distribution'
+
+configurations.all {
+
+    /*
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.kafka') {
+            details.useVersion '1.1.1'
+            // force our kafka version.
+        }
+    }
+    */
+    resolutionStrategy {
+        // none of this seems to be working =/
+        force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
+        //forcedModules = ['org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1']
+        //preferProjectModules()
+    }
+}
+
 // END ALL PROJECTS
 
 // BEGIN SUBPROJECTS //
@@ -33,13 +56,6 @@ subprojects { subproject ->
     task sourcesJar(type: Jar) {
         classifier = 'sources'
         from sourceSets.main.allSource
-    }
-
-    task tarBall(type: Tar) {
-        classifier = 'dist'
-        baseName = subproject.name
-        from subproject.configurations.runtime
-        from jar
     }
 
     signing {
@@ -100,18 +116,7 @@ subprojects { subproject ->
 // END SUBPROJECTS
 
 // BEGIN ROOT PROJECT
-task confluentTarBall(type: Tar) {
-    destinationDir = file("${rootDir}/bin/tar/")
-    baseName = 'kcbq-connector'
-    classifier = 'confluent-dist'
-    with project(':kcbq-connector').tarBall
-    with project(':kcbq-confluent').tarBall
-    exclude 'jackson-core-2.1.3.jar' // Runtime conflicts occur if this is left in; thankfully, 2.5.4 is compatible
-}
 
-clean {
-    delete "${rootDir}/bin/"
-}
 // END ROOT PROJECT
 
 // BEGIN INDIVIDUAL PROJECTS
@@ -198,7 +203,7 @@ project(':kcbq-connector') {
     }
 
     artifacts {
-        archives javadocJar, sourcesJar, tarBall, rootProject.confluentTarBall
+        archives javadocJar, sourcesJar
     }
 
     uploadArchives {
@@ -257,6 +262,23 @@ project('kcbq-api') {
 }
 
 project('kcbq-confluent') {
+    apply plugin: 'distribution'
+
+    configurations.all {
+        resolutionStrategy {
+            force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
+        }
+    }
+
+    distributions {
+        main {
+            baseName = 'someName'
+            contents {
+                from configurations.runtime
+            }
+        }
+    }
+
     jar {
         manifest {
             attributes  'Implementation-Title': 'Kafka Connect BigQuery Schema Registry Schema Retriever',
@@ -279,6 +301,7 @@ project('kcbq-confluent') {
 
     dependencies {
         compile project(':kcbq-api')
+        runtime project(':kcbq-connector')
 
         compile group: 'com.google.cloud', name: 'google-cloud', version: '0.47.0-alpha'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // BEGIN ALL PROJECTS //
 allprojects {
     apply plugin: 'java'
-    apply plugin: 'project-report' // todo delete me
 }
 
 // for some reason this does not work if applied in allprojects.
@@ -181,7 +180,7 @@ project(':kcbq-connector') {
     }
 
     artifacts {
-        archives javadocJar, sourcesJar, distTar
+        archives javadocJar, sourcesJar
     }
 
     uploadArchives {
@@ -298,7 +297,7 @@ project('kcbq-confluent') {
     }
 
     artifacts {
-        archives javadocJar, sourcesJar
+        archives javadocJar, sourcesJar, distTar
     }
 
     uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -240,8 +240,8 @@ project('kcbq-confluent') {
 
     configurations.all {
         resolutionStrategy {
-            force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
             // depending on debezium results in us pulling in the most recent kafka version, but we want to use 1.1.1.
+            force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ allprojects {
     apply plugin: 'java'
 }
 
-// for some reason this does not work if applied in allprojects.
-apply plugin: 'distribution'
-
 // END ALL PROJECTS
 
 // BEGIN SUBPROJECTS //
@@ -244,12 +241,13 @@ project('kcbq-confluent') {
     configurations.all {
         resolutionStrategy {
             force 'org.apache.kafka:connect-api:1.1.1', 'org.apache.kafka:kafka-clients:1.1.1'
+            // depending on debezium results in us pulling in the most recent kafka version, but we want to use 1.1.1.
         }
     }
 
     distributions {
         main {
-            baseName = 'kafka-connect-bigquery'
+            baseName = 'kcbq-confluent'
             contents {
                 from configurations.runtime
             }

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -206,7 +206,6 @@ warn 'Deleting existing BigQuery test tables'
 statusupdate 'Executing Kafka Connect in Docker'
 
 # Run clean task to ensure there's only one connector tarball in the build/dist directory
-# todo fixme
 "$GRADLEW" -q -p "$BASE_DIR/../.." clean distTar
 
 [[ ! -e "$DOCKER_DIR/connect/properties" ]] && mkdir "$DOCKER_DIR/connect/properties"

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -232,8 +232,8 @@ echo >> "$CONNECTOR_PROPS"
 CONNECT_DOCKER_IMAGE='kcbq/connect'
 CONNECT_DOCKER_NAME='kcbq_test_connect'
 
-cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar "$DOCKER_DIR/connect/kcbq.tar"
-cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar "$DOCKER_DIR/connect/retriever.tar"
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kcbq-confluent-*.tar "$DOCKER_DIR/connect/kcbq.tar"
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kcbq-confluent-*.tar "$DOCKER_DIR/connect/retriever.tar"
 cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
 
 if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -233,9 +233,8 @@ echo >> "$CONNECTOR_PROPS"
 CONNECT_DOCKER_IMAGE='kcbq/connect'
 CONNECT_DOCKER_NAME='kcbq_test_connect'
 
-# todo fixme
-cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*-SNAPSHOT.tar "$DOCKER_DIR/connect/kcbq.tar"
-cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*-SNAPSHOT.tar "$DOCKER_DIR/connect/retriever.tar"
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar "$DOCKER_DIR/connect/kcbq.tar"
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*.tar "$DOCKER_DIR/connect/retriever.tar"
 cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
 
 if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -205,8 +205,9 @@ warn 'Deleting existing BigQuery test tables'
 # Executing connector in standalone mode (this is the execution portion of the actual test)
 statusupdate 'Executing Kafka Connect in Docker'
 
-# Run clean task to ensure there's only one connector tarball in the build directory
-"$GRADLEW" -q -p "$BASE_DIR/../.." clean confluentTarBall
+# Run clean task to ensure there's only one connector tarball in the build/dist directory
+# todo fixme
+"$GRADLEW" -q -p "$BASE_DIR/../.." clean distTar
 
 [[ ! -e "$DOCKER_DIR/connect/properties" ]] && mkdir "$DOCKER_DIR/connect/properties"
 RESOURCES_DIR="$BASE_DIR/resources"
@@ -232,8 +233,9 @@ echo >> "$CONNECTOR_PROPS"
 CONNECT_DOCKER_IMAGE='kcbq/connect'
 CONNECT_DOCKER_NAME='kcbq_test_connect'
 
-cp "$BASE_DIR"/../../bin/tar/kcbq-connector-*-confluent-dist.tar "$DOCKER_DIR/connect/kcbq.tar"
-cp "$BASE_DIR"/../../bin/tar/kcbq-connector-*-confluent-dist.tar "$DOCKER_DIR/connect/retriever.tar"
+# todo fixme
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*-SNAPSHOT.tar "$DOCKER_DIR/connect/kcbq.tar"
+cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kafka-connect-bigquery-*-SNAPSHOT.tar "$DOCKER_DIR/connect/retriever.tar"
 cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
 
 if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then


### PR DESCRIPTION
Fix tar creation in two ways:
1. previously tar creation took individual tars and squished them together. This resulted in some weirdness when individual projects would pull in two different versions of the same dependency, as the resulting overall tar would end up having those two different versions in it (rather than just one).
2. Pulling in debezium was resulting in a tar that used the latest kafka (2.0.0 at the moment). Add some gradle configuration to force kafka resolution to 1.1.1.

Fix readme and integration tests to use new tar build command/location.