### PR TITLE
Fix table-metadata related issues in GCS loading.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -225,7 +225,9 @@ public class GCSToBQLoadRunnable implements Runnable {
         // log a message.
         logger.warn("GCS to BQ load job failed", ex);
         // remove job from active jobs (it's not active anymore)
-        activeJobs.remove(job);
+        List<Blob> blobs = activeJobs.remove(job);
+        // unclaim blobs
+        claimedBlobs.removeAll(blobs);
         failureCount++;
       } finally {
         logger.info("GCS To BQ job tally: {} successful jobs, {} failed jobs.",
@@ -239,6 +241,7 @@ public class GCSToBQLoadRunnable implements Runnable {
    */
   private void deleteBlobs() {
     int deletedBlobs = 0;
+    logger.info("Attempting to delete {} blobs", deletableBlobs.size());
     for (Blob blob : deletableBlobs) {
       try {
         blob.delete();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -71,7 +71,7 @@ public class GCSToBQLoadRunnable implements Runnable {
 
   private static String SOURCE_URI_FORMAT = "gs://%s/%s";
   public static final Pattern METADATA_TABLE_PATTERN =
-          Pattern.compile("(?<project>[^:]+):(?<dataset>[^.]+).(?<table>.+)");
+          Pattern.compile("((?<project>[^:]+):)?(?<dataset>[^.]+)\\.(?<table>.+)");
 
   /**
    * Create a {@link GCSToBQLoadRunnable} with the given bigquery, bucket, and ms wait interval.
@@ -134,27 +134,32 @@ public class GCSToBQLoadRunnable implements Runnable {
    * @return the TableId this data should be loaded into, or null if we could not tell what
    *         table it should be loaded into.
    */
-  private TableId getTableFromBlob(Blob blob) {
+  public static TableId getTableFromBlob(Blob blob) {
     if (blob.getMetadata() == null
         || blob.getMetadata().get(GCSToBQWriter.GCS_METADATA_TABLE_KEY) == null) {
-      logger.error("Found blob {}\\{} with no metadata.", blob.getBucket(), blob.getName());
+      logger.error("Found blob {}/{} with no metadata.", blob.getBucket(), blob.getName());
       return null;
     }
 
     String serializedTableId = blob.getMetadata().get(GCSToBQWriter.GCS_METADATA_TABLE_KEY);
     Matcher matcher = METADATA_TABLE_PATTERN.matcher(serializedTableId);
+
+    if (!matcher.find()) {
+      logger.error("Found blob `{}/{}` with un-parsable table metadata.",
+          blob.getBucket(), blob.getName());
+      return null;
+    }
+
     String project = matcher.group("project");
     String dataset = matcher.group("dataset");
     String table = matcher.group("table");
     logger.debug("Table data: project: {}; dataset: {}; table: {}", project, dataset, table);
 
-    if (project == null || dataset == null || table == null) {
-      logger.error("Found blob `{}/{}` without parsable table metadata.",
-                   blob.getBucket(), blob.getName());
-      return null;
+    if (project == null) {
+      return TableId.of(dataset, table);
+    } else {
+      return TableId.of(project, dataset, table);
     }
-
-    return TableId.of(project, dataset, table);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnableTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnableTest.java
@@ -1,0 +1,97 @@
+package com.wepay.kafka.connect.bigquery;
+
+/*
+ * Copyright 2018 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.storage.Blob;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class GCSToBQLoadRunnableTest {
+
+  @Test
+  public void testGetTableFromBlobWithProject() {
+    final TableId expectedTableId = TableId.of("project", "dataset", "table");
+
+    Map<String, String> metadata =
+        Collections.singletonMap("sinkTable", serializeTableId(expectedTableId));
+    Blob mockBlob = createMockBlobWithTableMetadata(metadata);
+
+    TableId actualTableId = GCSToBQLoadRunnable.getTableFromBlob(mockBlob);
+    assertEquals(expectedTableId, actualTableId);
+  }
+
+  @Test
+  public void testGetTableFromBlobWithoutProject() {
+    final TableId expectedTableId = TableId.of("dataset", "table");
+
+    Map<String, String> metadata =
+        Collections.singletonMap("sinkTable", serializeTableId(expectedTableId));
+    Blob mockBlob = createMockBlobWithTableMetadata(metadata);
+
+    TableId actualTableId = GCSToBQLoadRunnable.getTableFromBlob(mockBlob);
+    assertEquals(expectedTableId, actualTableId);
+  }
+
+  @Test
+  public void testGetTableFromBlobWithoutMetadata() {
+    Blob mockBlob = mock(Blob.class);
+    Mockito.when(mockBlob.getMetadata()).thenReturn(null);
+
+    TableId tableId = GCSToBQLoadRunnable.getTableFromBlob(mockBlob);
+    assertNull(tableId);
+  }
+
+  @Test
+  public void testGetTableFromBlobWithBadMetadata() {
+    Map<String, String> metadata = Collections.singletonMap("sinkTable", "bar/baz");
+    Blob mockBlob = createMockBlobWithTableMetadata(metadata);
+
+    TableId tableId = GCSToBQLoadRunnable.getTableFromBlob(mockBlob);
+    assertNull(tableId);
+  }
+
+  private String serializeTableId(TableId tableId) {
+    final String project = tableId.getProject();
+    final String dataset = tableId.getDataset();
+    final String table = tableId.getTable();
+    StringBuilder sb = new StringBuilder();
+    if (project != null) {
+      sb.append(project).append(":");
+    }
+    return sb.append(dataset).append(".").append(table).toString();
+  }
+
+  private Blob createMockBlobWithTableMetadata(Map<String, String> metadata) {
+    Blob mockBlob = mock(Blob.class);
+    Mockito.when(mockBlob.getMetadata()).thenReturn(metadata);
+    return mockBlob;
+  }
+
+
+}


### PR DESCRIPTION
A tableId with a null project will no longer be written as a stringified "null" in the metadata. (Now that metadata will just not have any project information).
Fix GCSToBQLoadRunnable's handling of parsing that information.

Also add tests to GCSToBQLoadRunnable's getTableFromBlob method.