### PR TITLE
Integration tests now pass!

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ test/integrationtest.sh
 
 This assumes that the project, dataset, and key file have been specified by variable or 
 configuration file. For more information on how to specify these, run the test script with
-the `--usage` flag.
+the `--help` flag.
 
 > **NOTE:** You must have a recent version of [boot2docker], [Docker Machine], [Docker], etc.
 installed. Older versions will hang when cleaning containers, and linking doesn't work properly.

--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,7 @@ project('kcbq-confluent') {
         main {
             baseName = 'kcbq-confluent'
             contents {
-                from configurations.runtime
+                from configurations.runtime, jar
             }
         }
     }

--- a/kcbq-connector/test/docker/connect/Dockerfile
+++ b/kcbq-connector/test/docker/connect/Dockerfile
@@ -22,7 +22,7 @@
 #              --link kcbq_test_kafka:kafka --link kcbq_test_schema-registry:schema-registry \
 #              kcbq/connect
 
-FROM confluent/platform:3.0.0
+FROM confluentinc/cp-kafka-connect-base:4.1.2
 
 COPY connect-docker.sh /usr/local/bin/
 
@@ -31,8 +31,8 @@ RUN ["chmod", "+x", "/usr/local/bin/connect-docker.sh"]
 RUN ["mkdir", "/usr/logs"]
 RUN ["chmod", "a+rwx", "/usr/logs"]
 
-RUN ["mkdir", "/usr/share/java/kafka-connect-bigquery"]
-RUN ["chmod", "a+rwx", "/usr/share/java/kafka-connect-bigquery"]
+RUN ["mkdir", "-p", "/usr/local/share/kafka/plugins/kafka-connect-bigquery"]
+RUN ["chmod", "a+rwx", "/usr/local/share/kafka/plugins/kafka-connect-bigquery"]
 
-USER confluent
+USER root
 ENTRYPOINT ["/usr/local/bin/connect-docker.sh"]

--- a/kcbq-connector/test/docker/connect/connect-docker.sh
+++ b/kcbq-connector/test/docker/connect/connect-docker.sh
@@ -14,8 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-tar -C /usr/share/java/kafka-connect-bigquery/ -xf /usr/share/java/kafka-connect-bigquery/kcbq.tar
-tar -C /usr/share/java/kafka-connect-bigquery/ -xf /usr/share/java/kafka-connect-bigquery/retriever.tar
+tar -C /usr/local/share/kafka/plugins/kafka-connect-bigquery/ -xf /usr/local/share/kafka/plugins/kafka-connect-bigquery/kcbq.tar
 
 connect-standalone \
     /etc/kafka-connect-bigquery/standalone.properties \

--- a/kcbq-connector/test/docker/populate/Dockerfile
+++ b/kcbq-connector/test/docker/populate/Dockerfile
@@ -22,11 +22,11 @@
 #              --link kcbq_test_kafka:kafka --link kcbq_test_schema-registry:schema-registry \
 #              kcbq/populate
 
-FROM confluent/platform:3.0.0
+FROM confluentinc/cp-schema-registry:4.1.2
 
 COPY populate-docker.sh /usr/local/bin/
 
 RUN ["chmod", "+x", "/usr/local/bin/populate-docker.sh"]
 
-USER confluent
+USER root
 ENTRYPOINT ["/usr/local/bin/populate-docker.sh"]

--- a/kcbq-connector/test/docker/populate/populate-docker.sh
+++ b/kcbq-connector/test/docker/populate/populate-docker.sh
@@ -17,7 +17,7 @@
 for schema_dir in /tmp/schemas/*; do
   kafka-avro-console-producer \
       --topic "kcbq_test_`basename $schema_dir`" \
-      --broker-list 'kafka:9092' \
+      --broker-list 'kafka:29092' \
       --property value.schema="`cat \"$schema_dir/schema.json\"`" \
       --property schema.registry.url='http://schema-registry:8081' \
       < "$schema_dir/data.json"

--- a/kcbq-connector/test/resources/standalone-template.properties
+++ b/kcbq-connector/test/resources/standalone-template.properties
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-bootstrap.servers=kafka:9092
+bootstrap.servers=kafka:29092
 key.converter=io.confluent.connect.avro.AvroConverter
 key.converter.schema.registry.url=http://schema-registry:8081
 value.converter=io.confluent.connect.avro.AvroConverter
@@ -24,3 +24,4 @@ internal.key.converter.schemas.enable=false
 internal.value.converter.schemas.enable=false
 offset.storage.file.filename=/tmp/connect.offsets
 offset.flush.interval.ms=10000
+plugin.path=/usr/local/share/kafka/plugins


### PR DESCRIPTION
Couple of classes of changes here:
- integration tests have been upgraded to the confluent dependency versions implied by the normal build versions.
- rectify some minorly incorrect information regarding how to run the integration tests in the README
- fix jar creation! kcbq-confluent was the source of the jar and was including only its dependencies in the final jar, not itself. That's been fixed.