### PR TITLE
[ISSUE 149] Make underlying Schema Registry client configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ project.ext {
     googleCloudVersion = '0.47.0-alpha'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
-    ioConfluentVersion = '3.2.0'
+    ioConfluentVersion = '5.1.1'
     junitVersion = '4.12'
     kafkaVersion = '1.1.1'
     mockitoVersion = '1.10.19'

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -50,8 +50,13 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
   public void configure(Map<String, String> properties) {
     SchemaRegistrySchemaRetrieverConfig config =
         new SchemaRegistrySchemaRetrieverConfig(properties);
-    schemaRegistryClient =
-        new CachedSchemaRegistryClient(config.getString(config.LOCATION_CONFIG), 0);
+    Map<String, ?> schemaRegistryClientProperties =
+        config.originalsWithPrefix(config.SCHEMA_REGISTRY_CLIENT_PREFIX);
+    schemaRegistryClient = new CachedSchemaRegistryClient(
+        config.getString(config.LOCATION_CONFIG),
+        0,
+        schemaRegistryClientProperties
+    );
     avroData = new AvroData(config.getInt(config.AVRO_DATA_CACHE_SIZE_CONFIG));
   }
 

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverConfig.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverConfig.java
@@ -27,6 +27,11 @@ public class SchemaRegistrySchemaRetrieverConfig extends AbstractConfig {
   private static final String AVRO_DATA_CACHE_SIZE_DOC =
       "The size of the cache to use when converting schemas from Avro to Kafka Connect";
 
+  public static final String SCHEMA_REGISTRY_CLIENT_PREFIX = "schemaRegistryClient.";
+  private static final String SCHEMA_REGISTRY_CLIENT_PREFIX_DOC =
+      "Configurations beginning with this prefix will be passed on to the underlying Schema "
+          + "Registry client, with the prefix stripped.";
+
   static {
     config = new ConfigDef()
         .define(

--- a/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverConfigTest.java
+++ b/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverConfigTest.java
@@ -1,0 +1,38 @@
+package com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class SchemaRegistrySchemaRetrieverConfigTest {
+  
+  @Test
+  public void testClientPrefix() {
+    final Map<String, String> clientProperties = new HashMap<>();
+    final Map<String, String> allProperties = new HashMap<>();
+
+    clientProperties.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "SASL_INHERIT");
+    clientProperties.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, "foo:bar");
+
+    allProperties.put(SchemaRegistrySchemaRetrieverConfig.AVRO_DATA_CACHE_SIZE_CONFIG, "69");
+    allProperties.put(SchemaRegistrySchemaRetrieverConfig.LOCATION_CONFIG, "http://localhost:8083");
+    
+    for (Map.Entry<String, String> clientConfig : clientProperties.entrySet()) {
+      allProperties.put(
+          SchemaRegistrySchemaRetrieverConfig.SCHEMA_REGISTRY_CLIENT_PREFIX + clientConfig.getKey(),
+          clientConfig.getValue()
+      );
+    }
+    
+    SchemaRegistrySchemaRetrieverConfig config =
+        new SchemaRegistrySchemaRetrieverConfig(allProperties);
+    assertEquals(
+        clientProperties,
+        config.originalsWithPrefix(config.SCHEMA_REGISTRY_CLIENT_PREFIX)
+    );
+  }
+}


### PR DESCRIPTION
Attempts to address https://github.com/wepay/kafka-connect-bigquery/issues/149

NOTE: This has not been tested

@Riduidel could you take a look and see if this is an option? Using the source branch for this PR, you can now configure the underlying client used by the `SchemaRegistrySchemaRetriever` directly, using something like:
```properties
schemaRegistryClient.basic.auth.credentials.source=SASL_INHERIT
schemaRegistryClient.basic.auth.info=username:password
```

The configs currently supported by the client can be found [here](https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java).

@criccomini @mtagle saw the issue this morning, decided to sketch this out. Don't have time to test it but it's probably a start in the right direction if you guys are interested in adding this kind of security support to the `SchemaRegistrySchemaRetriever`.