### PR TITLE
Support passing GCP credentials as JSON in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,22 @@ project=
 # The name of the BigQuery dataset to write to (leave the '.*=' at the beginning, enter your
 # dataset after it)
 datasets=.*=
-# The location of a BigQuery service account JSON key file
+# The location of a GCP service account credentials file or a user credentials file in JSON format
 keyfile=
+# GCP service account credentials or user credentials in JSON format (non-escaped JSON blob)
+credentials=
 ```
 
 You'll need to choose a BigQuery project to write to, a dataset from that project to write to, and
-provide the location of a JSON key file that can be used to access a BigQuery service account that
-can write to the project/dataset pair. Once you've decided on these properties, fill them in and
-save the properties file.
+provide GCP credentials that can be used to access a BigQuery service account that can write
+to the project/dataset pair. This can be done in two ways:
+- by providing the name of a key file using `keyfile` parameter; or
+- by providing the credentials explicitly as a JSON string (a non-escaped JSON blob) using
+`credentials` parameter.
+
+When specified, `credentials` has priority over `keyfile`.
+
+Once you've decided on these properties, fill them in and save the properties file.
 
 Once you get more familiar with the connector, you might want to revisit the `connector.properties`
 file and experiment with tweaking its settings.
@@ -139,11 +147,13 @@ Integration tests run by creating [Docker] instances for [Zookeeper], [Kafka], [
 and the BigQuery Connector itself, then verifying the results using a [JUnit] test.
 
 They use schemas and data that can be found in the `test/docker/populate/test_schemas/` directory, 
-and rely on a user-provided JSON key file (like in the `quickstart` example) to access BigQuery.
+and rely on a user-provided JSON key file (like in the `quickstart` example) or explicit JSON
+credentials to access BigQuery.
 
-The project and dataset they write to, as well as the specific JSON key file they use, can be
-specified by command-line flag, environment variable, or configuration file — the exact details of
-each can be found by running the integration test script with the `-?` flag.
+The project and dataset they write to, as well as the specific JSON key file or JSON credentials
+string they use, can be specified by command-line flag, environment variable,
+or configuration file — the exact details of each can be found by running the integration
+test script with the `-?` flag.
 
 ### Data Corruption Concerns
 

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ project(':kcbq-connector') {
         main = 'com.wepay.kafka.connect.bigquery.it.utils.TableClearer'
         classpath = sourceSets.integrationTest.runtimeClasspath
         args findProperty('kcbq_test_keyfile') ?: ''
+        args findProperty('kcbq_test_credentials') ?: ''
         args findProperty('kcbq_test_project') ?: ''
         args findProperty('kcbq_test_dataset') ?: ''
         if (findProperty('kcbq_test_tables') != null)
@@ -160,6 +161,7 @@ project(':kcbq-connector') {
         main = 'com.wepay.kafka.connect.bigquery.it.utils.BucketClearer'
         classpath = sourceSets.integrationTest.runtimeClasspath
         args findProperty('kcbq_test_keyfile') ?: ''
+        args findProperty('kcbq_test_credentials') ?: ''
         args findProperty('kcbq_test_project') ?: ''
         args findProperty('kcbq_test_bucket') ?: ''
     }

--- a/kcbq-connector/quickstart/properties/connector.properties
+++ b/kcbq-connector/quickstart/properties/connector.properties
@@ -36,5 +36,7 @@ project=
 # The name of the BigQuery dataset to write to (leave the '.*=' at the beginning, enter your
 # dataset after it)
 datasets=.*=
-# The location of a BigQuery service account JSON key file
+# The location of a GCP service account credentials file or a user credentials file in JSON format
 keyfile=
+# GCP service account credentials or user credentials in JSON format (non-escaped JSON blob)
+credentials=

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQueryHelper.java
@@ -43,28 +43,21 @@ public class BigQueryHelper {
    * from specific datasets.
    *
    * @param projectName The name of the BigQuery project to work with
-   * @param keyFilename The name of a file containing a JSON key that can be used to provide
-   *                    credentials to BigQuery, or null if no authentication should be performed.
+   * @param credentials BigQuery credentials, or null if no authentication should be performed.
    * @return The resulting BigQuery object.
    */
-  public BigQuery connect(String projectName, String keyFilename) {
-    if (keyFilename == null) {
+  public BigQuery connect(String projectName, GoogleCredentials credentials) {
+    if (credentials == null) {
       return connect(projectName);
     }
 
-    logger.debug("Attempting to open file {} for service account json key", keyFilename);
-    try (InputStream credentialsStream = new FileInputStream(keyFilename)) {
-      logger.debug("Attempting to authenticate with BigQuery using provided json key");
-      return new
-          BigQueryOptions.DefaultBigQueryFactory().create(
-          BigQueryOptions.newBuilder()
-          .setProjectId(projectName)
-          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
-          .build()
-      );
-    } catch (IOException err) {
-      throw new BigQueryConnectException("Failed to access json key file", err);
-    }
+    logger.debug("Attempting to authenticate with BigQuery using provided credentials");
+    return new BigQueryOptions.DefaultBigQueryFactory().create(
+        BigQueryOptions.newBuilder()
+        .setProjectId(projectName)
+        .setCredentials(credentials)
+        .build()
+    );
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.TableId;
 
@@ -91,8 +92,8 @@ public class BigQuerySinkConnector extends SinkConnector {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new BigQueryHelper().connect(projectName, keyFilename);
+    GoogleCredentials credentials = config.getCredentials();
+    return new BigQueryHelper().connect(projectName, credentials);
   }
 
   private SchemaManager getSchemaManager(BigQuery bigQuery) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.TableId;
@@ -223,8 +224,8 @@ public class BigQuerySinkTask extends SinkTask {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new BigQueryHelper().connect(projectName, keyFilename);
+    GoogleCredentials credentials = config.getCredentials();
+    return new BigQueryHelper().connect(projectName, credentials);
   }
 
   private SchemaManager getSchemaManager(BigQuery bigQuery) {
@@ -254,8 +255,8 @@ public class BigQuerySinkTask extends SinkTask {
       return testGcs;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFilename = config.getString(config.KEYFILE_CONFIG);
-    return new GCSBuilder(projectName).setKeyFileName(keyFilename).build();
+    GoogleCredentials credentials = config.getCredentials();
+    return new GCSBuilder(projectName).setCredentials(credentials).build();
   }
 
   private GCSToBQWriter getGcsWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GoogleCredentialsReader.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GoogleCredentialsReader.java
@@ -1,0 +1,51 @@
+package com.wepay.kafka.connect.bigquery;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Reads Google credentials from different sources.
+ */
+public class GoogleCredentialsReader {
+    private static final Logger logger = LoggerFactory.getLogger(GoogleCredentialsReader.class);
+
+    /**
+     * Returns {@link GoogleCredentials} defined by a service account credentials file or
+     * user credentials file in JSON format.
+     * @param filename the name of the file.
+     * @return the credential defined by the file.
+     * @throws BigQueryConnectException if the credential cannot be created from the file.
+     */
+    public static GoogleCredentials fromJsonFile(String filename) {
+        logger.debug("Attempting to open credentials file {}", filename);
+        try (InputStream stream = new FileInputStream(filename)) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (IOException err) {
+            throw new BigQueryConnectException("Failed to read credentials from file", err);
+        }
+    }
+
+    /**
+     * Returns {@link GoogleCredentials} defined by a service account credentials or
+     * user credentials in JSON format.
+     * @param jsonString the string with the credentials.
+     * @return the credential defined by the JSON string.
+     * @throws BigQueryConnectException if the credential cannot be created from the string.
+     */
+    public static GoogleCredentials fromJsonString(String jsonString) {
+        try (InputStream stream = new ByteArrayInputStream(
+            jsonString.getBytes(StandardCharsets.UTF_8))) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (IOException err) {
+            throw new BigQueryConnectException("Failed to read credentials from JSON string", err);
+        }
+    }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -63,6 +63,7 @@ public class SinkPropertiesFactory {
     config.getList(config.DATASETS_CONFIG);
 
     config.getString(config.KEYFILE_CONFIG);
+    config.getString(config.CREDENTIALS_CONFIG);
     config.getString(config.PROJECT_CONFIG);
 
     config.getBoolean(config.SANITIZE_TOPICS_CONFIG);


### PR DESCRIPTION
Support passing the GCP credentials via the configuration directive `credentials` as a non-escaped JSON blob.

This helps to run the Kafka connector when the environment can't be manipulated.

Changes:
- `credentials` configuration keys added. It has the priority over `keyfile` when provided.
- `GoogleCredentials` objects are now provided by `BigQuerySinkConfig.getCredentials`, which handles both `keyfile` and `credentials` configuration keys.
- The ability to use explicit JSON credentials added to the integration test suite:
  - support of `-c|--credentials` CLI parameter, `KCBQ_TEST_CREDENTIALS` environment variable, and `credentials` configuration key in `integrationtest.sh`; using them in all relevant pieces of config;
  - support of `kcbq_test_credentials` in `integrationTestPrep` Gradle task and passing it to `BucketClearer` and `TableClearer`.
- `README.md` updated.
