### PR TITLE
Await termination on correct executor

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -330,7 +330,7 @@ public class BigQuerySinkTask extends SinkTask {
         try {
           logger.info("Attempting to shut down GCS Load Executor.");
           gcsLoadExecutor.shutdown();
-          executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
+          gcsLoadExecutor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
           logger.warn("Could not shut down GCS Load Executor within {}s.",
                       EXECUTOR_SHUTDOWN_TIMEOUT_SEC);


### PR DESCRIPTION
We had problems with duplicate messages when restarting the task, so we think this is at least part of the problem. 