### PR TITLE
Prevent context update after/while rebalancing

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -123,19 +123,8 @@ public class BigQuerySinkTask extends SinkTask {
     } catch (InterruptedException err) {
       throw new ConnectException("Interrupted while waiting for write tasks to complete.", err);
     }
-    updateOffsets(offsets);
 
     topicPartitionManager.resumeAll();
-  }
-
-  /**
-   * This really doesn't do much and I'm not totally clear on whether or not I need it.
-   * But, in the interest of maintaining old functionality, here we are.
-   */
-  private void updateOffsets(Map<TopicPartition, OffsetAndMetadata> offsets) {
-    for (Map.Entry<TopicPartition, OffsetAndMetadata> offsetEntry : offsets.entrySet()) {
-      context.offset(offsetEntry.getKey(), offsetEntry.getValue().offset());
-    }
   }
 
   private PartitionedTableId getRecordTable(SinkRecord record) {


### PR DESCRIPTION
Hi,

This method leads to the context being updated with previously assigned partitions, and to a fatal error of trying to seek to a "no longer assigned partition".

Reproduction can be done by submitting a BQ connector with one task, and update that same connector to use 5 tasks for instance. 

It really often ends up with the first created task to fail with that exception : 

```
[2019-06-05 10:19:20,150] ERROR WorkerSinkTask{id=mybigquery--0} Task threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerTask:177)
java.lang.IllegalStateException: No current assignment for partition mypartition-0
	at org.apache.kafka.clients.consumer.internals.SubscriptionState.assignedState(SubscriptionState.java:259)
	at org.apache.kafka.clients.consumer.internals.SubscriptionState.seek(SubscriptionState.java:264)
	at org.apache.kafka.clients.consumer.KafkaConsumer.seek(KafkaConsumer.java:1501)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.rewind(WorkerSinkTask.java:601)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.access$1200(WorkerSinkTask.java:70)
	at org.apache.kafka.connect.runtime.WorkerSinkTask$HandleRebalance.onPartitionsAssigned(WorkerSinkTask.java:675)
	at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.onJoinComplete(ConsumerCoordinator.java:291)
```

I was able to load in BigQuery millions of records with that fix, while killing the connector, adding and removing tasks while still not loose any records.

Could you please double check that behavior and merge that PR ?

Have a good day

Nicolas

