### PR TITLE
Add prefix/folder related configuration.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -177,7 +177,7 @@ public class BigQuerySinkTask extends SinkTask {
           if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String gcsBlobName = record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
             String gcsFolderName = config.getString(config.GCS_FOLDER_NAME_CONFIG);
-            if (!gcsFolderName.equals("")) {
+            if (!"".equals(gcsFolderName)) {
               gcsBlobName = gcsFolderName + "/" + gcsBlobName;
             }
             tableWriterBuilder = new GCSBatchTableWriter.Builder(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -175,7 +175,7 @@ public class BigQuerySinkTask extends SinkTask {
         if (!tableWriterBuilders.containsKey(table)) {
           TableWriterBuilder tableWriterBuilder;
           if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
-            String gcsBlobName = record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
+            String gcsBlobName = config.getString(config.GCS_FOLDER_NAME_CONFIG) + "/" + record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
             tableWriterBuilder = new GCSBatchTableWriter.Builder(
                 gcsToBQWriter,
                 table.getBaseTableId(),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -177,7 +177,7 @@ public class BigQuerySinkTask extends SinkTask {
           if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String gcsBlobName = record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
             String gcsFolderName = config.getString(config.GCS_FOLDER_NAME_CONFIG);
-            if (!"".equals(gcsFolderName)) {
+            if (gcsFolderName != null && !"".equals(gcsFolderName)) {
               gcsBlobName = gcsFolderName + "/" + gcsBlobName;
             }
             tableWriterBuilder = new GCSBatchTableWriter.Builder(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -175,7 +175,11 @@ public class BigQuerySinkTask extends SinkTask {
         if (!tableWriterBuilders.containsKey(table)) {
           TableWriterBuilder tableWriterBuilder;
           if (config.getList(config.ENABLE_BATCH_CONFIG).contains(record.topic())) {
-            String gcsBlobName = config.getString(config.GCS_FOLDER_NAME_CONFIG) + "/" + record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
+            String gcsBlobName = record.topic() + "_" + uuid + "_" + Instant.now().toEpochMilli();
+            String gcsFolderName = config.getString(config.GCS_FOLDER_NAME_CONFIG);
+            if (!gcsFolderName.equals("")) {
+              gcsBlobName = gcsFolderName + "/" + gcsBlobName;
+            }
             tableWriterBuilder = new GCSBatchTableWriter.Builder(
                 gcsToBQWriter,
                 table.getBaseTableId(),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -84,6 +84,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "The name of the bucket in which gcs blobs used to batch load to BigQuery "
       + "should be located. Only relevant if enableBatchLoad is configured.";
 
+  public static final String GCS_FOLDER_NAME_CONFIG =                     "gcsFolderName";
+  private static final ConfigDef.Type GCS_FOLDER_NAME_TYPE =              ConfigDef.Type.STRING;
+  private static final Object GCS_FOLDER_NAME_DEFAULT =                   "";
+  private static final ConfigDef.Importance GCS_FOLDER_NAME_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
+  private static final String GCS_FOLDER_NAME_DOC =
+          "The name of the folder under the bucket in which gcs blobs used to batch load to BigQuery "
+                  + "should be located. Only relevant if enableBatchLoad is configured.";
+
   public static final String TOPICS_TO_TABLES_CONFIG =                     "topicsToTables";
   private static final ConfigDef.Type TOPICS_TO_TABLES_TYPE =              ConfigDef.Type.LIST;
   private static final ConfigDef.Importance TOPICS_TO_TABLES_IMPORTANCE =
@@ -195,6 +203,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             GCS_BUCKET_NAME_DEFAULT,
             GCS_BUCKET_NAME_IMPORTANCE,
             GCS_BUCKET_NAME_DOC
+        ).define(
+            GCS_FOLDER_NAME_CONFIG,
+            GCS_FOLDER_NAME_TYPE,
+            GCS_FOLDER_NAME_DEFAULT,
+            GCS_FOLDER_NAME_IMPORTANCE,
+            GCS_FOLDER_NAME_DOC
         ).define(
             TOPICS_TO_TABLES_CONFIG,
             TOPICS_TO_TABLES_TYPE,

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -37,10 +37,11 @@ usage() {
        "[-p|--project <BigQuery project>]\n" \
        "[-d|--dataset <BigQuery project>]\n" \
        "[-b|--bucket <cloud Storage bucket>\n]" \
+       "[-f|--folder <cloud Storage folder under bucket>\n]" \
        1>&2
   echo 1>&2
   echo "Options can also be specified via environment variable:" \
-       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, and KCBQ_TEST_BUCKET" \
+       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, KCBQ_TEST_BUCKET, and KCBQ_TEST_FOLDER" \
        "respectively control the keyfile, project, dataset, and bucket." \
        1>&2
   echo 1>&2
@@ -100,6 +101,7 @@ KCBQ_TEST_KEYFILE=${KCBQ_TEST_KEYFILE:-$keyfile}
 KCBQ_TEST_PROJECT=${KCBQ_TEST_PROJECT:-$project}
 KCBQ_TEST_DATASET=${KCBQ_TEST_DATASET:-$dataset}
 KCBQ_TEST_BUCKET=${KCBQ_TEST_BUCKET:-$bucket}
+KCBQ_TEST_FOLDER=${KCBQ_TEST_FOLDER:-$folder}
 
 # Capture any command line flags
 while [[ $# -gt 0 ]]; do
@@ -123,6 +125,11 @@ while [[ $# -gt 0 ]]; do
         [[ -z "$2" ]] && { error "bucket name must follow $1 flag"; usage 1; }
         shift
         KCBQ_TEST_BUCKET="$1"
+        ;;
+    -b|--folder)
+        [[ -z "$2" ]] && { error "folder name must follow $1 flag"; usage 1; }
+        shift
+        KCBQ_TEST_FOLDER="$1"
         ;;
     -h|--help|'-?')
         usage 0
@@ -243,6 +250,8 @@ echo "datasets=.*=$KCBQ_TEST_DATASET" >> "$CONNECTOR_PROPS"
 
 echo "gcsBucketName=$KCBQ_TEST_BUCKET" >> "$CONNECTOR_PROPS"
 
+echo "gcsFolderName=$KCBQ_TEST_FOLDER" >> "$CONNECTOR_PROPS"
+
 echo -n 'topics=' >> "$CONNECTOR_PROPS"
 basename "$BASE_DIR"/resources/test_schemas/* \
   | sed -E 's/^(.*)$/kcbq_test_\1/' \
@@ -280,5 +289,6 @@ echo "keyfile=$KCBQ_TEST_KEYFILE" > "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "project=$KCBQ_TEST_PROJECT" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "dataset=$KCBQ_TEST_DATASET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 echo "bucket=$KCBQ_TEST_BUCKET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
+echo "folder=$KCBQ_TEST_FOLDER" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
 
 "$GRADLEW" -p "$BASE_DIR/.." cleanIntegrationTest integrationTest


### PR DESCRIPTION
Add the prefix/folder configuration so that records from different connectors will be saved in different folders under the common GCS bucket.