### PR TITLE
Put git hash in non-release version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,19 @@ $ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kcbq-
 ### Setting up smudge filter
 Rather than hand editing gradle.properties to change the version, it is relatively simple to
 set up a smudge filter which will automagically insert a version based on git tags.  To do so,
-add the following line to .gitattributes:
+run the following line:
 
-gradle.properties filter=id
-
-Then, create smudge and clean filters by executing:
-
+```bash
+gradle.properties filter=id > .gitattributes
 git config filter.id.clean 'git show HEAD:./gradle.properties'
 git config filter.id.smudge 'awk '"'"'$1 == "version" { "git describe --tags" | getline version; $2 = version; } 1'"'"' FS== OFS=='
+```
 
-or by adding the following stanza to .git/config
-[filter "id"]
-	clean = git show HEAD:./gradle.properties
-	smudge = "awk '$1 == \"version\" { \"git describe --tags\" | getline version; $2 = version; } 1' FS== OFS=="
-
-Note that using smudge filters is a terrible kludge, and the clean filter described above will make
-it difficult to commit changes to gradle.properties.
-
+After doing that, you can auto update the version with:
+```bash
+rm gradle.properties
+git checkout HEAD gradle.properties
+```
 
 ### Setting-Up Background Processes
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ gradle.properties filter=id
 Then, create smudge and clean filters by executing:
 
 git config filter.id.clean 'git show HEAD:./gradle.properties'
-git config filter.id.smudge 'awk '"'"'$1 == "version" { "git describe --tags --dirty" | getline version; $2 = version; } 1'"'"' FS== OFS=='
+git config filter.id.smudge 'awk '"'"'$1 == "version" { "git describe --tags" | getline version; $2 = version; } 1'"'"' FS== OFS=='
 
 or by adding the following stanza to .git/config
 [filter "id"]
 	clean = git show HEAD:./gradle.properties
-	smudge = "awk '$1 == \"version\" { \"git describe --tags --dirty\" | getline version; $2 = version; } 1' FS== OFS=="
+	smudge = "awk '$1 == \"version\" { \"git describe --tags\" | getline version; $2 = version; } 1' FS== OFS=="
 
 Note that using smudge filters is a terrible kludge, and the clean filter described above will make
 it difficult to commit changes to gradle.properties.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ run the following commands:
 ```bash
 gradle.properties filter=id > .gitattributes
 git config filter.id.clean 'git show HEAD:./gradle.properties'
-git config filter.id.smudge 'awk '"'"'$1 == "version" { "git describe --tags" | getline version; $2 = version; } 1'"'"' FS== OFS=='
+git config filter.id.smudge "awk '"'$1 == "version" { "git describe --tags" | getline $2 } 1'"' FS== OFS=="
 ```
 
 After doing that, you can auto update the version with:

--- a/README.md
+++ b/README.md
@@ -67,13 +67,12 @@ run the following commands:
 echo gradle.properties filter=id > .gitattributes
 git config filter.id.clean 'git show HEAD:./gradle.properties'
 git config filter.id.smudge "awk '"'$1 == "version" { "git describe --tags" | getline $2 } 1'"' FS== OFS=="
+echo '#!/bin/sh' > .git/hooks/post-commit
+echo 'rm gradle.properties; git checkout HEAD gradle.properties' >> .git/hooks/post-commit
+chmod +x .git/hooks/post-commit
 ```
 
-After doing that, you can auto update the version with:
-```bash
-rm gradle.properties
-git checkout HEAD gradle.properties
-```
+After doing that, you can auto update the version by running the post-commit hook, or by making a commit.
 
 ### Setting-Up Background Processes
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kcbq-
 ### Setting up smudge filter
 Rather than hand editing gradle.properties to change the version, it is relatively simple to
 set up a smudge filter which will automagically insert a version based on git tags.  To do so,
-run the following line:
+run the following commands:
 
 ```bash
 gradle.properties filter=id > .gitattributes

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ set up a smudge filter which will automagically insert a version based on git ta
 run the following commands:
 
 ```bash
-gradle.properties filter=id > .gitattributes
+echo gradle.properties filter=id > .gitattributes
 git config filter.id.clean 'git show HEAD:./gradle.properties'
 git config filter.id.smudge "awk '"'$1 == "version" { "git describe --tags" | getline $2 } 1'"' FS== OFS=="
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ save the properties file.
 
 Once you get more familiar with the connector, you might want to revisit the `connector.properties`
 file and experiment with tweaking its settings.
-   
+
 ### Building and Extracting a Tarball
 
 If you haven't already, move into the repository's top-level directory:
@@ -57,6 +57,27 @@ And then extract its contents:
 ```bash
 $ mkdir bin/jar/ && tar -C bin/jar/ -xf kcbq-confluent/build/distributions/kcbq-confluent-*.tar
 ```
+
+### Setting up smudge filter
+Rather than hand editing gradle.properties to change the version, it is relatively simple to
+set up a smudge filter which will automagically insert a version based on git tags.  To do so,
+add the following line to .gitattributes:
+
+gradle.properties filter=id
+
+Then, create smudge and clean filters by executing:
+
+git config filter.id.clean 'git show HEAD:./gradle.properties'
+git config filter.id.smudge 'awk '"'"'$1 == "version" { "git describe --tags --dirty" | getline version; $2 = version; } 1'"'"' FS== OFS=='
+
+or by adding the following stanza to .git/config
+[filter "id"]
+	clean = git show HEAD:./gradle.properties
+	smudge = "awk '$1 == \"version\" { \"git describe --tags --dirty\" | getline version; $2 = version; } 1' FS== OFS=="
+
+Note that using smudge filters is a terrible kludge, and the clean filter described above will make
+it difficult to commit changes to gradle.properties.
+
 
 ### Setting-Up Background Processes
 


### PR DESCRIPTION
This commit will use git tags to generate version numbers in gradle.properties.  The current release method requires hand editing gradle.properties, and encourages building multiple distinct versions all with the name x.x.x-SNAPSHOT.  With this change, a git hash will be used instead of the static string SNAPSHOT, making it possible to determine the source of the build.   Until a tag is made on the mainline, this will cause ./gradlew to fail