### PR TITLE
Refactor integration test

### DIFF
--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -94,8 +94,9 @@ init() {
 }
 
 parse_args() {
+	folder=kcbq-test  # assign default
 	# Process command line
-	while [[ $# -gt 0 ]]; do
+	while test $# -gt 0; do
 		case "$1" in
 		-k) keyfile="$2"; shift ;;
 		-p) project="$2"; shift ;;
@@ -107,7 +108,8 @@ parse_args() {
 		project=*) project=${1#project=};;
 		dataset=*) dataset=${1#dataset=};;
 		bucket=*) bucket=${1#bucket=};;
-		*) error "unrecognized option: '$1'" ;;
+		folder=*) folder=${1#folder-};;
+		*) error "unrecognized argument: '$1'" ;;
 		esac
 		shift
 	done

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -17,285 +17,260 @@
 ####################################################################################################
 # Basic script setup
 
-set -e
-
-if [[ -t 1 ]]; then
-  KCBQ_TEST_COLORS='true'
-else
-  KCBQ_TEST_COLORS='false'
-fi
-
-NORMAL='\033[0m'
-BOLD='\033[1m'
-RED='\033[1;31m'
-GREEN='\033[1;32m'
-YELLOW='\033[1;33m'
-
 usage() {
-  echo -e "usage: $0\n" \
-       "[-k|--key-file <JSON key file>] (path must be absolute; relative paths will not work)\n" \
-       "[-p|--project <BigQuery project>]\n" \
-       "[-d|--dataset <BigQuery project>]\n" \
-       "[-b|--bucket <cloud Storage bucket>\n]" \
-       "[-f|--folder <cloud Storage folder under bucket>\n]" \
-       1>&2
-  echo 1>&2
-  echo "Options can also be specified via environment variable:" \
-       "KCBQ_TEST_KEYFILE, KCBQ_TEST_PROJECT, KCBQ_TEST_DATASET, KCBQ_TEST_BUCKET, and KCBQ_TEST_FOLDER" \
-       "respectively control the keyfile, project, dataset, and bucket." \
-       1>&2
-  echo 1>&2
-  echo "Options can also be specified in a file named 'test.conf'" \
-       "placed in the same directory as this script, with a series of <property>=<value> lines." \
-       "The properties are 'keyfile', 'project', 'dataset', and 'bucket'." \
-       1>&2
-  echo 1>&2
-  echo "The descending order of priority for each of these forms of specification is:" \
-       "command line option, environment variable, configuration file." \
-       1>&2
-  # Accept an optional exit value parameter
-  exit ${1:-0}
+	cat <<- EOF
+	usage: $(basename $0) <properties>
+	 [-k|--key-file <JSON key file>]
+	 [-p|--project <BigQuery project>]
+	 [-d|--dataset <BigQuery project>]
+	 [-b|--bucket <cloud Storage bucket>
+	 [-f|--folder <cloud Storage folder under bucket>
+
+	properties must include keyfile, BigQuery dataset name, and a gcloud Storage bucket.
+	The keyfile should be a json formatted key for an account that has access to
+	the storage bucket and the dataset.  If a BigQuery project is not specified,
+	it will be taken from the project_id field of the keyfile.  Properties
+	may be specified either as arguments to flags or as key-value pairs.  For example:
+	$(basename $0) -k keyfile.json -p project-name -d dataset-name -b bucket-name
+	- or -
+	$(basename $0) keyfile=key.json project=project-name -d dataset-name -b bucket-name
+
+	Properties can also be specified via environment variable.  eg:
+	keyfile=key.json project=project-name $(basename $0) -d dataset-name -b bucket-name
+
+	Properties can also be specified in a file named 'test.conf'
+	placed in the same directory as this script, with a series of <property>=<value> lines.
+	The properties are 'keyfile', 'project', 'dataset', and 'bucket'.
+
+	The descending order of priority for each of these forms of specification is:
+	command line argument, configuration file, environment variable.
+	EOF
 }
 
-error() {
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$RED" 1>&2
-  echo -ne "$0: $@" 1>&2
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$NORMAL"
-  echo
+color() {
+	test -t 1 || return
+	case $1 in
+	normal) tput sgr0;;
+	bold)   tput bold;;
+	red)    tput setaf 1;;
+	green)  tput setaf 2;;
+	yellow) tput setaf 3;;
+	esac
 }
 
-warn() {
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$YELLOW" 1>&2
-  echo -ne "$0: $@" 1>&2
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$NORMAL"
-  echo
+msg() {
+	color $1
+	shift
+	printf "%s: %s\n" "$(basename $0)" "$*"
+	color normal
 }
 
-statusupdate() {
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$GREEN"
-  echo -ne "$0: $@"
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$NORMAL"
-  echo
+error() { msg red "$@"; exit 1; } >&2
+warn() {  msg yellow "$@"; } >&2
+statusupdate() { msg green "$@"; }
+log() { msg bold "$@"; }
+
+init() {
+	# Initialize global variables, and do some cleanup
+	BASE_DIR=$(dirname "$0")
+	GRADLEW="$BASE_DIR/../../gradlew"
+
+	# Read in properties file, if it exists and can be read
+	. "$BASE_DIR/test.conf" 2> /dev/null
+
+	# Supply -r to xargs if supported.  (This suppresses running the command
+	# if there is no input for gnu xargs, avoiding many error messages from
+	# dockercleanup, etc.)
+	if echo | xargs --no-run-if-empty; then
+		xargs() { command xargs --no-run-if-empty "$@"; }
+	else
+		xargs() { command xargs "$@"; }
+	fi 2> /dev/null
+
+	DOCKER_DIR="$BASE_DIR/docker"
+	zk_docker_name='kcbq_test_zookeeper'
+	kafka_docker_name='kcbq_test_kafka'
+	schema_registry_docker_name='kcbq_test_schema-registry'
 }
 
-log() {
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$BOLD"
-  echo -ne "$0: $@"
-  [[ "$KCBQ_TEST_COLORS" = "true" ]] && echo -ne "$NORMAL"
-  echo
+parse_args() {
+	# Process command line
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-k) keyfile="$2"; shift ;;
+		-p) project="$2"; shift ;;
+		-d) dataset="$2"; shift ;;
+		-b) bucket="$2"; shift ;;
+		-f) folder="$2"; shift ;;
+		-h|--help|'-?') usage ;;
+		keyfile=*) keyfile=${1#keyfile=};;
+		project=*) project=${1#project=};;
+		dataset=*) dataset=${1#dataset=};;
+		bucket=*) bucket=${1#bucket=};;
+		*) error "unrecognized option: '$1'" ;;
+		esac
+		shift
+	done
+
+	# Make sure required arguments have been provided one way or another
+	[[ -z "$keyfile" ]] && error 'a key filename is required (specify with -k)'
+	# If unset, extract project name from the key file
+	: ${project:=$( jq -r .project_id $keyfile 2> /dev/null )}
+	[[ -z "$project" ]] && error 'a project name is required (specify with -p)'
+	[[ -z "$dataset" ]] && error 'a dataset name is required (specify with -d)'
+	[[ -z "$bucket" ]] && error 'a bucket name is required (specify with -b)'
+
+	keyfile=$(realpath $keyfile)
 }
-
-BASE_DIR=$(dirname "$0")
-GRADLEW="$BASE_DIR/../../gradlew"
-
-####################################################################################################
-# Configuration processing
-
-# Read in properties file, if it exists and can be read
-PROPERTIES_FILE="$BASE_DIR/test.conf"
-[[ -f "$PROPERTIES_FILE" ]] && [[ -r "$PROPERTIES_FILE" ]] && source "$PROPERTIES_FILE"
-
-# Copy the file's properties into actual test variables,
-# without overriding any that have already been specified
-KCBQ_TEST_KEYFILE=${KCBQ_TEST_KEYFILE:-$keyfile}
-KCBQ_TEST_PROJECT=${KCBQ_TEST_PROJECT:-$project}
-KCBQ_TEST_DATASET=${KCBQ_TEST_DATASET:-$dataset}
-KCBQ_TEST_BUCKET=${KCBQ_TEST_BUCKET:-$bucket}
-KCBQ_TEST_FOLDER=${KCBQ_TEST_FOLDER:-$folder}
-
-# Capture any command line flags
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -k|--key-file)
-        [[ -z "$2" ]] && { error "key filename must follow $1 flag"; usage 1; }
-        shift
-        KCBQ_TEST_KEYFILE="$1"
-        ;;
-    -p|--project)
-        [[ -z "$2" ]] && { error "project name must follow $1 flag"; usage 1; }
-        shift
-        KCBQ_TEST_PROJECT="$1"
-        ;;
-    -d|--dataset)
-        [[ -z "$2" ]] && { error "dataset name must follow $1 flag"; usage 1; }
-        shift
-        KCBQ_TEST_DATASET="$1"
-        ;;
-    -b|--bucket)
-        [[ -z "$2" ]] && { error "bucket name must follow $1 flag"; usage 1; }
-        shift
-        KCBQ_TEST_BUCKET="$1"
-        ;;
-    -b|--folder)
-        [[ -z "$2" ]] && { error "folder name must follow $1 flag"; usage 1; }
-        shift
-        KCBQ_TEST_FOLDER="$1"
-        ;;
-    -h|--help|'-?')
-        usage 0
-        ;;
-    *)
-        error "unrecognized option: '$1'"; usage 1
-        ;;
-  esac
-  shift
-done
-
-# Make sure required arguments have been provided one way or another
-[[ -z "$KCBQ_TEST_KEYFILE" ]] && { error 'a key filename is required'; usage 1; }
-[[ -z "$KCBQ_TEST_PROJECT" ]] && { error 'a project name is required'; usage 1; }
-[[ -z "$KCBQ_TEST_DATASET" ]] && { error 'a dataset name is required'; usage 1; }
-[[ -z "$KCBQ_TEST_BUCKET" ]] && { error 'a bucket name is required'; usage 1; }
-
-####################################################################################################
-# Schema Registry Docker initialization
-
-if echo | xargs --no-run-if-empty; then
-        xargs() { command xargs --no-run-if-empty "$@"; }
-else
-        xargs() { command xargs "$@"; }
-fi 2> /dev/null
-
 
 dockercleanup() {
-  log 'Cleaning up leftover Docker containers'
-  docker ps -aq -f 'name=kcbq_test_(zookeeper|kafka|schema-registry|populate|connect)' \
-  | xargs docker rm -f > /dev/null
+	log 'Cleaning up Docker containers'
+	docker ps -aq -f 'name=kcbq_test_(zookeeper|kafka|schema-registry|populate|connect)' \
+	| xargs docker rm -f > /dev/null
 }
 
 dockerimageexists() {
-  docker images --format '{{ .Repository }}' | grep -q "$1"
+	docker images --format '{{ .Repository }}' | grep -q "$1"
 }
 
-# Cleanup these on exit in case something goes wrong
-trap dockercleanup EXIT
-# And remove any that are still around right now
-dockercleanup
+setup_containers() {
+	statusupdate 'Creating Zookeeper Docker instance'
+	docker run \
+		--name "$zk_docker_name" \
+		-d \
+		-e ZOOKEEPER_CLIENT_PORT=32181 \
+		confluentinc/cp-zookeeper:4.1.2
 
-DOCKER_DIR="$BASE_DIR/docker"
+	statusupdate 'Creating Kafka Docker instance'
+	docker run \
+		--name "$kafka_docker_name" \
+		--link "$zk_docker_name":zookeeper \
+		--add-host kafka:127.0.0.1 \
+		-d \
+		-e KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181 \
+		-e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092 \
+		-e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+		confluentinc/cp-kafka:4.1.2
 
-ZOOKEEPER_DOCKER_NAME='kcbq_test_zookeeper'
-KAFKA_DOCKER_NAME='kcbq_test_kafka'
-SCHEMA_REGISTRY_DOCKER_NAME='kcbq_test_schema-registry'
+	statusupdate 'Creating Schema Registry Docker instance'
+	# Have to pause here to make sure Zookeeper/Kafka get on their feet first
+	sleep 5
+	docker run \
+		--name "$schema_registry_docker_name" \
+		--link "$zk_docker_name":zookeeper --link "$kafka_docker_name":kafka \
+		--env SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL=none \
+		-d \
+		-e SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:32181 \
+		-e SCHEMA_REGISTRY_HOST_NAME=schema-registry \
+		confluentinc/cp-schema-registry:4.1.2
 
-statusupdate 'Creating Zookeeper Docker instance'
-docker run --name "$ZOOKEEPER_DOCKER_NAME" \
-           -d \
-           -e ZOOKEEPER_CLIENT_PORT=32181 \
-           confluentinc/cp-zookeeper:4.1.2
+	statusupdate 'Populating Kafka/Schema Registry Docker instances with test data'
 
-statusupdate 'Creating Kafka Docker instance'
-docker run --name "$KAFKA_DOCKER_NAME" \
-           --link "$ZOOKEEPER_DOCKER_NAME":zookeeper \
-           --add-host kafka:127.0.0.1 \
-           -d \
-           -e KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181 \
-           -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092 \
-           -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-           confluentinc/cp-kafka:4.1.2
+	populate_docker_image='kcbq/populate'
+	populate_docker_name='kcbq_test_populate'
 
-statusupdate 'Creating Schema Registry Docker instance'
-# Have to pause here to make sure Zookeeper/Kafka get on their feet first
-sleep 5
-docker run --name "$SCHEMA_REGISTRY_DOCKER_NAME" \
-           --link "$ZOOKEEPER_DOCKER_NAME":zookeeper --link "$KAFKA_DOCKER_NAME":kafka \
-           --env SCHEMA_REGISTRY_AVRO_COMPATIBILITY_LEVEL=none \
-           -d \
-           -e SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:32181 \
-           -e SCHEMA_REGISTRY_HOST_NAME=schema-registry \
-           confluentinc/cp-schema-registry:4.1.2
+	if ! dockerimageexists "$populate_docker_image"; then
+		docker build -q -t "$populate_docker_image" "$DOCKER_DIR/populate"
+	fi
+	# Have to pause here to make sure the Schema Registry gets on its feet first
+	sleep 35
+	docker create \
+		--name "$populate_docker_name" \
+		--link "$kafka_docker_name:kafka" \
+		--link "$schema_registry_docker_name:schema-registry" \
+		"$populate_docker_image"
+	docker cp "$BASE_DIR/resources/test_schemas/" "$populate_docker_name:/tmp/schemas/"
+	docker start -a "$populate_docker_name"
+}
 
-####################################################################################################
-# Writing data to Kafka Docker instance via Avro console producer
-statusupdate 'Populating Kafka/Schema Registry Docker instances with test data'
+cleanup_bq() {
+	####################################################################################################
+	# Deleting existing BigQuery tables/bucket
+	warn 'Deleting existing BigQuery test tables and existing GCS bucket'
 
-POPULATE_DOCKER_IMAGE='kcbq/populate'
-POPULATE_DOCKER_NAME='kcbq_test_populate'
+	"$GRADLEW" -p "$BASE_DIR/.." \
+		-Pkcbq_test_keyfile="$keyfile" \
+		-Pkcbq_test_project="$project" \
+		-Pkcbq_test_dataset="$dataset" \
+		-Pkcbq_test_tables="test_tables" \
+		-Pkcbq_test_bucket="$bucket" \
+		integrationTestPrep
+}
 
-if ! dockerimageexists "$POPULATE_DOCKER_IMAGE"; then
-  docker build -q -t "$POPULATE_DOCKER_IMAGE" "$DOCKER_DIR/populate"
-fi
-# Have to pause here to make sure the Schema Registry gets on its feet first
-sleep 35
-docker create --name "$POPULATE_DOCKER_NAME" \
-              --link "$KAFKA_DOCKER_NAME:kafka" --link "$SCHEMA_REGISTRY_DOCKER_NAME:schema-registry" \
-              "$POPULATE_DOCKER_IMAGE"
-docker cp "$BASE_DIR/resources/test_schemas/" "$POPULATE_DOCKER_NAME:/tmp/schemas/"
-docker start -a "$POPULATE_DOCKER_NAME"
+build_clean_dist() {
+	"$GRADLEW" -q -p "$BASE_DIR/../.." clean distTar
+}
 
-####################################################################################################
-# Deleting existing BigQuery tables/bucket
-warn 'Deleting existing BigQuery test tables and existing GCS bucket'
+run_kafka_connect() {
+	test_topics=
+	for file in "$BASE_DIR"/resources/test_schemas/*; do
+		test_topics+="${test_topics:+,}$(basename "kcbq_test_$file")"
+	done
+
+	statusupdate 'Executing Kafka Connect in Docker'
+	mkdir -p "$DOCKER_DIR/connect/properties"
+
+	STANDALONE_PROPS="$DOCKER_DIR/connect/properties/standalone.properties"
+	cp "$BASE_DIR/resources/standalone-template.properties" "$STANDALONE_PROPS"
+
+	{
+	cat "$BASE_DIR/resources/connector-template.properties"
+	cat <<- EOF
+	project=$project
+	datasets=.*=$dataset
+	gcsBucketName=$bucket
+	gcsFolderName=$folder
+	topics=$test_topics
+
+	EOF
+	} > "$DOCKER_DIR/connect/properties/connector.properties"
+
+	CONNECT_DOCKER_IMAGE='kcbq/connect'
+	CONNECT_DOCKER_NAME='kcbq_test_connect'
+	cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kcbq-confluent-*.tar "$DOCKER_DIR/connect/kcbq.tar"
+	cp "$keyfile" "$DOCKER_DIR/connect/key.json"
+
+	if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then
+	  docker build -q -t "$CONNECT_DOCKER_IMAGE" "$DOCKER_DIR/connect"
+	fi
+	docker create --name "$CONNECT_DOCKER_NAME" \
+		      --link "$kafka_docker_name:kafka" --link "$schema_registry_docker_name:schema-registry" \
+		      -t "$CONNECT_DOCKER_IMAGE" /bin/bash
+	docker cp "$DOCKER_DIR/connect/kcbq.tar" "$CONNECT_DOCKER_NAME:/usr/local/share/kafka/plugins/kafka-connect-bigquery/kcbq.tar"
+	docker cp "$DOCKER_DIR/connect/properties/" "$CONNECT_DOCKER_NAME:/etc/kafka-connect-bigquery/"
+	docker cp "$DOCKER_DIR/connect/key.json" "$CONNECT_DOCKER_NAME:/tmp/key.json"
+	docker start -a "$CONNECT_DOCKER_NAME"
+}
 
 
-test_tables=
-test_topics=
-for file in "$BASE_DIR"/resources/test_schemas/*; do
-        test_tables+="${test_tables:+ }$(basename "kcbq_test_${file/-/_}")"
-        test_topics+="${test_topics:+,}$(basename "kcbq_test_$file")"
-done
+run_integration_test() {
+	# Checking on BigQuery data via Java test (this is the verification portion of the actual test)
+	statusupdate 'Verifying that test data made it successfully to BigQuery'
 
-"$GRADLEW" -p "$BASE_DIR/.." \
-    -Pkcbq_test_keyfile="$KCBQ_TEST_KEYFILE" \
-    -Pkcbq_test_project="$KCBQ_TEST_PROJECT" \
-    -Pkcbq_test_dataset="$KCBQ_TEST_DATASET" \
-    -Pkcbq_test_tables="test_tables" \
-    -Pkcbq_test_bucket="$KCBQ_TEST_BUCKET" \
-    integrationTestPrep
+	dir="$BASE_DIR/../src/integration-test/resources"
+	mkdir -p "$dir"
+	{
+		echo "keyfile=$keyfile"
+		echo "project=$project"
+		echo "dataset=$dataset"
+		echo "bucket=$bucket"
+		echo "folder=$folder"
+	} > "$dir/test.properties"
 
-####################################################################################################
-# Executing connector in standalone mode (this is the execution portion of the actual test)
-statusupdate 'Executing Kafka Connect in Docker'
+	"$GRADLEW" -p "$BASE_DIR/.." cleanIntegrationTest integrationTest
+}
 
-# Run clean task to ensure there's only one connector tarball in the build/dist directory
-"$GRADLEW" -q -p "$BASE_DIR/../.." clean distTar
+main() {
+	init
+	parse_args "$@"
+	trap dockercleanup EXIT
+	dockercleanup
 
-[[ ! -e "$DOCKER_DIR/connect/properties" ]] && mkdir "$DOCKER_DIR/connect/properties"
-RESOURCES_DIR="$BASE_DIR/resources"
+	setup_containers
+	cleanup_bq
+	build_clean_dist
+	run_kafka_connect
+	run_integration_test
+}
 
-STANDALONE_PROPS="$DOCKER_DIR/connect/properties/standalone.properties"
-cp "$RESOURCES_DIR/standalone-template.properties" "$STANDALONE_PROPS"
-
-CONNECTOR_PROPS="$DOCKER_DIR/connect/properties/connector.properties"
-cp "$RESOURCES_DIR/connector-template.properties" "$CONNECTOR_PROPS"
-cat << EOF >> $CONNECTOR_PROPS
-project=$KCBQ_TEST_PROJECT
-datasets=.*=$KCBQ_TEST_DATASET
-gcsBucketName=$KCBQ_TEST_BUCKET
-gcsFolderName=$KCBQ_TEST_FOLDER
-topics=$test_topics
-
-EOF
-
-CONNECT_DOCKER_IMAGE='kcbq/connect'
-CONNECT_DOCKER_NAME='kcbq_test_connect'
-
-cp "$BASE_DIR"/../../kcbq-confluent/build/distributions/kcbq-confluent-*.tar "$DOCKER_DIR/connect/kcbq.tar"
-cp "$KCBQ_TEST_KEYFILE" "$DOCKER_DIR/connect/key.json"
-
-if ! dockerimageexists "$CONNECT_DOCKER_IMAGE"; then
-  docker build -q -t "$CONNECT_DOCKER_IMAGE" "$DOCKER_DIR/connect"
-fi
-docker create --name "$CONNECT_DOCKER_NAME" \
-              --link "$KAFKA_DOCKER_NAME:kafka" --link "$SCHEMA_REGISTRY_DOCKER_NAME:schema-registry" \
-              -t "$CONNECT_DOCKER_IMAGE" /bin/bash
-docker cp "$DOCKER_DIR/connect/kcbq.tar" "$CONNECT_DOCKER_NAME:/usr/local/share/kafka/plugins/kafka-connect-bigquery/kcbq.tar"
-docker cp "$DOCKER_DIR/connect/properties/" "$CONNECT_DOCKER_NAME:/etc/kafka-connect-bigquery/"
-docker cp "$DOCKER_DIR/connect/key.json" "$CONNECT_DOCKER_NAME:/tmp/key.json"
-docker start -a "$CONNECT_DOCKER_NAME"
-
-####################################################################################################
-# Checking on BigQuery data via Java test (this is the verification portion of the actual test)
-statusupdate 'Verifying that test data made it successfully to BigQuery'
-
-INTEGRATION_TEST_RESOURCE_DIR="$BASE_DIR/../src/integration-test/resources"
-[[ ! -d "$INTEGRATION_TEST_RESOURCE_DIR" ]] && mkdir -p "$INTEGRATION_TEST_RESOURCE_DIR"
-INTEGRATION_TEST_PROPERTIES_FILE="$INTEGRATION_TEST_RESOURCE_DIR/test.properties"
-
-echo "keyfile=$KCBQ_TEST_KEYFILE" > "$INTEGRATION_TEST_PROPERTIES_FILE"
-echo "project=$KCBQ_TEST_PROJECT" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
-echo "dataset=$KCBQ_TEST_DATASET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
-echo "bucket=$KCBQ_TEST_BUCKET" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
-echo "folder=$KCBQ_TEST_FOLDER" >> "$INTEGRATION_TEST_PROPERTIES_FILE"
-
-"$GRADLEW" -p "$BASE_DIR/.." cleanIntegrationTest integrationTest
+main "$@"


### PR DESCRIPTION
This includes a lot of cleanup of the integration test, but the primary purpose is to make it run on linux.  The primary issues it addresses are differing behaviors of xargs and basename.  Currently, the script expects xargs to behave as if --no-run-if-empty was given (this is the default behavior on macos, but is not default in gnu xargs common on linux hosts), and it expects basename to take multiple arguments (this causes an error in gnu coreutils 8.26).  Also, I added some flags to keep the containers running if desired to enable further analysis after the test has completed.