### PR TITLE
Upgrade google-cloud version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
     apacheHttpClientVersion = '4.5.6'
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
-    googleCloudVersion = '0.47.0-alpha'
+    googleCloudVersion = '1.79.0'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -195,9 +195,10 @@ project(':kcbq-connector') {
         compile (
                 project(':kcbq-api'),
 
-                "com.google.cloud:google-cloud:$googleCloudVersion",
+                "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
+                "com.google.cloud:google-cloud-storage:$googleCloudVersion",
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
-                "com.google.code.gson:gson:$googleCloudVersion",
+                "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
@@ -248,7 +249,7 @@ project('kcbq-api') {
 
     dependencies {
         compile (
-                "com.google.cloud:google-cloud:$googleCloudVersion",
+                "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion"
         )
     }
@@ -316,7 +317,6 @@ project('kcbq-confluent') {
         compile (
                 project(':kcbq-api'),
 
-                "com.google.cloud:google-cloud:$googleCloudVersion",
                 "io.confluent:kafka-connect-avro-converter:$ioConfluentVersion",
                 "io.confluent:kafka-schema-registry-client:$ioConfluentVersion",
                 "org.apache.avro:avro:$avroVersion",


### PR DESCRIPTION
Upgrade google-cloud dependency version to fix potential `NullPointerException`.
```
"trace": "java.lang.NullPointerException
at com.google.cloud.bigquery.StandardTableDefinition$StreamingBuffer.fromPb(StandardTableDefinition.java:121)
at com.google.cloud.bigquery.StandardTableDefinition$Builder.<init>(StandardTableDefinition.java:157)
at com.google.cloud.bigquery.StandardTableDefinition$Builder.<init>(StandardTableDefinition.java:127)
at com.google.cloud.bigquery.StandardTableDefinition.fromPb(StandardTableDefinition.java:326)
at com.google.cloud.bigquery.TableDefinition.fromPb(TableDefinition.java:218)
at com.google.cloud.bigquery.TableInfo$BuilderImpl.<init>(TableInfo.java:162)
at com.google.cloud.bigquery.Table.fromPb(Table.java:559)
at com.google.cloud.bigquery.BigQueryImpl.getTable(BigQueryImpl.java:385)
at com.wepay.kafka.connect.bigquery.BigQuerySinkConnector.ensureExistingTables(BigQuerySinkConnector.java:111)
at com.wepay.kafka.connect.bigquery.BigQuerySinkConnector.ensureExistingTables(BigQuerySinkConnector.java:136)
at com.wepay.kafka.connect.bigquery.BigQuerySinkConnector.start(BigQuerySinkConnector.java:155)
at org.apache.kafka.connect.runtime.WorkerConnector.doStart(WorkerConnector.java:100)
at org.apache.kafka.connect.runtime.WorkerConnector.start(WorkerConnector.java:125)
at org.apache.kafka.connect.runtime.WorkerConnector.transitionTo(WorkerConnector.java:182)
at org.apache.kafka.connect.runtime.Worker.startConnector(Worker.java:183)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startConnector(DistributedHerder.java:876)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.access$1200(DistributedHerder.java:101)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder$11.call(DistributedHerder.java:634)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder$11.call(DistributedHerder.java:620)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.tick(DistributedHerder.java:250)
at org.apache.kafka.connect.runtime.distributed.DistributedHerder.run(DistributedHerder.java:200)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```
@mtagle 