### PR TITLE
Fix gcs load retry logic

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -75,9 +75,9 @@ public class GCSBatchTableWriter implements Runnable {
     try {
       writer.writeRows(rows, tableId, bucketName, blobName);
     } catch (ConnectException ex) {
-      throw new ConnectException("Failed to write rows to GCS", ex);
+      throw new ConnectException(String.format("Failed to write rows to GCS for table %s", tableId.getTable()), ex);
     } catch (InterruptedException ex) {
-      throw new ConnectException("Thread interrupted while batch writing to GCS.", ex);
+      throw new ConnectException(String.format("Thread interrupted while batch writing to GCS for table %s", tableId.getTable()), ex);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -75,9 +75,9 @@ public class GCSBatchTableWriter implements Runnable {
     try {
       writer.writeRows(rows, tableId, bucketName, blobName);
     } catch (ConnectException ex) {
-      throw new ConnectException(String.format("Failed to write rows to GCS for table %s", tableId.getTable()), ex);
+      throw new ConnectException("Failed to write rows to GCS", ex);
     } catch (InterruptedException ex) {
-      throw new ConnectException(String.format("Thread interrupted while batch writing to GCS for table %s", tableId.getTable()), ex);
+      throw new ConnectException("Thread interrupted while batch writing", ex);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -74,8 +74,10 @@ public class GCSBatchTableWriter implements Runnable {
   public void run() {
     try {
       writer.writeRows(rows, tableId, bucketName, blobName);
-    } catch (ConnectException | InterruptedException ex) {
-      throw new ConnectException("Thread interrupted while batch writing to BigQuery.", ex);
+    } catch (ConnectException ex) {
+      throw new ConnectException("Failed to write rows to GCS", ex);
+    } catch (InterruptedException ex) {
+      throw new ConnectException("Thread interrupted while batch writing to GCS.", ex);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -109,23 +109,20 @@ public class GCSToBQWriter {
     }
 
     int retryCount = 0;
-    boolean exceptionsOccurred;
     boolean success = false;
     do {
       if (retryCount > 0) {
         waitRandomTime();
       }
-      exceptionsOccurred = false;
       // Perform GCS Upload
       try {
         uploadRowsToGcs(rows, blobInfo);
         success = true;
       } catch (StorageException se) {
-        exceptionsOccurred = true;
         logger.warn("Exceptions occurred for table {}, attempting retry", tableId.getTable());
       }
       retryCount++;
-    } while (exceptionsOccurred && (retryCount < retries));
+    } while (!success && (retryCount < retries));
 
     if (success) {
       logger.info("Batch loaded {} rows", rows.size());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -108,10 +108,10 @@ public class GCSToBQWriter {
           String.format("Table with TableId %s does not exist.", tableId.getTable()));
     }
 
-    int retryCount = 0;
+    int attemptCount = 0;
     boolean success = false;
-    do {
-      if (retryCount > 0) {
+    while (!success && (attemptCount <= retries)) {
+      if (attemptCount > 0) {
         waitRandomTime();
       }
       // Perform GCS Upload
@@ -121,14 +121,13 @@ public class GCSToBQWriter {
       } catch (StorageException se) {
         logger.warn("Exceptions occurred for table {}, attempting retry", tableId.getTable());
       }
-      retryCount++;
-    } while (!success && (retryCount < retries));
+      attemptCount++;
+    }
 
     if (success) {
       logger.info("Batch loaded {} rows", rows.size());
-    }
-    else {
-      throw new ConnectException(String.format("Failed to load %d rows into GCS within %d attempts.", rows.size(), retries));
+    } else {
+      throw new ConnectException(String.format("Failed to load %d rows into GCS within %d re-attempts.", rows.size(), retries));
     }
 
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -25,6 +25,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.gson.Gson;
 
 import com.wepay.kafka.connect.bigquery.exception.GCSConnectException;
@@ -109,22 +110,30 @@ public class GCSToBQWriter {
 
     int retryCount = 0;
     boolean exceptionsOccurred;
+    boolean success = false;
     do {
       if (retryCount > 0) {
         waitRandomTime();
       }
       exceptionsOccurred = false;
-      // Perform GCS Upload and BQ Transfer
+      // Perform GCS Upload
       try {
         uploadRowsToGcs(rows, blobInfo);
-      } catch (ConnectException ce) {
+        success = true;
+      } catch (StorageException se) {
         exceptionsOccurred = true;
         logger.warn("Exceptions occurred for table {}, attempting retry", tableId.getTable());
       }
       retryCount++;
     } while (exceptionsOccurred && (retryCount < retries));
 
-    logger.info("Batch loaded {} rows", rows.size());
+    if (success) {
+      logger.info("Batch loaded {} rows", rows.size());
+    }
+    else {
+      throw new ConnectException(String.format("Failed to load %d rows into GCS within %d attempts.", rows.size(), retries));
+    }
+
   }
 
   private static Map<String, String> getMetadata(TableId tableId) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -1,0 +1,166 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2019 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.wepay.kafka.connect.bigquery.BigQuerySinkTask;
+import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GCSToBQWriterTest {
+
+  private static SinkTaskPropertiesFactory propertiesFactory;
+
+  @BeforeClass
+  public static void initializePropertiesFactory() {
+    propertiesFactory = new SinkTaskPropertiesFactory();
+  }
+
+  @Test
+  public void testGCSNoFailure(){
+    // test succeeding on first attempt
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    expectTable(bigQuery);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    verify(storage, times(1)).create((BlobInfo)anyObject(), (byte[])anyObject());
+  }
+
+  @Test
+  public void testGCSFailure(){
+    // test failure through all configured retry attempts.
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    expectTable(bigQuery);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    when(storage.create((BlobInfo)anyObject(), (byte[])anyObject()))
+        .thenThrow(new StorageException(500, "internal server error"));
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, null, storage);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    try {
+      testTask.flush(Collections.emptyMap());
+      Assert.fail("expected testTask.flush to fail.");
+    } catch (ConnectException ex){
+      // expected!
+    }
+  }
+
+  private void expectTable(BigQuery mockBigQuery) {
+    Table mockTable = mock(Table.class);
+    when(mockBigQuery.getTable(anyObject())).thenReturn(mockTable);
+  }
+
+  /**
+   * Utility method for making and retrieving properties based on provided parameters.
+   * @param bigqueryRetry The number of retries.
+   * @param bigqueryRetryWait The wait time for each retry.
+   * @param topic The topic of the record.
+   * @param dataset The dataset of the record.
+   * @return The map of bigquery sink configurations.
+   */
+  private Map<String,String> makeProperties(String bigqueryRetry,
+                                            String bigqueryRetryWait,
+                                            String topic,
+                                            String dataset) {
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
+    properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+    // gcs config
+    properties.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG, "myBucket");
+    return properties;
+  }
+
+  /**
+   * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+   * @param topic The topic of the record.
+   * @param partition The partition of the record.
+   * @param field The name of the field in the record's struct.
+   * @param value The content of the field.
+   * @return The spoofed SinkRecord.
+   */
+  private SinkRecord spoofSinkRecord(String topic,
+                                     int partition,
+                                     long kafkaOffset,
+                                     String field,
+                                     String value) {
+    Schema basicRowSchema = SchemaBuilder
+        .struct()
+        .field(field, Schema.STRING_SCHEMA)
+        .build();
+    Struct basicRowValue = new Struct(basicRowSchema);
+    basicRowValue.put(field, value);
+    return new SinkRecord(topic,
+        partition,
+        null,
+        null,
+        basicRowSchema,
+        basicRowValue,
+        kafkaOffset,
+        null,
+        null);
+  }
+
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -128,7 +128,7 @@ public class GCSToBQWriterTest {
       testTask.flush(Collections.emptyMap());
       Assert.fail("expected testTask.flush to fail.");
     } catch (ConnectException ex){
-      verify(storage, times(3)).create((BlobInfo)anyObject(), (byte[])anyObject());
+      verify(storage, times(4)).create((BlobInfo)anyObject(), (byte[])anyObject());
     }
   }
 


### PR DESCRIPTION
wrote a bunch of tests for GCSToBQWriter

fixed retry logic for GCSToBQWriter:
- catch the error thrown by GCS if the upload is unsuccessful (and thus actually retry).
- keep track of whether we actually succeeded in our retry attempts or not/ don't suggest we succeeded in a log message if we did not.
- stop retrying once we succeed in a retry attempt.

it's possible that this will fix the issues we've been seeing with dropped rows when going through GCS loading. 