### PR TITLE
Add Support for Schemaless Record

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
-    commonsVersion = '3.9'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -201,7 +200,6 @@ project(':kcbq-connector') {
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
-                "org.apache.commons:commons-lang3:$commonsVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
+    commonsVersion = '3.9'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'
@@ -200,6 +201,7 @@ project(':kcbq-connector') {
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
+                "org.apache.commons:commons-lang3:$commonsVersion",
                 "org.apache.kafka:connect-api:$kafkaVersion",
                 "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.ClassUtils;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.nio.ByteBuffer;
@@ -83,6 +82,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   }
 
   private Object validateSchemalessRecord(Object value) {
+    if (value instanceof Double) {
+      return convertDouble((Double) value);
+    }
     if (ClassUtils.isPrimitiveWrapper(value.getClass()) || value instanceof String) {
       return value;
     }
@@ -101,8 +103,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
                 Collectors.toMap(
                         entry -> {
                           if (!(entry.getKey() instanceof String)) {
-                            throw new DataException(
-                                    "Map objects in absence of schema needs to have string value keys.");
+                            throw new ConversionConnectException(
+                                    "Map objects in absence of schema needs to have string value keys. " +
+                                    "Failed to convert record to bigQuery format.");
                           }
                           return entry.getKey();
                         },

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -73,6 +73,14 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
    */
   public Map<String, Object> convertRecord(SinkRecord kafkaConnectRecord) {
     Schema kafkaConnectSchema = kafkaConnectRecord.valueSchema();
+    Object kafkaConnectValue = kafkaConnectRecord.value();
+    if (kafkaConnectSchema == null) {
+      if (kafkaConnectValue instanceof Map) {
+        return (Map) kafkaConnectRecord;
+      }
+      throw new ConversionConnectException("Only Map objects supported in absence of schema for " +
+              "record conversion to BigQuery format.");
+    }
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new
           ConversionConnectException("Top-level Kafka Connect schema must be of type 'struct'");

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -583,7 +583,7 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test (expected = ConversionConnectException.class)
-  public void testInValidMapSchemaless() {
+  public void testInvalidMapSchemaless() {
     Map kafkaConnectMap = new HashMap<Object, Object>(){{
       put("f1", "f2");
       put( "f3" ,

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -560,6 +560,98 @@ public class BigQueryRecordConverterTest {
     assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
   }
 
+  @Test
+  public void testValidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(kafkaConnectMap, convertedMap);
+  }
+
+  @Test (expected = ConversionConnectException.class)
+  public void testInValidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put(1, "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+  }
+
+  @Test
+  public void testMapSchemalessConvertDouble() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", Double.POSITIVE_INFINITY);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", Double.POSITIVE_INFINITY);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Double.MAX_VALUE);
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Double.MAX_VALUE);
+    assertEquals(((ArrayList)((Map)(convertedMap.get("f3"))).get("f6")).get(1), Double.MAX_VALUE);
+  }
+
+  @Test
+  public void testMapSchemalessConvertBytes() {
+    byte[] helloWorld = "helloWorld".getBytes();
+    ByteBuffer helloWorldBuffer = ByteBuffer.wrap(helloWorld);
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", helloWorldBuffer);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", helloWorld);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Base64.getEncoder().encodeToString(helloWorld));
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Base64.getEncoder().encodeToString(helloWorld));
+  }
+
   private static SinkRecord spoofSinkRecord(Schema valueSchema, Object value) {
     return new SinkRecord(null, 0, null, null, valueSchema, value, 0);
   }


### PR DESCRIPTION
What
----
Currently the BigQueryRecordConverter throws an error when schemaless JSON data is consumed. JsonConverter converts JSON to map before it arrives at the BigQuery connector. Therefore, instead of throwing null pointer error, the BigQueryRecordConverter should deal with schemaless data type by converting it to legitimate format.

Should solve this issue -> https://github.com/wepay/kafka-connect-bigquery/issues/174 

@C0urante 
Review is greatly appreciated!