### PR TITLE
Resolve table name dynamically

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -34,8 +34,8 @@ import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.TopicToTableResolver;
+import com.wepay.kafka.connect.bigquery.utils.TopicToTableUpdater;
 import com.wepay.kafka.connect.bigquery.utils.Version;
-
 import com.wepay.kafka.connect.bigquery.write.batch.GCSBatchTableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriter;
@@ -128,6 +128,11 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   private PartitionedTableId getRecordTable(SinkRecord record) {
+    if (!topicsToBaseTableIds.containsKey(record.topic())) {
+      topicsToBaseTableIds = TopicToTableUpdater.updateTopicToTable(config, record.topic(),
+              topicsToBaseTableIds);
+    }
+
     TableId baseTableId = topicsToBaseTableIds.get(record.topic());
 
     PartitionedTableId.Builder builder = new PartitionedTableId.Builder(baseTableId);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableUpdater.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableUpdater.java
@@ -1,0 +1,92 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.wepay.kafka.connect.bigquery.utils.TopicToTableResolver.getTopicToTableSingleMatch;
+
+public class TopicToTableUpdater {
+  public static String getTopicToDateset (
+          List<Map.Entry<Pattern, String>> patterns,
+          String topicName,
+          String valueProperty,
+          String patternProperty) {
+
+    String match = null;
+    for (Map.Entry<Pattern, String> pattern : patterns) {
+      Matcher patternMatcher = pattern.getKey().matcher(topicName);
+      if (patternMatcher.matches()) {
+        if (match != null) {
+          String secondMatch = pattern.getValue();
+          throw new ConfigException(
+                  "Value '" + topicName
+                          + "' for property '" + valueProperty
+                          + "' matches " + patternProperty
+                          + " regexes for both '" + match
+                          + "' and '" + secondMatch + "'"
+          );
+        }
+        match = pattern.getValue();
+      }
+    }
+    if (match == null) {
+      throw new ConfigException(
+              "Value '" + topicName
+                      + "' for property '" + valueProperty
+                      + "' failed to match any of the provided " + patternProperty
+                      + " regexes"
+      );
+    }
+
+    return match;
+  }
+
+  /**
+   * Return a Map detailing which BigQuery table each topic should write to.
+   *
+   * @param config Config that contains properties used to generate the map
+   * @return A Map associating Kafka topic names to BigQuery table names.
+   */
+  public static Map<String, TableId> updateTopicToTable(
+          BigQuerySinkConfig config,
+          String topicName,
+          Map<String, TableId> topicToTable) {
+    Boolean sanitize = config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG);
+    String match = getTopicToTableSingleMatch(config, topicName);
+
+    if (match == null) {
+      match = topicName;
+    }
+    if (sanitize) {
+      match = sanitizeTableName(match);
+    }
+    String dataset =
+            getTopicToDateset(
+                    config.getSinglePatterns(config.DATASETS_CONFIG),
+                    topicName,
+                    config.TOPICS_CONFIG,
+                    config.DATASETS_CONFIG
+            );
+    topicToTable.put(topicName, TableId.of(dataset, match));
+    return topicToTable;
+  }
+
+  /**
+   * Strips illegal characters from a table name. BigQuery only allows alpha-numeric and
+   * underscore. Everything illegal is converted to an underscore.
+   *
+   * @param tableName The table name to sanitize.
+   * @return A clean table name with only alpha-numerics and underscores.
+   */
+  private static String sanitizeTableName(String tableName) {
+    return tableName.replaceAll("[^a-zA-Z0-9_]", "_");
+  }
+
+
+}


### PR DESCRIPTION
Currently the table lookup map in BigQuery connector only include topics passed in to the connector config file. To dynamically route messages to different topics and thus different tables, big query connector should be able to evaluate the topic names embedded in messages automatically and include them in the look up map, so that the messages can be routed to different BigQuery tables.