### PR TITLE
Add field name Sanitization

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -25,17 +25,16 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
-
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
+import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.TopicToTableResolver;
 import com.wepay.kafka.connect.bigquery.utils.Version;
-
 import com.wepay.kafka.connect.bigquery.write.batch.GCSBatchTableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriter;
@@ -44,7 +43,6 @@ import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import com.wepay.kafka.connect.bigquery.write.row.SimpleBigQueryWriter;
-
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -52,7 +50,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,7 +154,12 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   private RowToInsert getRecordRow(SinkRecord record) {
-    return RowToInsert.of(getRowId(record), recordConverter.convertRecord(record));
+    Map convertedRecord = recordConverter.convertRecord(record);
+    if (config.getBoolean(config.SANITIZE_FIELD_NAME_CONFIG)) {
+      convertedRecord = FieldNameSanitizer.replaceInvalidKeys(convertedRecord);
+    }
+
+    return RowToInsert.of(getRowId(record), convertedRecord);
   }
 
   private String getRowId(SinkRecord record) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -154,7 +154,7 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   private RowToInsert getRecordRow(SinkRecord record) {
-    Map convertedRecord = recordConverter.convertRecord(record);
+    Map<String,Object> convertedRecord = recordConverter.convertRecord(record);
     if (config.getBoolean(config.SANITIZE_FIELD_NAME_CONFIG)) {
       convertedRecord = FieldNameSanitizer.replaceInvalidKeys(convertedRecord);
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -133,6 +133,19 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "Whether to automatically sanitize topic names before using them as table names;"
       + " if not enabled topic names will be used directly as table names";
 
+  public static final String SANITIZE_FIELD_NAME_CONFIG =                     "sanitizeFieldNames";
+  private static final ConfigDef.Type SANITIZE_FIELD_NAME_TYPE =              ConfigDef.Type.BOOLEAN;
+  public static final Boolean SANITIZE_FIELD_NAME_DEFAULT =                   false;
+  private static final ConfigDef.Importance SANITIZE_FIELD_NAME_IMPORTANCE =
+          ConfigDef.Importance.MEDIUM;
+  private static final String SANITIZE_FIELD_NAME_DOC =
+          "Whether to automatically sanitize field names before using them as field names in big query. "
+                  + "Big query specifies that field name can only contain letters, numbers, and "
+                  + "underscores. The sanitizer will replace the invalid symbols with underscore. "
+                  + "If the field name starts with a digit, the sanitizer will add an underscore in "
+                  + "front of field name. Note: field a.b and a_b will have same value after sanitizing, "
+                  + "and might cause key duplication error.";
+
   public static final String INCLUDE_KAFKA_DATA_CONFIG =                   "includeKafkaData";
   public static final ConfigDef.Type INCLUDE_KAFKA_DATA_TYPE =             ConfigDef.Type.BOOLEAN;
   public static final Boolean INCLUDE_KAFKA_DATA_DEFAULT =                 false;
@@ -231,6 +244,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             SANITIZE_TOPICS_DEFAULT,
             SANITIZE_TOPICS_IMPORTANCE,
             SANITIZE_TOPICS_DOC
+        ).define(
+            SANITIZE_FIELD_NAME_CONFIG,
+            SANITIZE_FIELD_NAME_TYPE,
+            SANITIZE_FIELD_NAME_DEFAULT,
+            SANITIZE_FIELD_NAME_IMPORTANCE,
+            SANITIZE_FIELD_NAME_DOC
         ).define(
             INCLUDE_KAFKA_DATA_CONFIG,
             INCLUDE_KAFKA_DATA_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -5,34 +5,30 @@ import java.util.stream.Collectors;
 
 public class FieldNameSanitizer {
 
-  // replace all non-letter, non-digit characters with underscore
-  // append underscore in front of name if it does not begin with letter or underscore
+  // Replace all non-letter, non-digit characters with underscore. Append underscore in front of
+  // name if it does not begin with alphabet or underscore.
   private static String sanitizeName(String name) {
-    name = name.replaceAll("[^a-zA-Z0-9_]", "_");
-    if (name.matches("^[^a-zA-Z_].*")) {
-      name = "_" + name;
+    String sanitizedName = name.replaceAll("[^a-zA-Z0-9_]", "_");
+    if (sanitizedName.matches("^[^a-zA-Z_].*")) {
+      sanitizedName = "_" + sanitizedName;
     }
-    return name;
+    return sanitizedName;
   }
 
 
-  // Big Query specifies field name must begin with a letter or underscore and can only contain
-  // letters, numbers, and underscores
-  // Note that a.b and a/b will have the same value after sanitization
-  // which will cause Duplicate key Exception
-  public static Map<String,Object> replaceInvalidKeys(Map<String, Object> map) {
-
+  // Big Query specifies field name must begin with a alphabet or underscore and can only contain
+  // letters, numbers, and underscores.
+  // Note: a.b and a/b will have the same value after sanitization which will cause Duplicate key
+  // Exception.
+  public static Map<String, Object> replaceInvalidKeys(Map<String, Object> map) {
     return map.entrySet().stream().collect(Collectors.toMap(
-            (entry) -> {
-              return sanitizeName(entry.getKey());
-            },
-            (entry) -> {
-              if (entry.getValue() instanceof Map) {
-                return replaceInvalidKeys((Map) entry.getValue());
-              }
-              return entry.getValue();
-
-            }
+        (entry) -> sanitizeName(entry.getKey()),
+        (entry) -> {
+          if (entry.getValue() instanceof Map) {
+            return replaceInvalidKeys((Map<String, Object>) entry.getValue());
+          }
+          return entry.getValue();
+        }
     ));
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -1,0 +1,38 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FieldNameSanitizer {
+
+  // replace all non-letter, non-digit characters with underscore
+  // append underscore in front of name if it does not begin with letter or underscore
+  private static String sanitizeName(String name) {
+    name = name.replaceAll("[^a-zA-Z0-9_]", "_");
+    if (name.matches("^[^a-zA-Z_].*")) {
+      name = "_" + name;
+    }
+    return name;
+  }
+
+
+  // Big Query specifies field name must begin with a letter or underscore and can only contain
+  // letters, numbers, and underscores
+  // Note that a.b and a/b will have the same value after sanitization
+  // which will cause Duplicate key Exception
+  public static Map<String,Object> replaceInvalidKeys(Map<String, Object> map) {
+
+    return map.entrySet().stream().collect(Collectors.toMap(
+            (entry) -> {
+              return sanitizeName(entry.getKey());
+            },
+            (entry) -> {
+              if (entry.getValue() instanceof Map) {
+                return replaceInvalidKeys((Map) entry.getValue());
+              }
+              return entry.getValue();
+
+            }
+    ));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
@@ -1,0 +1,51 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FieldNameSanitizerTest {
+  HashMap testMap;
+
+  @Before
+  public void setUp() {
+    testMap =
+        new HashMap<String, HashMap<?, ?>>() {{
+          put("A.1", new HashMap<String, Object>() {{
+            put("_B1", 1);
+            put("B.2", "hello.B-2");
+          }});
+          put("A-2", new HashMap<String, Object>() {{
+            put("=/B.3", "hello B3");
+            put("B./4", "hello B4");
+            put("2A/", "hello B5");
+            put("3A/", "hello B6");
+          }});
+        }};
+  }
+
+  @Test
+  public void testInvalidSymbol() {
+    testMap = (HashMap)FieldNameSanitizer.replaceInvalidKeys(testMap);
+    assertTrue(testMap.containsKey("A_1"));
+    assertTrue(testMap.containsKey("A_2"));
+    assertTrue(((HashMap)(testMap.get("A_1"))).containsKey("B_2"));
+    assertTrue(((HashMap)(testMap.get("A_1"))).containsKey("_B1"));
+
+    assertEquals(((HashMap)(testMap.get("A_1"))).get("B_2"), "hello.B-2");
+    assertEquals(((HashMap)(testMap.get("A_1"))).get("_B1"), 1);
+
+    assertTrue(((HashMap)(testMap.get("A_2"))).containsKey("__B_3"));
+    assertTrue(((HashMap)(testMap.get("A_2"))).containsKey("B__4"));
+
+    assertEquals(((HashMap)(testMap.get("A_2"))).get("__B_3"), "hello B3");
+    assertEquals(((HashMap)(testMap.get("A_2"))).get("B__4"), "hello B4");
+
+    assertEquals(((HashMap)(testMap.get("A_2"))).get("_2A_"), "hello B5");
+    assertEquals(((HashMap)(testMap.get("A_2"))).get("_3A_"), "hello B6");
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizerTest.java
@@ -1,5 +1,6 @@
 package com.wepay.kafka.connect.bigquery.utils;
 
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -9,43 +10,69 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class FieldNameSanitizerTest {
-  HashMap testMap;
+  private Map<String, Object> testMap;
 
   @Before
   public void setUp() {
-    testMap =
-        new HashMap<String, HashMap<?, ?>>() {{
-          put("A.1", new HashMap<String, Object>() {{
-            put("_B1", 1);
-            put("B.2", "hello.B-2");
-          }});
-          put("A-2", new HashMap<String, Object>() {{
-            put("=/B.3", "hello B3");
-            put("B./4", "hello B4");
-            put("2A/", "hello B5");
-            put("3A/", "hello B6");
-          }});
-        }};
+    testMap = new HashMap<String, Object>() {{
+      put("A.1", new HashMap<String, Object>() {{
+        put("_B1", 1);
+        put("B.2", "hello.B-2");
+      }});
+      put("A-2", new HashMap<String, Object>() {{
+        put("=/B.3", "hello B3");
+        put("B./4", "hello B4");
+        put("2A/", "hello B5");
+        put("3A/", "hello B6");
+      }});
+      put("Foo", "Simple Value");
+      put("Foo_1", "Simple Value 1");
+      put("Foo-2", "Simple Value 2");
+    }};
   }
 
   @Test
   public void testInvalidSymbol() {
-    testMap = (HashMap)FieldNameSanitizer.replaceInvalidKeys(testMap);
-    assertTrue(testMap.containsKey("A_1"));
-    assertTrue(testMap.containsKey("A_2"));
-    assertTrue(((HashMap)(testMap.get("A_1"))).containsKey("B_2"));
-    assertTrue(((HashMap)(testMap.get("A_1"))).containsKey("_B1"));
+    Map<String, Object> sanitizedMap = FieldNameSanitizer.replaceInvalidKeys(testMap);
+    assertTrue(sanitizedMap.containsKey("A_1"));
+    assertTrue(sanitizedMap.containsKey("A_2"));
 
-    assertEquals(((HashMap)(testMap.get("A_1"))).get("B_2"), "hello.B-2");
-    assertEquals(((HashMap)(testMap.get("A_1"))).get("_B1"), 1);
+    Map<String, Object> nestedMap1 = (Map<String, Object>) sanitizedMap.get("A_1");
+    // Validate changed keys.
+    assertTrue(nestedMap1.containsKey("B_2"));
+    assertTrue(nestedMap1.containsKey("_B1"));
 
-    assertTrue(((HashMap)(testMap.get("A_2"))).containsKey("__B_3"));
-    assertTrue(((HashMap)(testMap.get("A_2"))).containsKey("B__4"));
+    // Validate unchanged values.
+    assertEquals(nestedMap1.get("B_2"), "hello.B-2");
+    assertEquals(nestedMap1.get("_B1"), 1);
 
-    assertEquals(((HashMap)(testMap.get("A_2"))).get("__B_3"), "hello B3");
-    assertEquals(((HashMap)(testMap.get("A_2"))).get("B__4"), "hello B4");
+    // Validate map size.
+    assertEquals(2, nestedMap1.size());
 
-    assertEquals(((HashMap)(testMap.get("A_2"))).get("_2A_"), "hello B5");
-    assertEquals(((HashMap)(testMap.get("A_2"))).get("_3A_"), "hello B6");
+    Map<String, Object> nestedMap2 = (Map<String, Object>) sanitizedMap.get("A_2");
+    // Validate changed keys.
+    assertTrue(nestedMap2.containsKey("__B_3"));
+    assertTrue(nestedMap2.containsKey("B__4"));
+    assertTrue(nestedMap2.containsKey("_2A_"));
+    assertTrue(nestedMap2.containsKey("_3A_"));
+
+    // Validate unchanged values.
+    assertEquals(nestedMap2.get("__B_3"), "hello B3");
+    assertEquals(nestedMap2.get("B__4"), "hello B4");
+    assertEquals(nestedMap2.get("_2A_"), "hello B5");
+    assertEquals(nestedMap2.get("_3A_"), "hello B6");
+
+    // Validate map size.
+    assertEquals(4, nestedMap2.size());
+
+    // Validate keys shall be unchanged.
+    assertTrue(sanitizedMap.containsKey("Foo"));
+    assertTrue(sanitizedMap.containsKey("Foo_1"));
+
+    // Validate key shall be changed.
+    assertTrue(sanitizedMap.containsKey("Foo_2"));
+
+    // Validate map size.
+    assertEquals(5, sanitizedMap.size());
   }
 }


### PR DESCRIPTION
BigQuery dataset only allows underscore as special character for field names, and field names have to start with a letter or underscore.

This is the PR against https://github.com/wepay/kafka-connect-bigquery/pull/180. As ConfluentInc has signed corporate CLA with WePay and @codingparsley is currently not part of ConfluentInc hence raised separate PR. Please if we can merge same and close https://github.com/wepay/kafka-connect-bigquery/pull/180.

@criccomini @mtagle 