### PR TITLE
Add Support for Schemaless Record

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -19,31 +19,26 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
-
-import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
-
-import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.nio.ByteBuffer;
-
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class for converting from {@link SinkRecord SinkRecords} and BigQuery rows, which are represented
@@ -51,6 +46,11 @@ import java.util.Set;
  */
 public class BigQueryRecordConverter implements RecordConverter<Map<String, Object>> {
 
+  private static final Set<Class> BASIC_TYPES = new HashSet(
+          Arrays.asList(
+            Boolean.class, Character.class, Byte.class, Short.class,
+                  Integer.class, Long.class, Float.class, Double.class, String.class)
+          );
   private boolean shouldConvertSpecialDouble;
 
   static {
@@ -73,11 +73,58 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
    */
   public Map<String, Object> convertRecord(SinkRecord kafkaConnectRecord) {
     Schema kafkaConnectSchema = kafkaConnectRecord.valueSchema();
+    Object kafkaConnectValue = kafkaConnectRecord.value();
+    if (kafkaConnectSchema == null) {
+      if (kafkaConnectValue instanceof Map) {
+        return (Map<String, Object>) convertSchemalessRecord(kafkaConnectValue);
+      }
+      throw new ConversionConnectException("Only Map objects supported in absence of schema for " +
+              "record conversion to BigQuery format.");
+    }
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new
           ConversionConnectException("Top-level Kafka Connect schema must be of type 'struct'");
     }
     return convertStruct(kafkaConnectRecord.value(), kafkaConnectSchema);
+  }
+
+  private Object convertSchemalessRecord(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Double) {
+      return convertDouble((Double) value);
+    }
+    if (BASIC_TYPES.contains(value.getClass())) {
+      return value;
+    }
+    if (value instanceof byte[] || value instanceof ByteBuffer) {
+      return convertBytes(value);
+    }
+    if (value instanceof List) {
+      return
+          ((List) value).stream().map(
+                  v -> convertSchemalessRecord(v)
+          ).collect(Collectors.toList());
+    }
+    if (value instanceof Map) {
+      return
+        ((Map<Object, Object>) value).entrySet().stream().collect(
+                Collectors.toMap(
+                        entry -> {
+                          if (!(entry.getKey() instanceof String)) {
+                            throw new ConversionConnectException(
+                                    "Failed to convert record to bigQuery format: " +
+                                    "Map objects in absence of schema needs to have string value keys. ");
+                          }
+                          return entry.getKey();
+                        },
+                        entry -> convertSchemalessRecord(entry.getValue())
+                )
+        );
+    }
+    throw new ConversionConnectException("Unsupported class " + value.getClass() +
+            " found in schemaless record data. Can't convert record to bigQuery format");
   }
 
   @SuppressWarnings("unchecked")
@@ -103,9 +150,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       case STRUCT:
         return convertStruct(kafkaConnectObject, kafkaConnectSchema);
       case BYTES:
-        ByteBuffer byteBuffer = (ByteBuffer) kafkaConnectObject;
-        byte[] bytes = byteBuffer.array();
-        return Base64.getEncoder().encodeToString(bytes);
+        return convertBytes(kafkaConnectObject);
       case BOOLEAN:
         return (Boolean) kafkaConnectObject;
       case FLOAT32:
@@ -209,5 +254,16 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       }
     }
     return kafkaConnectDouble;
+  }
+
+  private String convertBytes(Object kafkaConnectObject) {
+    byte[] bytes;
+    if (kafkaConnectObject instanceof ByteBuffer) {
+      ByteBuffer byteBuffer = (ByteBuffer) kafkaConnectObject;
+      bytes = byteBuffer.array();
+    } else {
+      bytes = (byte[]) kafkaConnectObject;
+    }
+    return Base64.getEncoder().encodeToString(bytes);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -560,6 +560,98 @@ public class BigQueryRecordConverterTest {
     assertEquals(bigQueryExpectedRecord, bigQueryTestRecord);
   }
 
+  @Test
+  public void testValidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(kafkaConnectMap, convertedMap);
+  }
+
+  @Test (expected = ConversionConnectException.class)
+  public void testInvalidMapSchemaless() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", "f2");
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put(1, "false");
+                put("f5", true);
+                put("f6", new ArrayList<String>(){{
+                  add("hello");
+                  add("world");
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+  }
+
+  @Test
+  public void testMapSchemalessConvertDouble() {
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", Double.POSITIVE_INFINITY);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", Double.POSITIVE_INFINITY);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Double.MAX_VALUE);
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Double.MAX_VALUE);
+    assertEquals(((ArrayList)((Map)(convertedMap.get("f3"))).get("f6")).get(1), Double.MAX_VALUE);
+  }
+
+  @Test
+  public void testMapSchemalessConvertBytes() {
+    byte[] helloWorld = "helloWorld".getBytes();
+    ByteBuffer helloWorldBuffer = ByteBuffer.wrap(helloWorld);
+    Map kafkaConnectMap = new HashMap<Object, Object>(){{
+      put("f1", helloWorldBuffer);
+      put( "f3" ,
+              new HashMap<Object, Object>(){{
+                put("f4", helloWorld);
+                put("f5", true);
+                put("f6", new ArrayList<Double>(){{
+                  add(1.2);
+                  add(Double.POSITIVE_INFINITY);
+                }});
+              }}
+      );
+    }};
+
+    SinkRecord kafkaConnectRecord = spoofSinkRecord(null, kafkaConnectMap);
+    Map<String, Object> convertedMap =
+            new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE).convertRecord(kafkaConnectRecord);
+    assertEquals(convertedMap.get("f1"), Base64.getEncoder().encodeToString(helloWorld));
+    assertEquals(((Map)(convertedMap.get("f3"))).get("f4"), Base64.getEncoder().encodeToString(helloWorld));
+  }
+
   private static SinkRecord spoofSinkRecord(Schema valueSchema, Object value) {
     return new SinkRecord(null, 0, null, null, valueSchema, value, 0);
   }


### PR DESCRIPTION
* Currently the BigQueryRecordConverter throws an error when schemaless JSON data is consumed.
* JsonConverter converts JSON to map before it arrives at the BigQuery connector. Therefore, instead of throwing null pointer error, the BigQueryRecordConverter should deal with schemaless data type by converting it to legitimate format.
* Should also fix https://github.com/wepay/kafka-connect-bigquery/issues/174

This is the PR against #181 . As ConfluentInc has signed corporate CLA with WePay and @CodingParsley is currently not part of ConfluentInc hence raised separate PR. Please if we can merge same and close #181 .

@criccomini @mtagle