### PR TITLE
Resolve table name dynamically

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -125,6 +125,13 @@ public class BigQuerySinkTask extends SinkTask {
   }
 
   private PartitionedTableId getRecordTable(SinkRecord record) {
+    // Dynamically update topicToBaseTableIds mapping. topicToBaseTableIds was used to be
+    // constructed when connector starts hence new topic configuration needed connector to restart.
+    // Dynamic update shall not require connector restart and shall compute table id in runtime.
+    if (!topicsToBaseTableIds.containsKey(record.topic())) {
+      TopicToTableResolver.updateTopicToTable(config, record.topic(), topicsToBaseTableIds);
+    }
+
     TableId baseTableId = topicsToBaseTableIds.get(record.topic());
 
     PartitionedTableId.Builder builder = new PartitionedTableId.Builder(baseTableId);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -434,6 +434,22 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return matches;
   }
 
+  /**
+   * Return a String detailing which BigQuery dataset topic should write to.
+   *
+   * @param topicName The name of the topic for which dataset needs to be fetched.
+   * @return A String associating Kafka topic name to BigQuery dataset.
+   */
+  public String getTopicToDataset(String topicName) {
+    // Do not check for missing key in map as default empty map shall be returned.
+    return getSingleMatches(
+        getSinglePatterns(DATASETS_CONFIG),
+        Collections.singletonList(topicName),
+        TOPICS_CONFIG,
+        DATASETS_CONFIG
+    ).get(topicName);
+  }
+
 
   /**
    * Return a Map detailing which BigQuery dataset each topic should write to.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -7,7 +7,7 @@ public class FieldNameSanitizer {
 
   // Replace all non-letter, non-digit characters with underscore. Append underscore in front of
   // name if it does not begin with alphabet or underscore.
-  private static String sanitizeName(String name) {
+  public static String sanitizeName(String name) {
     String sanitizedName = name.replaceAll("[^a-zA-Z0-9_]", "_");
     if (sanitizedName.matches("^[^a-zA-Z_].*")) {
       sanitizedName = "_" + sanitizedName;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility class that will resolve topic names to table names based on format strings using regex
@@ -43,47 +45,55 @@ public class TopicToTableResolver {
    */
   public static Map<String, TableId> getTopicsToTables(BigQuerySinkConfig config) {
     Map<String, String> topicsToDatasets = config.getTopicsToDatasets();
-    List<Map.Entry<Pattern, String>> patterns = config.getSinglePatterns(
-        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG);
+
     List<String> topics = config.getList(BigQuerySinkConfig.TOPICS_CONFIG);
     Boolean sanitize = config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG);
+
     Map<String, TableId> matches = new HashMap<>();
     for (String value : topics) {
-      String match = null;
-      String previousPattern = null;
-      for (Map.Entry<Pattern, String> pattern : patterns) {
-        Matcher patternMatcher = pattern.getKey().matcher(value);
-        if (patternMatcher.matches()) {
-          if (match != null) {
-            String secondMatch = pattern.getKey().toString();
-            throw new ConfigException("Value '" + value
-              + "' for property '" + BigQuerySinkConfig.TOPICS_CONFIG
-              + "' matches " + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
-              + " regexes for both '" + previousPattern
-              + "' and '" + secondMatch + "'"
-            );
-          }
-          String formatString = pattern.getValue();
-          try {
-            match = patternMatcher.replaceAll(formatString);
-            previousPattern = pattern.getKey().toString();
-          } catch (IndexOutOfBoundsException err) {
-            throw new ConfigException("Format string '" + formatString
-              + "' is invalid in property '" + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
-              + "'", err);
-          }
-        }
-      }
+      String match = getTopicToTableSingleMatch(config, value);
       if (match == null) {
         match = value;
       }
+
       if (sanitize) {
-        match = sanitizeTableName(match);
+        match = FieldNameSanitizer.sanitizeName(match);
       }
+
       String dataset = topicsToDatasets.get(value);
       matches.put(value, TableId.of(dataset, match));
     }
+
     return matches;
+  }
+
+  /**
+   * Update Map detailing BigQuery table for respective topic should write to.
+   *
+   * @param config Config that contains properties used to generate the map.
+   * @param topicName The name of respective topic to map with table.
+   * @param topicToTable Map containing data for topic to respective table.
+   */
+  public static void updateTopicToTable(BigQuerySinkConfig config, String topicName,
+      Map<String, TableId> topicToTable) {
+    // Though the methods getTopicsToTable and updateTopicToTable are similar but code is not merged
+    // as they slightly operate in different way. Former fetches complete topicsToDatasets map and
+    // act on same while latter only fetches single match for dataset as required by topicName.
+    Boolean sanitize = config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG);
+    String match = getTopicToTableSingleMatch(config, topicName);
+
+    if (match == null) {
+      match = topicName;
+    }
+
+    if (sanitize) {
+      match = FieldNameSanitizer.sanitizeName(match);
+    }
+
+    String dataset = config.getTopicToDataset(topicName);
+    // Do not check for dataset being null as TableId construction shall take care of same in below
+    // line.
+    topicToTable.put(topicName, TableId.of(dataset, match));
   }
 
   /**
@@ -106,14 +116,37 @@ public class TopicToTableResolver {
     return tableIdsToTopics;
   }
 
-  /**
-   * Strips illegal characters from a table name. BigQuery only allows alpha-numeric and
-   * underscore. Everything illegal is converted to an underscore.
-   *
-   * @param tableName The table name to sanitize.
-   * @return A clean table name with only alpha-numerics and underscores.
-   */
-  private static String sanitizeTableName(String tableName) {
-    return tableName.replaceAll("[^a-zA-Z0-9_]", "_");
+  private static String getTopicToTableSingleMatch(BigQuerySinkConfig config, String topicName) {
+    String match = null;
+    String previousPattern = null;
+
+    List<Map.Entry<Pattern, String>> patterns = config.getSinglePatterns(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG);
+
+    for (Map.Entry<Pattern, String> pattern : patterns) {
+      Matcher patternMatcher = pattern.getKey().matcher(topicName);
+      if (patternMatcher.matches()) {
+        if (match != null) {
+          String secondMatch = pattern.getKey().toString();
+          throw new ConfigException("Value '" + topicName
+              + "' for property '" + BigQuerySinkConfig.TOPICS_CONFIG
+              + "' matches " + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
+              + " regexes for both '" + previousPattern
+              + "' and '" + secondMatch + "'"
+          );
+        }
+        String formatString = pattern.getValue();
+        try {
+          match = patternMatcher.replaceAll(formatString);
+          previousPattern = pattern.getKey().toString();
+        } catch (IndexOutOfBoundsException err) {
+          throw new ConfigException("Format string '" + formatString
+              + "' is invalid in property '" + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
+              + "'", err);
+        }
+      }
+    }
+
+    return match;
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -116,6 +116,13 @@ public class TopicToTableResolver {
     return tableIdsToTopics;
   }
 
+  /**
+   * Return a String specifying table corresponding to topic.
+   *
+   * @param config Config that contains properties for configured patterns.
+   * @param topicName The name of topic for which match is to be found.
+   * @return A String resulting match of table for topic name.
+   */
   private static String getTopicToTableSingleMatch(BigQuerySinkConfig config, String topicName) {
     String match = null;
     String previousPattern = null;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -18,6 +18,7 @@ package com.wepay.kafka.connect.bigquery.utils;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigquery.TableId;
 
@@ -106,6 +107,129 @@ public class TopicToTableResolverTest {
     );
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
     TopicToTableResolver.getTopicsToTables(testConfig);
+  }
+
+  @Test
+  public void testUpdateTopicToTable() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_CONFIG,
+        "sanitize-me,db_debezium_identity_profiles_info.foo,db.core.cluster-0.users"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3"
+    );
+    Map<String, TableId> topicsToTables = new HashMap<>();
+    topicsToTables.put("sanitize-me", TableId.of("scratch", "sanitize_me"));
+    topicsToTables.put("db_debezium_identity_profiles_info.foo",
+        TableId.of("scratch", "info_foo"));
+    topicsToTables.put("db.core.cluster-0.users", TableId.of("scratch", "core_users"));
+
+    String testTopicName = "new_topic";
+    // Create shallow copy of map, deep copy not needed.
+    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", testTopicName));
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+
+    assertEquals(expectedTopicsToTables, topicsToTables);
+  }
+
+  @Test
+  public void testUpdateTopicToTableWithTableSanitization() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3"
+    );
+
+    String testTopicName = "1new.topic";
+    Map<String, TableId> topicsToTables = new HashMap<>();
+    // Create shallow copy of map, deep copy not needed.
+    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", "_1new_topic"));
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+
+    assertEquals(expectedTopicsToTables, topicsToTables);
+  }
+
+  @Test
+  public void testUpdateTopicToTableWithRegex() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3,new_topic_(.*)=$1"
+    );
+
+    String testTopicName = "new_topic_abc.def";
+    Map<String, TableId> topicsToTables = new HashMap<>();
+    // Create shallow copy of map, deep copy not needed.
+    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", "abc_def"));
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+
+    assertEquals(expectedTopicsToTables, topicsToTables);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testUpdateTopicToTableWithInvalidRegex() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        ".*=$1"
+    );
+
+    String testTopicName = "new_topic_abc.def";
+    Map<String, TableId> topicsToTables = new HashMap<>();
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testUpdateTopicToTableWithMultipleMatches() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "(.*)=$1,new_topic_(.*)=$1"
+    );
+
+    String testTopicName = "new_topic_abc.def";
+    Map<String, TableId> topicsToTables = new HashMap<>();
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
   }
 
   @Test


### PR DESCRIPTION
Currently the table lookup map for BigQuery is constructed when connector starts. Added dynamic update of map in case new topic is being configured.

This is the PR against #184. As ConfluentInc has signed corporate CLA with WePay and @CodingParsley is currently not part of ConfluentInc hence raised separate PR. Please if we can merge same and close #184.

Also this PR is on top of child PR #187

@criccomini @mtagle @bingqinzhou