### PR TITLE
Log errors encountered when writing batches

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -81,6 +81,7 @@ public class TableWriter implements Runnable {
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
+          logger.debug("Could not write batch of size {} to BigQuery.", currentBatch.size(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
             currentBatchSize = getNewBatchSize(currentBatchSize);


### PR DESCRIPTION
We run into the following error with the BigQuery connector

```
org.apache.kafka.connect.errors.ConnectException: Attempted to reduce batch size below 1.
    at com.wepay.kafka.connect.bigquery.write.batch.TableWriter.getNewBatchSize(TableWriter.java:106)
```
It is not clear if the problem was that the original set of records was too few, or there were problems writing batches to BigQuery and the connector retried because it misinterpreted the error codes [here](https://github.com/wepay/kafka-connect-bigquery/blob/1.2.0/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java#L83-L87).  

Adding this log message should give us some more context on what went wrong. 

Signed-off-by: Arjun Satish <arjun@confluent.io>