### PR TITLE
Initial commit/foundation to support connect record schema retriever

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -46,7 +46,7 @@ public class TableWriter implements Runnable {
 
   private final BigQueryWriter writer;
   private final PartitionedTableId table;
-  private final List<RowToInsert> rows;
+  private final List<SinkRecord> rows;
   private final String topic;
 
   /**
@@ -57,7 +57,7 @@ public class TableWriter implements Runnable {
    */
   public TableWriter(BigQueryWriter writer,
                      PartitionedTableId table,
-                     List<RowToInsert> rows,
+                     List<SinkRecord> rows,
                      String topic) {
     this.writer = writer;
     this.table = table;
@@ -74,7 +74,7 @@ public class TableWriter implements Runnable {
 
     try {
       while (currentIndex < rows.size()) {
-        List<RowToInsert> currentBatch =
+        List<SinkRecord> currentBatch =
             rows.subList(currentIndex, Math.min(currentIndex + currentBatchSize, rows.size()));
         try {
           writer.writeRows(table, currentBatch, topic);
@@ -149,7 +149,7 @@ public class TableWriter implements Runnable {
     private final PartitionedTableId table;
     private final String topic;
 
-    private List<RowToInsert> rows;
+    private List<SinkRecord> rows;
 
     private RecordConverter<Map<String, Object>> recordConverter;
 
@@ -174,7 +174,7 @@ public class TableWriter implements Runnable {
      * Add a record to the builder.
      * @param rowToInsert the row to add
      */
-    public void addRow(RowToInsert rowToInsert) {
+    public void addRow(SinkRecord rowToInsert) {
       rows.add(rowToInsert);
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
@@ -18,7 +18,7 @@ package com.wepay.kafka.connect.bigquery.write.batch;
  */
 
 
-import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
  * Interface for building a {@link TableWriter} or TableWriterGCS.
@@ -27,9 +27,9 @@ public interface TableWriterBuilder {
 
   /**
    * Add a record to the builder.
-   * @param rowToInsert the row to add.
+   * @param record The SinkRecord containing data to be persisted.
    */
-  void addRow(RowToInsert rowToInsert);
+  void addRow(SinkRecord record);
 
   /**
    * Create a {@link TableWriter} from this builder.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -24,8 +24,11 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,8 +50,9 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait) {
-    super(retry, retryWait);
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait,
+      RecordConverter<Map<String, Object>> recordConverter, boolean sanitizeData) {
+    super(retry, retryWait, recordConverter, sanitizeData);
     this.bigQuery = bigQuery;
   }
 
@@ -59,7 +63,7 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    */
   @Override
   public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
-                                                            List<InsertAllRequest.RowToInsert> rows,
+                                                            List<SinkRecord> rows,
                                                             String topic) {
     InsertAllRequest request = createInsertAllRequest(tableId, rows);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);


### PR DESCRIPTION
Support for json based topics has already been fixed under https://github.com/wepay/kafka-connect-bigquery/issues/174 though `autoUpdateSchemas` and `autoCreateTables` cannot be supported unless we have different schema retriever (other than using `schemaRegistry`).

To support `ConnectRecord` based schema retriever we need to use `ConnectRecord.valueSchema` hence this PR builds the foundation to support same.

Another issue which highlights the requirement for this behaviour https://github.com/wepay/kafka-connect-bigquery/issues/86.

@criccomini @mtagle @C0urante Please review.

In subsequent PR I shall go forward and implement connect record schema retriever.