### PR TITLE
updating confluent version to enable hosted SR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ project.ext {
     googleCloudVersion = '1.79.0'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
-    ioConfluentVersion = '5.1.1'
+    ioConfluentVersion = '5.3.1'
     junitVersion = '4.12'
     kafkaVersion = '1.1.1'
     mockitoVersion = '1.10.19'


### PR DESCRIPTION
see https://github.com/wepay/kafka-connect-bigquery/issues/208

Issue: when using confluent cloud hosted schema registry users are getting the following error:

Caused by: io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Unauthorized; error code: 401

The reason for this is an old version used:

https://github.com/wepay/kafka-connect-bigquery/blob/1.2.0/build.gradle#L15

    ioConfluentVersion = '5.1.1'

In the above version we didn't have the basic auth to the Schema registry, with this in mind the REST call will drop the authentication method and we will forever get error code 401.

To resolve this, you can recompile the code using the README steps, with simply using 5.3.1 in the file mentioned above.

To fix this we should PR a higher version to the above code.