### PR TITLE
CC-7246: add ability to partition based on timestamp of a record value field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ project.ext {
     apacheHttpClientVersion = '4.5.6'
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
-    googleCloudVersion = '1.79.0'
+    googleCloudVersion = '1.101.0'
     googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.1.1'

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -102,7 +102,10 @@ public class BigQuerySinkConnector extends SinkConnector {
     }
     SchemaRetriever schemaRetriever = config.getSchemaRetriever();
     SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter = config.getSchemaConverter();
-    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery);
+    return new SchemaManager(schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        config.getTimestampPartitionFieldName());
   }
 
   private void ensureExistingTables(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -155,6 +155,12 @@ public class BigQuerySinkTask extends SinkTask {
       convertedRecord = FieldNameSanitizer.replaceInvalidKeys(convertedRecord);
     }
 
+    if (config.useTimestampPartitioning()) {
+      if (!convertedRecord.containsKey(config.getTimestampPartitionFieldName())) {
+        logger.warn("Record does not contain the timestamp partitioning field name");
+      }
+    }
+
     return RowToInsert.of(getRowId(record), convertedRecord);
   }
 
@@ -241,7 +247,10 @@ public class BigQuerySinkTask extends SinkTask {
     schemaRetriever = config.getSchemaRetriever();
     SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter =
         config.getSchemaConverter();
-    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery);
+    return new SchemaManager(schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        config.getTimestampPartitionFieldName());
   }
 
   private BigQueryWriter getBigQueryWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -41,7 +41,9 @@ public class SchemaManager {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
-    this.timestampPartitionFieldName = timestampPartitionFieldName;
+    this.timestampPartitionFieldName = timestampPartitionFieldName == null
+        ? ""
+        : timestampPartitionFieldName;
   }
 
   /**
@@ -73,7 +75,7 @@ public class SchemaManager {
         schemaConverter.convertSchema(kafkaConnectSchema);
 
     TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
-    if (timestampPartitionFieldName != null || !timestampPartitionFieldName.isEmpty()) {
+    if (!timestampPartitionFieldName.isEmpty()) {
       // timestamp based partitioning vs ingestion time partitioning
       timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName).build();
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -6,11 +6,12 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 
+import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
-import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,20 +24,24 @@ public class SchemaManager {
   private final SchemaRetriever schemaRetriever;
   private final SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter;
   private final BigQuery bigQuery;
+  private final String timestampPartitionFieldName;
 
   /**
    * @param schemaRetriever Used to determine the Kafka Connect Schema that should be used for a
    *                        given table.
    * @param schemaConverter Used to convert Kafka Connect Schemas into BigQuery format.
    * @param bigQuery Used to communicate create/update requests to BigQuery.
+   * @param timestampPartitionFieldName the column name to use for timestamp partitioning.
    */
   public SchemaManager(
       SchemaRetriever schemaRetriever,
       SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter,
-      BigQuery bigQuery) {
+      BigQuery bigQuery,
+      String timestampPartitionFieldName) {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
+    this.timestampPartitionFieldName = timestampPartitionFieldName;
   }
 
   /**
@@ -66,9 +71,16 @@ public class SchemaManager {
   TableInfo constructTableInfo(TableId table, Schema kafkaConnectSchema) {
     com.google.cloud.bigquery.Schema bigQuerySchema =
         schemaConverter.convertSchema(kafkaConnectSchema);
+
+    TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
+    if (timestampPartitionFieldName != null || !timestampPartitionFieldName.isEmpty()) {
+      // timestamp based partitioning vs ingestion time partitioning
+      timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName).build();
+    }
+
     StandardTableDefinition tableDefinition = StandardTableDefinition.newBuilder()
         .setSchema(bigQuerySchema)
-        .setTimePartitioning(TimePartitioning.of(TimePartitioning.Type.DAY))
+        .setTimePartitioning(timePartitioning)
         .build();
     TableInfo.Builder tableInfoBuilder =
         TableInfo.newBuilder(table, tableDefinition);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -52,7 +52,8 @@ public class SchemaManagerTest {
 
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever,
                                                     mockSchemaConverter,
-                                                    mockBigQuery);
+                                                    mockBigQuery,
+                                                    "");
 
     Schema mockKafkaSchema = mock(Schema.class);
     // we would prefer to mock this class, but it is final.

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -19,6 +19,7 @@ package com.wepay.kafka.connect.bigquery.config;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -93,6 +94,27 @@ public class BigQuerySinkConfigTest {
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
 
     assertTrue(testConfig.getRecordConverter() instanceof KafkaDataBQRecordConverter);
+  }
+
+  @Test
+  public void testEmptyTimestampPartitionFieldName() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+
+    assertFalse(testConfig.useTimestampPartitioning());
+    assertTrue(testConfig.getTimestampPartitionFieldName().isEmpty());
+  }
+
+  @Test
+  public void testTimestampPartitionFieldName() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.TIMESTAMP_PARTITION_FIELD_NAME_CONFIG, "name");
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+
+    assertTrue(testConfig.useTimestampPartitioning());
+    assertEquals("name", testConfig.getTimestampPartitionFieldName());
   }
 
   @Test(expected = ConfigException.class)


### PR DESCRIPTION
implements this behavior:
https://cloud.google.com/bigquery/docs/partitioned-tables#date_timestamp_partitioned_tables

TLDR: BigQuery can partition based off a column that contains a timestamp, so by just passing a field in the struct to BigQuery, it will specify which column to partition by.

Signed-off-by: Lev Zemlyanov <lev@confluent.io>