### PR TITLE
Use batch delete operation when cleaning up blob ids

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -283,8 +283,11 @@ public class GCSToBQLoadRunnable implements Runnable {
       for (int i = 0; i < numberOfBlobs; i++) {
         if (!resultList.get(i)) {
           // This blob was not successful, remove it from the list.
+          // Adjust the target index by the number of failed deletes we've
+          // already seen since we're mutating the list as we go.
+          int targetIndex = i - failedDeletes;
+          blobIdsToDelete.remove(targetIndex);
           failedDeletes++;
-          blobIdsToDelete.remove(i);
         }
       }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -268,6 +268,11 @@ public class GCSToBQLoadRunnable implements Runnable {
     long failedDeletes = 0;
     long successfulDeletes = 0;
 
+    if (numberOfBlobs == 0) {
+      logger.info("No blobs to delete");
+      return;
+    }
+
     logger.info("Attempting to delete {} blobs", numberOfBlobs);
 
     try {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -275,8 +275,8 @@ public class GCSToBQLoadRunnable implements Runnable {
       List<Boolean> resultList = bucket.getStorage().delete(blobIdsToDelete);
 
       // Filter the blobs we couldn't delete from the list of deletable blobs
-      for (i = 0; i < blobIdsToDelete.length; i++) {
-        if (!resultList[i]) {
+      for (int i = 0; i < numberOfBlobs; i++) {
+        if (!resultList.get(i)) {
           // This blob was not successful, remove it from the list.
           failedDeletes++;
           blobIdsToDelete.remove(i);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -265,8 +265,8 @@ public class GCSToBQLoadRunnable implements Runnable {
     List<BlobId> blobIdsToDelete = new ArrayList<>();
     blobIdsToDelete.addAll(deletableBlobIds);
     int numberOfBlobs = blobIdsToDelete.size();
-    long failedDeletes = 0;
-    long successfulDeletes = 0;
+    int failedDeletes = 0;
+    int successfulDeletes = 0;
 
     if (numberOfBlobs == 0) {
       logger.info("No blobs to delete");


### PR DESCRIPTION
When we have a high number of blobs to delete from GCS (e.g. 10k) we're seeing the BQ Connector's batch load feature take upward of a half hour to delete all the blobs. Even with as few as 300 we can see delays of up to 60s.

This change significantly reduces the overhead involved by using the batch delete storage API to delete the blobs. In early testing I'm able to remove 500+ blobs in 3s, which is a significant improvement. This code preserves the same behavior previously with respect to the `deletableBlobIds` variable.