### PR TITLE
Add support for handling empty schemas and records

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -178,12 +178,17 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
     List<Field> kafkaConnectSchemaFields = kafkaConnectSchema.fields();
     Struct kafkaConnectStruct = (Struct) kafkaConnectObject;
     for (Field kafkaConnectField : kafkaConnectSchemaFields) {
-      Object bigQueryObject = convertObject(
-          kafkaConnectStruct.get(kafkaConnectField.name()),
-          kafkaConnectField.schema()
-      );
-      if (bigQueryObject != null) {
-        bigQueryRecord.put(kafkaConnectField.name(), bigQueryObject);
+      // ignore empty structures
+      boolean isEmptyStruct = kafkaConnectField.schema().type() == Schema.Type.STRUCT &&
+          kafkaConnectField.schema().fields().isEmpty();
+      if (!isEmptyStruct) {
+        Object bigQueryObject = convertObject(
+            kafkaConnectStruct.get(kafkaConnectField.name()),
+            kafkaConnectField.schema()
+        );
+        if (bigQueryObject != null) {
+          bigQueryRecord.put(kafkaConnectField.name(), bigQueryObject);
+        }
       }
     }
     return bigQueryRecord;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverterTest.java
@@ -314,6 +314,56 @@ public class BigQueryRecordConverterTest {
   }
 
   @Test
+  public void testEmptyStruct() {
+    Schema kafkaConnectInnerSchema = SchemaBuilder
+        .struct()
+        .build();
+
+    Struct kafkaConnectInnerStruct = new Struct(kafkaConnectInnerSchema);
+
+    SinkRecord kafkaConnectSinkRecord =
+        spoofSinkRecord(kafkaConnectInnerSchema, kafkaConnectInnerStruct, false);
+    Map<String, Object> bigQueryTestInnerRecord =
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE)
+            .convertRecord(kafkaConnectSinkRecord, KafkaSchemaRecordType.VALUE);
+    assertEquals(new HashMap<String, Object>(), bigQueryTestInnerRecord);
+  }
+
+  @Test
+  public void testEmptyInnerStruct() {
+    final String innerFieldStructName = "InnerStruct";
+    final String innerFieldStringName = "InnerString";
+    final String innerStringValue = "forty two";
+
+    Schema kafkaConnectInnerSchema = SchemaBuilder
+        .struct()
+        .build();
+
+    Struct kafkaConnectInnerStruct = new Struct(kafkaConnectInnerSchema);
+
+    Schema kafkaConnectOuterSchema = SchemaBuilder
+        .struct()
+        .field(innerFieldStructName, kafkaConnectInnerSchema)
+        .field(innerFieldStringName, Schema.STRING_SCHEMA)
+        .build();
+
+    Struct kafkaConnectOuterStruct = new Struct(kafkaConnectOuterSchema);
+    kafkaConnectOuterStruct.put(innerFieldStructName, kafkaConnectInnerStruct);
+    kafkaConnectOuterStruct.put(innerFieldStringName, innerStringValue);
+
+    Map<String, Object> bigQueryExpectedOuterRecord = new HashMap<>();
+    bigQueryExpectedOuterRecord.put(innerFieldStringName, innerStringValue);
+
+    SinkRecord kafkaConnectOuterSinkRecord =
+        spoofSinkRecord(kafkaConnectOuterSchema, kafkaConnectOuterStruct, false);
+    Map<String, Object> bigQueryTestOuterRecord =
+        new BigQueryRecordConverter(SHOULD_CONVERT_DOUBLE)
+            .convertRecord(kafkaConnectOuterSinkRecord, KafkaSchemaRecordType.VALUE);
+
+    assertEquals(bigQueryExpectedOuterRecord, bigQueryTestOuterRecord);
+  }
+
+  @Test
   public void testMap() {
     final String fieldName = "StringIntegerMap";
     final Map<Integer, Boolean> fieldValueKafkaConnect = new HashMap<>();

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -276,6 +276,61 @@ public class BigQuerySchemaConverterTest {
   }
 
   @Test
+  public void testEmptyStruct() { // Empty struct
+    com.google.cloud.bigquery.Schema bigQueryTestOuterSchema =
+        new BigQuerySchemaConverter(false).convertSchema(
+            SchemaBuilder
+                .struct()
+                .build()
+        );
+    assertEquals(com.google.cloud.bigquery.Schema.of(), bigQueryTestOuterSchema);
+  }
+
+  @Test
+  public void testEmptyInnerStruct() { // Empty nested struct
+    final String outerFieldStructName = "OuterStruct";
+    final String innerFieldStructName = "InnerStruct";
+    final String innerFieldStringName = "InnerString";
+
+    Schema kafkaConnectInnerSchema = SchemaBuilder
+        .struct()
+        .build();
+
+    com.google.cloud.bigquery.Field bigQueryInnerString = com.google.cloud.bigquery.Field.newBuilder(
+        innerFieldStringName,
+        LegacySQLTypeName.STRING
+    ).setMode(
+        com.google.cloud.bigquery.Field.Mode.REQUIRED
+    ).build();
+
+    com.google.cloud.bigquery.Field bigQueryOuterRecord =
+        com.google.cloud.bigquery.Field.newBuilder(
+            outerFieldStructName,
+            LegacySQLTypeName.RECORD,
+            bigQueryInnerString
+        ).setMode(
+            com.google.cloud.bigquery.Field.Mode.REQUIRED
+        ).build();
+
+    Schema kafkaConnectOuterSchema = SchemaBuilder
+        .struct()
+        .field(innerFieldStructName, kafkaConnectInnerSchema)
+        .field(innerFieldStringName, Schema.STRING_SCHEMA)
+        .build();
+
+    com.google.cloud.bigquery.Schema bigQueryExpectedOuterSchema =
+        com.google.cloud.bigquery.Schema.of(bigQueryOuterRecord);
+    com.google.cloud.bigquery.Schema bigQueryTestOuterSchema =
+        new BigQuerySchemaConverter(false).convertSchema(
+            SchemaBuilder
+                .struct()
+                .field(outerFieldStructName, kafkaConnectOuterSchema)
+                .build()
+        );
+    assertEquals(bigQueryExpectedOuterSchema, bigQueryTestOuterSchema);
+  }
+
+  @Test
   public void testMap() {
     final String fieldName = "StringIntegerMap";
     final String keyName = BigQuerySchemaConverter.MAP_KEY_FIELD_NAME;


### PR DESCRIPTION
Sometimes record types contain fields of type that do not have any fields defined (null objects, marker classes etc.).
Converters must omit them since it's impossible to map empty structures into BigQuery table schema and rows.

This is the first of PRs derived from #219 