### PR TITLE
Add support for topics with multiple schemas

### DIFF
--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -4,7 +4,9 @@ import com.google.cloud.bigquery.TableId;
 
 import org.apache.kafka.connect.data.Schema;
 
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Interface for retrieving the most up-to-date schemas for a given BigQuery table. Used in
@@ -21,17 +23,19 @@ public interface SchemaRetriever {
   /**
    * Retrieve the most current schema for the given topic.
    * @param table The table that will be created.
-   * @param topic The topic to retrieve a schema for.
+   * @param topicAndRecordName The topic and an optional record name to retrieve a schema for.
    * @param schemaType The type of kafka schema, either "value" or "key".
    * @return The Schema for the given table.
    */
-  public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType);
+  public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType);
+
+  Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases);
 
   /**
    * Set the last seen schema for a given topic
    * @param table The table that will be created.
-   * @param topic The topic to retrieve a schema for.
+   * @param topicAndRecordName The topic and an optional record name to retrieve a schema for.
    * @param schema The last seen Kafka Connect Schema
    */
-  public void setLastSeenSchema(TableId table, String topic, Schema schema);
+  public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema);
 }

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -18,7 +18,7 @@ public interface SchemaRetriever {
    * {@link org.apache.kafka.connect.sink.SinkConnector#start(Map)} method.
    * @param properties The configuration settings of the connector.
    */
-  public void configure(Map<String, String> properties);
+  void configure(Map<String, String> properties);
 
   /**
    * Retrieve the most current schema for the given topic.
@@ -27,8 +27,14 @@ public interface SchemaRetriever {
    * @param schemaType The type of kafka schema, either "value" or "key".
    * @return The Schema for the given table.
    */
-  public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType);
+  Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType);
 
+  /**
+   * Retrieve the most current schemas that match the configured topics and records.
+   * @param topics The list of a supported topics.
+   * @param recordAliases The map containing record name patterns and their aliases.
+   * @return the most current schemas that match the configured topics and records.
+   */
   Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases);
 
   /**
@@ -37,5 +43,5 @@ public interface SchemaRetriever {
    * @param topicAndRecordName The topic and an optional record name to retrieve a schema for.
    * @param schema The last seen Kafka Connect Schema
    */
-  public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema);
+  void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema);
 }

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -4,9 +4,7 @@ import com.google.cloud.bigquery.TableId;
 
 import org.apache.kafka.connect.data.Schema;
 
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * Interface for retrieving the most up-to-date schemas for a given BigQuery table. Used in
@@ -28,14 +26,6 @@ public interface SchemaRetriever {
    * @return The Schema for the given table.
    */
   Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType);
-
-  /**
-   * Retrieve the most current schemas that match the configured topics and records.
-   * @param topics The list of a supported topics.
-   * @param recordAliases The map containing record name patterns and their aliases.
-   * @return the most current schemas that match the configured topics and records.
-   */
-  Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases);
 
   /**
    * Set the last seen schema for a given topic

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
@@ -64,37 +64,6 @@ public class TopicAndRecordName {
     return Optional.ofNullable(this.recordName);
   }
 
-  /**
-   * Convert topic and record name into the schema registry subject.
-   * Subjects follow topic-recordName format.
-   *
-   * If recordName is not present, "value" will be used.
-   *
-   * @return corresponding schema registry subject.
-   */
-  public String toSubject() {
-    return toSubject(KafkaSchemaRecordType.VALUE);
-  }
-
-  /**
-   * Convert topic and record name into the schema registry subject.
-   * Subjects follow topic-recordName format.
-   *
-   * If recordName is not present, "value" or "key" will be used, depending on the schema type.
-   *
-   * @param schemaType schema type used to resolve full subject when recordName is absent.
-   * @return corresponding schema registry subject.
-   */
-  public String toSubject(KafkaSchemaRecordType schemaType) {
-    String subject = topic;
-    if (recordName == null) {
-      subject += "-" + schemaType.toString();
-    } else {
-      subject += "-" + recordName;
-    }
-    return subject;
-  }
-
   @Override
   public String toString() {
     return topic + "/" + recordName;

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
@@ -1,0 +1,70 @@
+package com.wepay.kafka.connect.bigquery.api;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class TopicAndRecordName {
+  private final String topic;
+  private final String recordName;
+
+  public static TopicAndRecordName from(String topic) {
+    return new TopicAndRecordName(topic, null);
+  }
+
+  public static TopicAndRecordName from(String topic, String recordName) {
+    return new TopicAndRecordName(topic, recordName);
+  }
+
+  public static TopicAndRecordName from(SinkRecord record, boolean includeRecordName) {
+    String maybeRecordName = includeRecordName ? record.valueSchema().name() : null;
+    return from(record.topic(), maybeRecordName);
+  }
+
+  public TopicAndRecordName(String topic, String recordName) {
+    this.topic = topic;
+    this.recordName = recordName;
+  }
+
+  public String getTopic() {
+    return this.topic;
+  }
+
+  public Optional<String> getRecordName() {
+    return Optional.ofNullable(this.recordName);
+  }
+
+  public String toSubject() {
+    return toSubject(KafkaSchemaRecordType.VALUE);
+  }
+
+  public String toSubject(KafkaSchemaRecordType schemaType) {
+    String subject = topic;
+    if (recordName == null) {
+      subject += "-" + schemaType.toString();
+    } else {
+      subject += "-" + recordName;
+    }
+    return subject;
+  }
+
+  @Override
+  public String toString() {
+    return topic + "/" + recordName;
+  }
+
+  @Override
+  public int hashCode() {
+    return this.topic.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof TopicAndRecordName) {
+      TopicAndRecordName that = (TopicAndRecordName) obj;
+      return Objects.equals(getTopic(), that.getTopic()) && Objects.equals(getRecordName(), that.getRecordName());
+    }
+    return false;
+  }
+}

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/TopicAndRecordName.java
@@ -5,23 +5,52 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * A container class with separate topic and (optional) record names.
+ */
 public class TopicAndRecordName {
   private final String topic;
   private final String recordName;
 
+  /**
+   * Convenience method for creating a new {@link TopicAndRecordName} with empty record name.
+   *
+   * @param topic the topic.
+   * @return a new {@link TopicAndRecordName} with empty record name.
+   */
   public static TopicAndRecordName from(String topic) {
     return new TopicAndRecordName(topic, null);
   }
 
+  /**
+   * Convenience method for creating a new {@link TopicAndRecordName}.
+   *
+   * @param topic the topic.
+   * @param recordName the record name.
+   * @return a new {@link TopicAndRecordName}.
+   */
   public static TopicAndRecordName from(String topic, String recordName) {
     return new TopicAndRecordName(topic, recordName);
   }
 
+  /**
+   * Convenience method for creating a new {@link TopicAndRecordName} from {@link SinkRecord}.
+   *
+   * @param record the record used to extract topic and (optionally) record name.
+   * @param includeRecordName whether or not to include the record name.
+   * @return a new {@link TopicAndRecordName}.
+   */
   public static TopicAndRecordName from(SinkRecord record, boolean includeRecordName) {
     String maybeRecordName = includeRecordName ? record.valueSchema().name() : null;
     return from(record.topic(), maybeRecordName);
   }
 
+  /**
+   * Create a new {@link TopicAndRecordName}.
+   *
+   * @param topic the topic
+   * @param recordName the record name
+   */
   public TopicAndRecordName(String topic, String recordName) {
     this.topic = topic;
     this.recordName = recordName;
@@ -35,10 +64,27 @@ public class TopicAndRecordName {
     return Optional.ofNullable(this.recordName);
   }
 
+  /**
+   * Convert topic and record name into the schema registry subject.
+   * Subjects follow topic-recordName format.
+   *
+   * If recordName is not present, "value" will be used.
+   *
+   * @return corresponding schema registry subject.
+   */
   public String toSubject() {
     return toSubject(KafkaSchemaRecordType.VALUE);
   }
 
+  /**
+   * Convert topic and record name into the schema registry subject.
+   * Subjects follow topic-recordName format.
+   *
+   * If recordName is not present, "value" or "key" will be used, depending on the schema type.
+   *
+   * @param schemaType schema type used to resolve full subject when recordName is absent.
+   * @return corresponding schema registry subject.
+   */
   public String toSubject(KafkaSchemaRecordType schemaType) {
     String subject = topic;
     if (recordName == null) {
@@ -56,7 +102,7 @@ public class TopicAndRecordName {
 
   @Override
   public int hashCode() {
-    return this.topic.hashCode();
+    return Objects.hashCode(this.topic) + Objects.hashCode(this.recordName);
   }
 
   @Override

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -65,7 +65,7 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
   @Override
   public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
     String topic = topicAndRecordName.getTopic();
-    String subject = topicAndRecordName.toSubject(schemaType);
+    String subject = getSubject(topicAndRecordName, schemaType);
     logger.debug("Retrieving schema information for topic {} with subject {} and schema type {}", topic, subject, schemaType);
     try {
       SchemaMetadata latestSchemaMetadata = schemaRegistryClient.getLatestSchemaMetadata(subject);
@@ -82,6 +82,21 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
 
   @Override
   public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema) {
+  }
+
+  /**
+   * Convert topic and record name into the schema registry subject.
+   * Subjects follow topic-recordName format.
+   *
+   * If recordName is not present, "value" or "key" will be used, depending on the schema type.
+   *
+   * @param schemaType schema type used to resolve full subject when recordName is absent.
+   * @return corresponding schema registry subject.
+   */
+  private String getSubject(TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) {
+    String topic = topicAndRecordName.getTopic();
+    String subjectPostfix = topicAndRecordName.getRecordName().orElseGet(schemaType::toString);
+    return topic + "-" + subjectPostfix;
   }
 
 }

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -24,14 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.
@@ -74,22 +67,6 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
     return retrieveSchema(topicAndRecordName, schemaType);
   }
 
-  @Override
-  public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) throws ConnectException {
-    Map<String, TopicAndRecordName> matchingSubjects = getSubjects(topics, recordAliases);
-    return matchingSubjects.values().stream()
-        .map(topicAndRecordName -> new AbstractMap.SimpleEntry<>(topicAndRecordName, retrieveSchema(topicAndRecordName, KafkaSchemaRecordType.VALUE)))
-        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
-  }
-
-  private boolean subjectMatchesRegex(String subject, Pattern regex, String topic) {
-    if (!subject.startsWith(topic)) {
-      return false;
-    }
-    String recordName = String.join(topic, Arrays.stream(subject.split(topic + "-")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toSet()));
-    return regex.matcher(recordName).matches();
-  }
-
   private Schema retrieveSchema(TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
     String topic = topicAndRecordName.getTopic();
     String subject = topicAndRecordName.toSubject(schemaType);
@@ -111,30 +88,4 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
   public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema) {
   }
 
-  private Map<String, TopicAndRecordName> getSubjects(List<String> topics, Map<Pattern, String> recordAliases) {
-    Collection<String> subjects;
-    try {
-      subjects = schemaRegistryClient.getAllSubjects();
-    } catch (IOException | RestClientException exception) {
-      throw new ConnectException("Exception while fetching subjects", exception);
-    }
-    Set<Pattern> recordNamePatterns = recordAliases.keySet();
-    return topics.stream().flatMap(topic ->
-        subjects.stream().filter(subject ->
-            recordNamePatterns.stream()
-                .anyMatch(pattern -> subjectMatchesRegex(subject, pattern, topic))
-        ).map(matchingSubject -> new AbstractMap.SimpleEntry<>(matchingSubject, extractTopicAndRecord(topic, matchingSubject)))
-    ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
-  }
-
-  private TopicAndRecordName extractTopicAndRecord(String topic, String subject) {
-    String recordName = subject;
-    if (subject.startsWith(topic)) {
-      recordName = subject.split(Pattern.quote(topic + "-"), 2)[1];
-    }
-    if (recordName.equals("value")) {
-      return TopicAndRecordName.from(topic);
-    }
-    return TopicAndRecordName.from(topic, recordName);
-  }
 }

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -5,6 +5,7 @@ import com.google.cloud.bigquery.TableId;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import io.confluent.connect.avro.AvroData;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
@@ -23,7 +24,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.
@@ -62,10 +70,31 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
   }
 
   @Override
-  public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType) {
-    String subject = getSubject(topic, schemaType);
+  public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
+    return retrieveSchema(topicAndRecordName, schemaType);
+  }
+
+  @Override
+  public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) throws ConnectException {
+    Map<String, TopicAndRecordName> matchingSubjects = getSubjects(topics, recordAliases);
+    return matchingSubjects.values().stream()
+        .map(topicAndRecordName -> new AbstractMap.SimpleEntry<>(topicAndRecordName, retrieveSchema(topicAndRecordName, KafkaSchemaRecordType.VALUE)))
+        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+  }
+
+  private boolean subjectMatchesRegex(String subject, Pattern regex, String topic) {
+    if (!subject.startsWith(topic)) {
+      return false;
+    }
+    String recordName = String.join(topic, Arrays.stream(subject.split(topic + "-")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toSet()));
+    return regex.matcher(recordName).matches();
+  }
+
+  private Schema retrieveSchema(TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
+    String topic = topicAndRecordName.getTopic();
+    String subject = topicAndRecordName.toSubject(schemaType);
+    logger.debug("Retrieving schema information for topic {} with subject {} and schema type {}", topic, subject, schemaType);
     try {
-      logger.debug("Retrieving schema information for topic {} with subject {}", topic, subject);
       SchemaMetadata latestSchemaMetadata = schemaRegistryClient.getLatestSchemaMetadata(subject);
       org.apache.avro.Schema avroSchema = new Parser().parse(latestSchemaMetadata.getSchema());
       return avroData.toConnectSchema(avroSchema);
@@ -79,9 +108,33 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
   }
 
   @Override
-  public void setLastSeenSchema(TableId table, String topic, Schema schema) { }
+  public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema) {
+  }
 
-  private String getSubject(String topic, KafkaSchemaRecordType schemaType) {
-    return topic + "-" + schemaType.toString();
+  private Map<String, TopicAndRecordName> getSubjects(List<String> topics, Map<Pattern, String> recordAliases) {
+    Collection<String> subjects;
+    try {
+      subjects = schemaRegistryClient.getAllSubjects();
+    } catch (IOException | RestClientException exception) {
+      throw new ConnectException("Exception while fetching subjects", exception);
+    }
+    Set<Pattern> recordNamePatterns = recordAliases.keySet();
+    return topics.stream().flatMap(topic ->
+        subjects.stream().filter(subject ->
+            recordNamePatterns.stream()
+                .anyMatch(pattern -> subjectMatchesRegex(subject, pattern, topic))
+        ).map(matchingSubject -> new AbstractMap.SimpleEntry<>(matchingSubject, extractTopicAndRecord(topic, matchingSubject)))
+    ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+  }
+
+  private TopicAndRecordName extractTopicAndRecord(String topic, String subject) {
+    String recordName = subject;
+    if (subject.startsWith(topic)) {
+      recordName = subject.split(Pattern.quote(topic + "-"), 2)[1];
+    }
+    if (recordName.equals("value")) {
+      return TopicAndRecordName.from(topic);
+    }
+    return TopicAndRecordName.from(topic, recordName);
   }
 }

--- a/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
+++ b/kcbq-confluent/src/main/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetriever.java
@@ -64,10 +64,6 @@ public class SchemaRegistrySchemaRetriever implements SchemaRetriever {
 
   @Override
   public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
-    return retrieveSchema(topicAndRecordName, schemaType);
-  }
-
-  private Schema retrieveSchema(TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) throws ConnectException {
     String topic = topicAndRecordName.getTopic();
     String subject = topicAndRecordName.toSubject(schemaType);
     logger.debug("Retrieving schema information for topic {} with subject {} and schema type {}", topic, subject, schemaType);

--- a/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
+++ b/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
@@ -1,12 +1,19 @@
 package com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.TableId;
 
+import com.google.common.collect.Sets;
+
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import io.confluent.connect.avro.AvroData;
 
@@ -18,32 +25,91 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 
 import org.junit.Test;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class SchemaRegistrySchemaRetrieverTest {
   @Test
   public void testRetrieveSchema() throws Exception {
     final TableId table = TableId.of("test", "kafka_topic");
     final String testTopic = "kafka-topic";
-    final String testSubjectValue = "kafka-topic-value";
-    final String testSubjectKey = "kafka-topic-key";
-    final String testAvroSchemaString =
-        "{\"type\": \"record\", "
-        + "\"name\": \"testrecord\", "
-        + "\"fields\": [{\"name\": \"f1\", \"type\": \"string\"}]}";
-    final SchemaMetadata testSchemaMetadata = new SchemaMetadata(1, 1, testAvroSchemaString);
+    final String testRecordName = "testrecord";
+    final TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from(testTopic, testRecordName);
+    final SchemaMetadata testSchemaMetadata = testSchemaMetadata(testRecordName);
 
     SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    when(schemaRegistryClient.getLatestSchemaMetadata(testSubjectValue)).thenReturn(testSchemaMetadata);
-    when(schemaRegistryClient.getLatestSchemaMetadata(testSubjectKey)).thenReturn(testSchemaMetadata);
+    when(schemaRegistryClient.getLatestSchemaMetadata(testTopicAndRecordName.toSubject(KafkaSchemaRecordType.VALUE))).thenReturn(testSchemaMetadata);
+    when(schemaRegistryClient.getLatestSchemaMetadata(testTopicAndRecordName.toSubject(KafkaSchemaRecordType.KEY))).thenReturn(testSchemaMetadata);
 
     SchemaRegistrySchemaRetriever testSchemaRetriever = new SchemaRegistrySchemaRetriever(
         schemaRegistryClient,
         new AvroData(0)
     );
 
-    Schema expectedKafkaConnectSchema =
-        SchemaBuilder.struct().field("f1", Schema.STRING_SCHEMA).name("testrecord").build();
+    Schema expectedKafkaConnectSchema = schemaFor(testRecordName);
 
-    assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopic, KafkaSchemaRecordType.VALUE));
-    assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopic, KafkaSchemaRecordType.KEY));
+    assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopicAndRecordName, KafkaSchemaRecordType.VALUE));
+    assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopicAndRecordName, KafkaSchemaRecordType.KEY));
   }
+
+  @Test
+  public void testRetrieveMultipleSchemas() throws Exception {
+    final List<String> testTopics = Stream.of("topic-1", "topic-2").collect(Collectors.toList());
+    final Map<String, String> subjectPatternsToRecords = Collections.unmodifiableMap(Stream.of(
+        new SimpleEntry<>("topic-1-record.A", "record.A"),
+        new SimpleEntry<>("topic-1-not.a.record.A", "record.A"),
+        new SimpleEntry<>("topic-2-record.B", "record.B"),
+        new SimpleEntry<>("topic-2-not.a.record.B", "record.B"),
+        new SimpleEntry<>("topic-3-record.A", "record.A"),
+        new SimpleEntry<>("topic-2-record.C", "record.C"),
+        new SimpleEntry<>("topic-3-record.C", "record.C"),
+        new SimpleEntry<>("justTopic-record.A", "record.A"),
+        new SimpleEntry<>("topic-1-justRecord", "justRecord")
+    ).collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue)));
+
+    Map<Pattern, String> testRecordAliases = new HashMap<>();
+    testRecordAliases.put(Pattern.compile("record\\.A"), "recordA");
+    testRecordAliases.put(Pattern.compile("rec.*\\.B"), "recordB");
+    testRecordAliases.put(Pattern.compile(".*\\.C"), "recordC");
+    testRecordAliases = Collections.unmodifiableMap(testRecordAliases);
+
+    SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(subjectPatternsToRecords.keySet());
+    for (Map.Entry<String, String> subjectToRecordName : subjectPatternsToRecords.entrySet()) {
+      when(schemaRegistryClient.getLatestSchemaMetadata(subjectToRecordName.getKey())).thenReturn(testSchemaMetadata(subjectToRecordName.getValue()));
+    }
+
+    SchemaRegistrySchemaRetriever testSchemaRetriever = new SchemaRegistrySchemaRetriever(
+        schemaRegistryClient,
+        new AvroData(0)
+    );
+
+    List<Schema> expectedKafkaConnectSchemas = Stream.of(
+        schemaFor("record.A"),
+        schemaFor("record.B"),
+        schemaFor("record.C")
+    ).collect(Collectors.toList());
+
+    Map<TopicAndRecordName, Schema> retrievedSchemas = testSchemaRetriever.retrieveSchemas(testTopics, testRecordAliases);
+    assertThat(retrievedSchemas.size(), is(3));
+    assertThat(Sets.newHashSet(retrievedSchemas.values()), equalTo(Sets.newHashSet(expectedKafkaConnectSchemas)));
+  }
+
+  private SchemaMetadata testSchemaMetadata(String schemaName) {
+    String schemaString = "{\"type\": \"record\", "
+        + "\"name\": \"" + schemaName + "\", "
+        + "\"fields\": [{\"name\": \"f1\", \"type\": \"string\"}]}";
+    return new SchemaMetadata(1, 1, schemaString);
+  }
+
+  private Schema schemaFor(String subject) {
+    return SchemaBuilder.struct().field("f1", Schema.STRING_SCHEMA).name(subject).build();
+  }
+
 }

--- a/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
+++ b/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
@@ -26,11 +26,12 @@ public class SchemaRegistrySchemaRetrieverTest {
     final String testTopic = "kafka-topic";
     final String testRecordName = "testrecord";
     final TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from(testTopic, testRecordName);
+    final String schemaRegistrySubjectName = testTopic + '-' + testRecordName;
     final SchemaMetadata testSchemaMetadata = testSchemaMetadata(testRecordName);
 
     SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    when(schemaRegistryClient.getLatestSchemaMetadata(testTopicAndRecordName.toSubject(KafkaSchemaRecordType.VALUE))).thenReturn(testSchemaMetadata);
-    when(schemaRegistryClient.getLatestSchemaMetadata(testTopicAndRecordName.toSubject(KafkaSchemaRecordType.KEY))).thenReturn(testSchemaMetadata);
+    when(schemaRegistryClient.getLatestSchemaMetadata(schemaRegistrySubjectName)).thenReturn(testSchemaMetadata);
+    when(schemaRegistryClient.getLatestSchemaMetadata(schemaRegistrySubjectName)).thenReturn(testSchemaMetadata);
 
     SchemaRegistrySchemaRetriever testSchemaRetriever = new SchemaRegistrySchemaRetriever(
         schemaRegistryClient,

--- a/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
+++ b/kcbq-confluent/src/test/java/com/wepay/kafka/connect/bigquery/schemaregistry/schemaretriever/SchemaRegistrySchemaRetrieverTest.java
@@ -1,17 +1,11 @@
 package com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.TableId;
-
-import com.google.common.collect.Sets;
 
 import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
@@ -24,15 +18,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import org.junit.Test;
-
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class SchemaRegistrySchemaRetrieverTest {
   @Test
@@ -56,49 +41,6 @@ public class SchemaRegistrySchemaRetrieverTest {
 
     assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopicAndRecordName, KafkaSchemaRecordType.VALUE));
     assertEquals(expectedKafkaConnectSchema, testSchemaRetriever.retrieveSchema(table, testTopicAndRecordName, KafkaSchemaRecordType.KEY));
-  }
-
-  @Test
-  public void testRetrieveMultipleSchemas() throws Exception {
-    final List<String> testTopics = Stream.of("topic-1", "topic-2").collect(Collectors.toList());
-    final Map<String, String> subjectPatternsToRecords = Collections.unmodifiableMap(Stream.of(
-        new SimpleEntry<>("topic-1-record.A", "record.A"),
-        new SimpleEntry<>("topic-1-not.a.record.A", "record.A"),
-        new SimpleEntry<>("topic-2-record.B", "record.B"),
-        new SimpleEntry<>("topic-2-not.a.record.B", "record.B"),
-        new SimpleEntry<>("topic-3-record.A", "record.A"),
-        new SimpleEntry<>("topic-2-record.C", "record.C"),
-        new SimpleEntry<>("topic-3-record.C", "record.C"),
-        new SimpleEntry<>("justTopic-record.A", "record.A"),
-        new SimpleEntry<>("topic-1-justRecord", "justRecord")
-    ).collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue)));
-
-    Map<Pattern, String> testRecordAliases = new HashMap<>();
-    testRecordAliases.put(Pattern.compile("record\\.A"), "recordA");
-    testRecordAliases.put(Pattern.compile("rec.*\\.B"), "recordB");
-    testRecordAliases.put(Pattern.compile(".*\\.C"), "recordC");
-    testRecordAliases = Collections.unmodifiableMap(testRecordAliases);
-
-    SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    when(schemaRegistryClient.getAllSubjects()).thenReturn(subjectPatternsToRecords.keySet());
-    for (Map.Entry<String, String> subjectToRecordName : subjectPatternsToRecords.entrySet()) {
-      when(schemaRegistryClient.getLatestSchemaMetadata(subjectToRecordName.getKey())).thenReturn(testSchemaMetadata(subjectToRecordName.getValue()));
-    }
-
-    SchemaRegistrySchemaRetriever testSchemaRetriever = new SchemaRegistrySchemaRetriever(
-        schemaRegistryClient,
-        new AvroData(0)
-    );
-
-    List<Schema> expectedKafkaConnectSchemas = Stream.of(
-        schemaFor("record.A"),
-        schemaFor("record.B"),
-        schemaFor("record.C")
-    ).collect(Collectors.toList());
-
-    Map<TopicAndRecordName, Schema> retrievedSchemas = testSchemaRetriever.retrieveSchemas(testTopics, testRecordAliases);
-    assertThat(retrievedSchemas.size(), is(3));
-    assertThat(Sets.newHashSet(retrievedSchemas.values()), equalTo(Sets.newHashSet(expectedKafkaConnectSchemas)));
   }
 
   private SchemaMetadata testSchemaMetadata(String schemaName) {

--- a/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
+++ b/kcbq-connector/src/integration-test/java/com/wepay/kafka/connect/bigquery/it/BigQueryConnectorIntegrationTest.java
@@ -202,6 +202,15 @@ public class BigQueryConnectorIntegrationTest {
 
   @Test
   public void testNull() {
+    testNull("kcbq_test_nulls");
+  }
+
+  @Test
+  public void testNullMulti() {
+    testNull("kcbq_test_multi_myrecord");
+  }
+
+  private void testNull(String tableName) {
     List<List<Object>> expectedRows = new ArrayList<>();
 
     // {"row":1,"f1":"Required string","f2":null,"f3":{"int":42},"f4":{"boolean":false}}
@@ -213,11 +222,20 @@ public class BigQueryConnectorIntegrationTest {
     // {"row":4,"f1":"Required string","f2":{"string":"Optional string"},"f3":null,"f4":null}
     expectedRows.add(Arrays.asList(4L, "Required string", "Optional string", null, null));
 
-    testRows(expectedRows, readAllRows("kcbq_test_nulls"));
+    testRows(expectedRows, readAllRows(tableName));
   }
 
   @Test
   public void testMatryoshka() {
+    testMatryoshka("kcbq_test_matryoshka_dolls");
+  }
+
+  @Test
+  public void testMatryoshkaMulti() {
+    testMatryoshka("kcbq_test_multi_matryoshka_dolls");
+  }
+
+  private void testMatryoshka(String tableName) {
     List<List<Object>> expectedRows = new ArrayList<>();
 
     /* { "row": 1,
@@ -248,11 +266,20 @@ public class BigQueryConnectorIntegrationTest {
         )
     ));
 
-    testRows(expectedRows, readAllRows("kcbq_test_matryoshka_dolls"));
+    testRows(expectedRows, readAllRows(tableName));
   }
 
   @Test
   public void testPrimitives() {
+    testPrimitives("kcbq_test_primitives");
+  }
+
+  @Test
+  public void testPrimitivesMulti() {
+    testPrimitives("kcbq_test_multi_com_wepay_kafka_connect_bigquery_primitives");
+  }
+
+  private void testPrimitives(String tableName) {
     List<List<Object>> expectedRows = new ArrayList<>();
 
     /* { "row": 1,
@@ -277,11 +304,20 @@ public class BigQueryConnectorIntegrationTest {
         boxByteArray(new byte[] { 0x0, 0xf, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A, 0x69, 0x78 })
     ));
 
-    testRows(expectedRows, readAllRows("kcbq_test_primitives"));
+    testRows(expectedRows, readAllRows(tableName));
   }
 
   @Test
   public void testLogicalTypes() {
+    testLogicalTypes("kcbq_test_logical_types");
+  }
+
+  @Test
+  public void testLogicalTypesMulti() {
+    testLogicalTypes("kcbq_test_multi_com_wepay_kafka_connect_bigquery_logicals");
+  }
+
+  private void testLogicalTypes(String tableName) {
     List<List<Object>> expectedRows = new ArrayList<>();
 
     // {"row": 1, "timestamp-test": 0, "date-test": 0}
@@ -291,11 +327,20 @@ public class BigQueryConnectorIntegrationTest {
     // {"row": 3, "timestamp-test": 1468275102000, "date-test": 16993}
     expectedRows.add(Arrays.asList(3L, 1468275102000000L, 1468195200000L));
 
-    testRows(expectedRows, readAllRows("kcbq_test_logical_types"));
+    testRows(expectedRows, readAllRows(tableName));
   }
 
   @Test
   public void testGCSLoad() {
+    testGCSLoad("kcbq_test_gcs_load");
+  }
+
+  @Test
+  public void testGCSLoadMulti() {
+    testGCSLoad("kcbq_test_multi_gcs_load_aliased");
+  }
+
+  private void testGCSLoad(String tableName) {
     List<List<Object>> expectedRows = new ArrayList<>();
 
     /* {"row":1,
@@ -362,7 +407,7 @@ public class BigQueryConnectorIntegrationTest {
         boxByteArray(new byte[] { 0x0, 0xf, 0x1E, 0x2D, 0x3C, 0x4B, 0x5A, 0x69, 0x78 })
     ));
 
-    testRows(expectedRows, readAllRows("kcbq_test_gcs_load"));
+    testRows(expectedRows, readAllRows(tableName));
   }
 
   private void testRows(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -99,20 +99,6 @@ public class BigQuerySinkConnector extends SinkConnector {
     return new SchemaManager(bigQuery, config);
   }
 
-  private void ensureExistingTables(
-      BigQuery bigQuery,
-      Map<TopicAndRecordName, TableId> topicsToTableIds) {
-    for (Map.Entry<TopicAndRecordName, TableId> topicToTableId : topicsToTableIds.entrySet()) {
-      TableId tableId = topicToTableId.getValue();
-      if (bigQuery.getTable(tableId) == null) {
-        logger.warn(
-          "You may want to enable auto table creation by setting {}=true in the properties file",
-          config.TABLE_CREATE_CONFIG);
-        throw new BigQueryConnectException("Table '" + tableId + "' does not exist");
-      }
-    }
-  }
-
   private void ensureExistingTables() {
     BigQuery bigQuery = getBigQuery();
     Map<TopicAndRecordName, TableId> topicsToTableIds = TopicToTableResolver.getTopicsToTables(config);
@@ -124,6 +110,18 @@ public class BigQuerySinkConnector extends SinkConnector {
     }
 
     ensureExistingTables(bigQuery, topicsToTableIds);
+  }
+
+  private void ensureExistingTables(BigQuery bigQuery, Map<TopicAndRecordName, TableId> topicsToTableIds) {
+    for (Map.Entry<TopicAndRecordName, TableId> topicToTableId : topicsToTableIds.entrySet()) {
+      TableId tableId = topicToTableId.getValue();
+      if (bigQuery.getTable(tableId) == null) {
+        logger.warn(
+            "You may want to enable auto table creation by setting {}=true in the properties file",
+            config.TABLE_CREATE_CONFIG);
+        throw new BigQueryConnectException("Table '" + tableId + "' does not exist");
+      }
+    }
   }
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -40,6 +40,17 @@ public class SchemaManager {
   private final Optional<String> kafkaDataFieldName;
 
   /**
+   * Create a new SchemaManager instance.
+   *
+   * SchemaManager relies on the following {@link BigQuerySinkConfig} properties:
+   * - schemaRetriever Used to determine the Kafka Connect Schema that should be used for a
+   *                   given table.
+   * - schemaConverter Used to convert Kafka Connect Schemas into BigQuery format.
+   * - kafkaKeyFieldName The name of kafka key field to be used in BigQuery.
+   *                     If set to null, Kafka Key Field will not be included in BigQuery.
+   * - kafkaDataFieldName The name of kafka data field to be used in BigQuery.
+   *                      If set to null, Kafka Data Field will not be included in BigQuery.
+   *
    * @param bigQuery Used to communicate create/update requests to BigQuery.
    * @param config BigQuery sink configuration.
    */

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -105,16 +105,6 @@ public class SchemaManager {
     return tableInfoBuilder.build();
   }
 
-  public Map<TopicAndRecordName, Schema> discoverSchemas() {
-    List<String> topics = config.getList(BigQuerySinkConfig.TOPICS_CONFIG);
-    Map<Pattern, String> recordAliases =
-        config
-            .getSinglePatterns(BigQuerySinkConfig.RECORD_ALIASES_CONFIG)
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    return schemaRetriever.retrieveSchemas(topics, recordAliases);
-  }
-
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
       List<Field> allFields = new ArrayList<> ();
       com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -114,9 +114,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance RECORD_ALIASES_IMPORTANCE =      ConfigDef.Importance.MEDIUM;
   private static final Object RECORD_ALIASES_DEFAULT =                        null;
   private static final String RECORD_ALIASES_DOC =
-      "A list of mappings from record name regexes to table name postfixes. Note the regex must include "
-      + "capture groups that are referenced in the format string using placeholders (i.e. $1) "
-      + "(form of <topic regex>=<format string>)";
+      "A list of mappings from record name regular expressions (regexes) to their aliases. "
+      + "BigQuery table name will follow the \"<topic_table_name>_<record_alias>\" template. "
+      + "Note the regex must include capture groups that are referenced in the format string "
+      + "using placeholders (i.e. $1) (form of <topic regex>=<format string>)";
 
   public static final String SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG =                    "supportMultiSchemaTopics";
   private static final ConfigDef.Type SUPPORT_MULTI_SCHEMA_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -109,23 +109,24 @@ public class BigQuerySinkConfig extends AbstractConfig {
       + "capture groups that are referenced in the format string using placeholders (i.e. $1) "
       + "(form of <topic regex>=<format string>)";
 
-  public static final String RECORD_ALIASES_CONFIG =                         "recordAliases";
-  private static final ConfigDef.Type RECORD_ALIASES_TYPE =                  ConfigDef.Type.LIST;
-  private static final ConfigDef.Importance RECORD_ALIASES_IMPORTANCE =      ConfigDef.Importance.MEDIUM;
-  private static final Object RECORD_ALIASES_DEFAULT =                        null;
-  private static final String RECORD_ALIASES_DOC =
-      "A list of mappings from record name regular expressions (regexes) to their aliases. "
+  public static final String SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG =                     "supportMultiSchemaTopics";
+  private static final ConfigDef.Type SUPPORT_MULTI_SCHEMA_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance SUPPORT_MULTI_SCHEMA_TOPICS_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
+  private static final Object SUPPORT_MULTI_SCHEMA_TOPICS_DEFAULT =                   false;
+  private static final String SUPPORT_MULTI_SCHEMA_TOPICS_DOC =
+      "Whether to support multi schema topics by appending record names to table names;"
+          + " if not enabled table names will be created using topic names only";
+
+  public static final String RECORDS_TO_TABLE_POSTFIXES_CONFIG =                     "recordsToTablePostfixes";
+  private static final ConfigDef.Type RECORDS_TO_TABLE_POSTFIXES_TYPE =              ConfigDef.Type.LIST;
+  private static final ConfigDef.Importance RECORDS_TO_TABLE_POSTFIXES_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
+  private static final Object RECORDS_TO_TABLE_POSTFIXES_DEFAULT =                   null;
+  private static final String RECORDS_TO_TABLE_POSTFIXES_DOC =
+      "A list of mappings from record name regular expressions (regexes) to their aliases, "
+      + "used when '" + SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG +  "' is enabled. "
       + "BigQuery table name will follow the \"<topic_table_name>_<record_alias>\" template. "
       + "Note the regex must include capture groups that are referenced in the format string "
       + "using placeholders (i.e. $1) (form of <topic regex>=<format string>)";
-
-  public static final String SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG =                    "supportMultiSchemaTopics";
-  private static final ConfigDef.Type SUPPORT_MULTI_SCHEMA_TOPICS_TYPE =              ConfigDef.Type.BOOLEAN;
-  private static final ConfigDef.Importance SUPPORT_MULTI_SCHEMA_TOPICS_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
-  private static final Object SUPPORT_MULTI_SCHEMA_TOPICS_DEFAULT =                    false;
-  private static final String SUPPORT_MULTI_SCHEMA_TOPICS_DOC =
-      "Whether to support multi schema topics by appending record names to table names;"
-      + " if not enabled table names will be created using topic names only";
 
   public static final String PROJECT_CONFIG =                     "project";
   private static final ConfigDef.Type PROJECT_TYPE =              ConfigDef.Type.STRING;
@@ -279,11 +280,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             TOPICS_TO_TABLES_IMPORTANCE,
             TOPICS_TO_TABLES_DOC
         ).define(
-            RECORD_ALIASES_CONFIG,
-            RECORD_ALIASES_TYPE,
-            RECORD_ALIASES_DEFAULT,
-            RECORD_ALIASES_IMPORTANCE,
-            RECORD_ALIASES_DOC
+            RECORDS_TO_TABLE_POSTFIXES_CONFIG,
+            RECORDS_TO_TABLE_POSTFIXES_TYPE,
+            RECORDS_TO_TABLE_POSTFIXES_DEFAULT,
+            RECORDS_TO_TABLE_POSTFIXES_IMPORTANCE,
+            RECORDS_TO_TABLE_POSTFIXES_DOC
         ).define(
             SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG,
             SUPPORT_MULTI_SCHEMA_TOPICS_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
@@ -2,9 +2,11 @@ package com.wepay.kafka.connect.bigquery.retrieve;
 
 import com.google.cloud.bigquery.TableId;
 
+import com.google.common.collect.Maps;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
@@ -14,7 +16,12 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.
@@ -23,6 +30,7 @@ public class MemorySchemaRetriever implements SchemaRetriever {
   private static final Logger logger = LoggerFactory.getLogger(MemorySchemaRetriever.class);
   private static final int CACHE_SIZE = 1000;
   private Cache<String, Schema> schemaCache;
+  private Map<String, TopicAndRecordName> cacheKeysToTopics;
 
   /**
    * Only here because the package-private constructor (which is only used in testing) would
@@ -31,19 +39,20 @@ public class MemorySchemaRetriever implements SchemaRetriever {
   public MemorySchemaRetriever() {
   }
 
-  private String getCacheKey(String tableName, String topic) {
-    return new StringBuilder(tableName).append(topic).toString();
+  private String getCacheKey(String tableName, TopicAndRecordName topicAndRecordName) {
+    return tableName + topicAndRecordName;
   }
 
   @Override
   public void configure(Map<String, String> properties) {
-    schemaCache = new SynchronizedCache<>(new LRUCache<String, Schema>(CACHE_SIZE));
+    schemaCache = new SynchronizedCache<>(new LRUCache<>(CACHE_SIZE));
+    cacheKeysToTopics = Collections.synchronizedMap(Maps.newHashMap());
   }
 
   @Override
-  public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType) {
+  public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) {
     String tableName = table.getTable();
-    Schema schema = schemaCache.get(getCacheKey(tableName, topic));
+    Schema schema = schemaCache.get(getCacheKey(tableName, topicAndRecordName));
     if (schema != null) {
       return schema;
     }
@@ -55,8 +64,19 @@ public class MemorySchemaRetriever implements SchemaRetriever {
   }
 
   @Override
-  public void setLastSeenSchema(TableId table, String topic, Schema schema) {
+  public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) {
+    return cacheKeysToTopics
+        .entrySet()
+        .stream()
+        .map(entry -> new AbstractMap.SimpleEntry<>(entry.getValue(), schemaCache.get(entry.getKey())))
+        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+  }
+
+  @Override
+  public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema) {
     logger.debug("Updating last seen schema to " + schema.toString());
-    schemaCache.put(getCacheKey(table.getTable(), topic), schema);
+    String cacheKey = getCacheKey(table.getTable(), topicAndRecordName);
+    schemaCache.put(cacheKey, schema);
+    cacheKeysToTopics.put(cacheKey, topicAndRecordName);
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetriever.java
@@ -16,12 +16,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.AbstractMap;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Uses the Confluent Schema Registry to fetch the latest schema for a given topic.
@@ -61,15 +57,6 @@ public class MemorySchemaRetriever implements SchemaRetriever {
     // When we receive our first message and try to add it, we'll hit the invalid schema case
     // and update the schema with the schema from the message
     return SchemaBuilder.struct().build();
-  }
-
-  @Override
-  public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) {
-    return cacheKeysToTopics
-        .entrySet()
-        .stream()
-        .map(entry -> new AbstractMap.SimpleEntry<>(entry.getValue(), schemaCache.get(entry.getKey())))
-        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
   }
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -159,8 +159,9 @@ public class TopicToTableResolver {
    * @return A String resulting match of alias for record name or just the record name if no matching alias was found.
    */
   private static String getRecordToTableSingleMatch(BigQuerySinkConfig config, String recordName) {
-    return Optional.ofNullable(config.getSingleMatch(recordName, "record name", BigQuerySinkConfig.RECORD_ALIASES_CONFIG))
-        .orElse(recordName);
+    return Optional.ofNullable(
+        config.getSingleMatch(recordName, "record name", BigQuerySinkConfig.RECORDS_TO_TABLE_POSTFIXES_CONFIG)
+    ).orElse(recordName);
   }
 
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -19,17 +19,16 @@ package com.wepay.kafka.connect.bigquery.utils;
 
 
 import com.google.cloud.bigquery.TableId;
-
+import com.google.common.collect.Maps;
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Optional;
 
 /**
  * A utility class that will resolve topic names to table names based on format strings using regex
@@ -43,13 +42,19 @@ public class TopicToTableResolver {
    * @param config Config that contains properties used to generate the map
    * @return A Map associating Kafka topic names to BigQuery table names.
    */
-  public static Map<String, TableId> getTopicsToTables(BigQuerySinkConfig config) {
+  public static Map<TopicAndRecordName, TableId> getTopicsToTables(BigQuerySinkConfig config) {
+    // Based only on the config we cannot determine what record type is used in which topic.
+    // It will be eventually discovered by handling new messages.
+    if (config.getBoolean(BigQuerySinkConfig.SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG)) {
+      return Maps.newHashMap();
+    }
+
     Map<String, String> topicsToDatasets = config.getTopicsToDatasets();
 
     List<String> topics = config.getList(BigQuerySinkConfig.TOPICS_CONFIG);
     Boolean sanitize = config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG);
 
-    Map<String, TableId> matches = new HashMap<>();
+    Map<TopicAndRecordName, TableId> matches = new HashMap<>();
     for (String value : topics) {
       String match = getTopicToTableSingleMatch(config, value);
       if (match == null) {
@@ -61,39 +66,51 @@ public class TopicToTableResolver {
       }
 
       String dataset = topicsToDatasets.get(value);
-      matches.put(value, TableId.of(dataset, match));
+      matches.put(TopicAndRecordName.from(value), TableId.of(dataset, match));
     }
 
     return matches;
+  }
+
+  public static Map<TopicAndRecordName, TableId> getTopicsToTables(BigQuerySinkConfig config, Map<TopicAndRecordName, Schema> schemasByTopic) {
+    Map<TopicAndRecordName, TableId> topicToTableIds = Maps.newHashMap();
+    schemasByTopic.forEach((key, value) -> updateTopicToTable(config, key, topicToTableIds));
+    return topicToTableIds;
   }
 
   /**
    * Update Map detailing BigQuery table for respective topic should write to.
    *
    * @param config Config that contains properties used to generate the map.
-   * @param topicName The name of respective topic to map with table.
+   * @param topicAndRecordName The name of respective topic and an optional record name to map with table.
    * @param topicToTable Map containing data for topic to respective table.
    */
-  public static void updateTopicToTable(BigQuerySinkConfig config, String topicName,
-      Map<String, TableId> topicToTable) {
+  public static void updateTopicToTable(BigQuerySinkConfig config, TopicAndRecordName topicAndRecordName,
+                                                      Map<TopicAndRecordName, TableId> topicToTable) {
     // Though the methods getTopicsToTable and updateTopicToTable are similar but code is not merged
     // as they slightly operate in different way. Former fetches complete topicsToDatasets map and
     // act on same while latter only fetches single match for dataset as required by topicName.
     Boolean sanitize = config.getBoolean(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG);
-    String match = getTopicToTableSingleMatch(config, topicName);
+    Boolean supportMultiSchemaTopics = config.getBoolean(BigQuerySinkConfig.SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG);
+    String match = Optional.ofNullable(getTopicToTableSingleMatch(config, topicAndRecordName.getTopic()))
+        .orElse(topicAndRecordName.getTopic());
 
-    if (match == null) {
-      match = topicName;
+    if (supportMultiSchemaTopics) {
+      String recordName = topicAndRecordName.getRecordName()
+          .map(rn -> getRecordToTableSingleMatch(config, rn))
+          .map(recordMatch -> "_" + recordMatch)
+          .orElse("");
+      match = match + recordName;
     }
 
     if (sanitize) {
       match = FieldNameSanitizer.sanitizeName(match);
     }
 
-    String dataset = config.getTopicToDataset(topicName);
+    String dataset = config.getTopicToDataset(topicAndRecordName.getTopic());
     // Do not check for dataset being null as TableId construction shall take care of same in below
     // line.
-    topicToTable.put(topicName, TableId.of(dataset, match));
+    topicToTable.put(topicAndRecordName, TableId.of(dataset, match));
   }
 
   /**
@@ -105,10 +122,10 @@ public class TopicToTableResolver {
    * @param config Config that contains properties used to generate the map
    * @return The resulting Map from TableId to topic name.
    */
-  public static Map<TableId, String> getBaseTablesToTopics(BigQuerySinkConfig config) {
-    Map<String, TableId> topicsToTableIds = getTopicsToTables(config);
-    Map<TableId, String> tableIdsToTopics = new HashMap<>();
-    for (Map.Entry<String, TableId> topicToTableId : topicsToTableIds.entrySet()) {
+  public static Map<TableId, TopicAndRecordName> getBaseTablesToTopics(BigQuerySinkConfig config) {
+    Map<TopicAndRecordName, TableId> topicsToTableIds = getTopicsToTables(config);
+    Map<TableId, TopicAndRecordName> tableIdsToTopics = new HashMap<>();
+    for (Map.Entry<TopicAndRecordName, TableId> topicToTableId : topicsToTableIds.entrySet()) {
       if (tableIdsToTopics.put(topicToTableId.getValue(), topicToTableId.getKey()) != null) {
         throw new ConfigException("Cannot have multiple topics writing to the same table");
       }
@@ -124,36 +141,19 @@ public class TopicToTableResolver {
    * @return A String resulting match of table for topic name.
    */
   private static String getTopicToTableSingleMatch(BigQuerySinkConfig config, String topicName) {
-    String match = null;
-    String previousPattern = null;
-
-    List<Map.Entry<Pattern, String>> patterns = config.getSinglePatterns(
-        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG);
-
-    for (Map.Entry<Pattern, String> pattern : patterns) {
-      Matcher patternMatcher = pattern.getKey().matcher(topicName);
-      if (patternMatcher.matches()) {
-        if (match != null) {
-          String secondMatch = pattern.getKey().toString();
-          throw new ConfigException("Value '" + topicName
-              + "' for property '" + BigQuerySinkConfig.TOPICS_CONFIG
-              + "' matches " + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
-              + " regexes for both '" + previousPattern
-              + "' and '" + secondMatch + "'"
-          );
-        }
-        String formatString = pattern.getValue();
-        try {
-          match = patternMatcher.replaceAll(formatString);
-          previousPattern = pattern.getKey().toString();
-        } catch (IndexOutOfBoundsException err) {
-          throw new ConfigException("Format string '" + formatString
-              + "' is invalid in property '" + BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG
-              + "'", err);
-        }
-      }
-    }
-
-    return match;
+    return config.getSingleMatch(topicName, BigQuerySinkConfig.TOPICS_CONFIG, BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG);
   }
+
+  /**
+   * Return a String specifying alias corresponding to record name.
+   *
+   * @param config     Config that contains properties for configured patterns.
+   * @param recordName The record name for which match is to be found.
+   * @return A String resulting match of alias for record name or just the record name if no matching alias was found.
+   */
+  private static String getRecordToTableSingleMatch(BigQuerySinkConfig config, String recordName) {
+    return Optional.ofNullable(config.getSingleMatch(recordName, "record name", BigQuerySinkConfig.RECORD_ALIASES_CONFIG))
+        .orElse(recordName);
+  }
+
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolver.java
@@ -39,7 +39,7 @@ public class TopicToTableResolver {
   /**
    * Return a Map detailing which BigQuery table each topic should write to.
    *
-   * @param config Config that contains properties used to generate the map
+   * @param config Config that contains properties used to generate the map.
    * @return A Map associating Kafka topic names to BigQuery table names.
    */
   public static Map<TopicAndRecordName, TableId> getTopicsToTables(BigQuerySinkConfig config) {
@@ -72,6 +72,13 @@ public class TopicToTableResolver {
     return matches;
   }
 
+  /**
+   * Return a Map detailing which BigQuery table each topic should write to.
+   *
+   * @param config Config that contains properties used to generate the map.
+   * @param schemasByTopic A Map containing data for topic to respective schema.
+   * @return A Map associating Kafka topic names to BigQuery table names.
+   */
   public static Map<TopicAndRecordName, TableId> getTopicsToTables(BigQuerySinkConfig config, Map<TopicAndRecordName, Schema> schemasByTopic) {
     Map<TopicAndRecordName, TableId> topicToTableIds = Maps.newHashMap();
     schemasByTopic.forEach((key, value) -> updateTopicToTable(config, key, topicToTableIds));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -23,6 +23,7 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 
@@ -55,12 +56,12 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   /**
    * Sends the request to BigQuery, and return a map of insertErrors in case of partial failure.
    * Throws an exception if any other errors occur as a result of doing so.
-   * @see BigQueryWriter#performWriteRequest(PartitionedTableId, List, String)
+   * @see BigQueryWriter#performWriteRequest(PartitionedTableId, List, TopicAndRecordName)
    */
   @Override
   public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
                                                             List<InsertAllRequest.RowToInsert> rows,
-                                                            String topic) {
+                                                            TopicAndRecordName topicAndRecordName) {
     InsertAllRequest request = createInsertAllRequest(tableId, rows);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -25,8 +25,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.mockito.Matchers.any;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.BigQuery;
@@ -38,7 +36,6 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 
 import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
@@ -50,7 +47,6 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class BigQuerySinkConnectorTest {
   private static SinkConnectorPropertiesFactory propertiesFactory;
@@ -64,12 +60,6 @@ public class BigQuerySinkConnectorTest {
 
     @Override
     public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) {
-      // Shouldn't be called
-      return null;
-    }
-
-    @Override
-    public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) {
       // Shouldn't be called
       return null;
     }
@@ -98,8 +88,7 @@ public class BigQuerySinkConnectorTest {
     BigQuery bigQuery = mock(BigQuery.class);
     when(bigQuery.getTable(any(TableId.class))).thenReturn(fakeTable);
 
-    SchemaManager schemaManager = mock(SchemaManager.class);
-    BigQuerySinkConnector testConnector = new BigQuerySinkConnector(bigQuery, schemaManager);
+    BigQuerySinkConnector testConnector = new BigQuerySinkConnector(bigQuery);
 
     testConnector.start(properties);
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -41,6 +41,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import org.apache.kafka.connect.data.Schema;
 
 import org.junit.BeforeClass;
@@ -49,6 +50,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class BigQuerySinkConnectorTest {
   private static SinkConnectorPropertiesFactory propertiesFactory;
@@ -61,13 +63,19 @@ public class BigQuerySinkConnectorTest {
     }
 
     @Override
-    public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType) {
+    public Schema retrieveSchema(TableId table, TopicAndRecordName topicAndRecordName, KafkaSchemaRecordType schemaType) {
       // Shouldn't be called
       return null;
     }
 
     @Override
-    public void setLastSeenSchema(TableId table, String topic, Schema schema) {
+    public Map<TopicAndRecordName, Schema> retrieveSchemas(List<String> topics, Map<Pattern, String> recordAliases) {
+      // Shouldn't be called
+      return null;
+    }
+
+    @Override
+    public void setLastSeenSchema(TableId table, TopicAndRecordName topicAndRecordName, Schema schema) {
     }
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import org.apache.kafka.connect.data.Schema;
@@ -46,20 +47,19 @@ public class SchemaManagerTest {
     final String testDoc = "test doc";
     final TableId tableId = TableId.of(testDatasetName, testTableName);
 
+    BigQuerySinkConfig mockConfig = mock(BigQuerySinkConfig.class);
     SchemaRetriever mockSchemaRetriever = mock(SchemaRetriever.class);
     @SuppressWarnings("unchecked")
     SchemaConverter<com.google.cloud.bigquery.Schema> mockSchemaConverter =
         (SchemaConverter<com.google.cloud.bigquery.Schema>) mock(SchemaConverter.class);
+    when(mockConfig.getSchemaConverter()).thenReturn(mockSchemaConverter);
+    when(mockConfig.getSchemaRetriever()).thenReturn(mockSchemaRetriever);
+    when(mockConfig.getKafkaDataFieldName()).thenReturn(Optional.of("kafkaData"));
+    when(mockConfig.getKafkaKeyFieldName()).thenReturn(Optional.of("kafkaKey"));
+
     BigQuery mockBigQuery = mock(BigQuery.class);
 
-    Optional<String> kafkaKeyFieldName = Optional.of("kafkaKey");
-    Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
-
-    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever,
-                                                    mockSchemaConverter,
-                                                    mockBigQuery,
-                                                    kafkaKeyFieldName,
-                                                    kafkaDataFieldName);
+    SchemaManager schemaManager = new SchemaManager(mockBigQuery, mockConfig);
 
     Schema mockKafkaSchema = mock(Schema.class);
     // we would prefer to mock this class, but it is final.

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -75,6 +75,21 @@ public class BigQuerySinkConfigTest {
     assertEquals(expectedTopicsToDatasets, testTopicsToDatasets);
   }
 
+  @Test()
+  public void testGetSingleMatch() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+
+    String configKey = BigQuerySinkConfig.RECORDS_TO_TABLE_POSTFIXES_CONFIG;
+    String configValue = "recordA=A,recordB=B,entity(.*)=$1,(.*)World=$1";
+    configProperties.put(configKey, configValue);
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertEquals("A", config.getSingleMatch("recordA", "test value", configKey));
+    assertEquals("B", config.getSingleMatch("recordB", "test value", configKey));
+    assertEquals("C", config.getSingleMatch("entityC", "test value", configKey));
+    assertEquals("Hello", config.getSingleMatch("entityHello", "test value", configKey));
+    assertEquals("Hello", config.getSingleMatch("HelloWorld", "test value", configKey));
+  }
+
   @Test
   public void testGetSchemaConverter() {
     Map<String, String> configProperties = propertiesFactory.getProperties();
@@ -146,6 +161,17 @@ public class BigQuerySinkConfigTest {
         "tracking-everything-in-the-database"
     );
     new BigQuerySinkConfig(badConfigProperties).getTopicsToDatasets();
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testFailedGetSingleMatch() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+
+    String configKey = BigQuerySinkConfig.RECORDS_TO_TABLE_POSTFIXES_CONFIG;
+    String configValue = "Hello(.*)=$1,(.*)World=$1";
+    configProperties.put(configKey, configValue);
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    config.getSingleMatch("HelloWorld", "test value", configKey);
   }
 
   @Test(expected = ConfigException.class)

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
@@ -2,7 +2,6 @@ package com.wepay.kafka.connect.bigquery.retrieve;
 
 import com.google.cloud.bigquery.TableId;
 
-import com.google.common.collect.Maps;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
@@ -13,13 +12,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 public class MemorySchemaRetrieverTest {
@@ -66,31 +59,6 @@ public class MemorySchemaRetrieverTest {
     Assert.assertEquals(
         retriever.retrieveSchema(floatTableId, floatSchemaTopic, KafkaSchemaRecordType.KEY), expectedFloatSchema);
     Assert.assertEquals(retriever.retrieveSchema(intTableId, intSchemaTopic, KafkaSchemaRecordType.KEY), expectedIntSchema);
-  }
-
-  @Test
-  public void testRetrieveSchemasSucceeds() {
-    final TopicAndRecordName floatSchemaTopic = TopicAndRecordName.from("test-float32", "float32-record-name");
-    final TopicAndRecordName intSchemaTopic = TopicAndRecordName.from("test-int32", "int32-record-name");
-    final TableId floatTableId = getTableId("testFloatTable", "testFloatDataset");
-    final TableId intTableId = getTableId("testIntTable", "testIntDataset");
-    SchemaRetriever retriever = new MemorySchemaRetriever();
-    retriever.configure(new HashMap<>());
-
-    Schema expectedIntSchema = SchemaBuilder.struct().name("schemaA").build();
-    Schema expectedFloatSchema = SchemaBuilder.struct().optional().name("schemaB").build();
-
-    retriever.setLastSeenSchema(floatTableId, floatSchemaTopic, expectedFloatSchema);
-    retriever.setLastSeenSchema(intTableId, intSchemaTopic, expectedIntSchema);
-
-    Map<TopicAndRecordName, Schema> expectedSchemas = Maps.newHashMap();
-    expectedSchemas.put(floatSchemaTopic, expectedFloatSchema);
-    expectedSchemas.put(intSchemaTopic, expectedIntSchema);
-
-    List<String> topics = Stream.of(floatSchemaTopic.getTopic(), intSchemaTopic.getTopic()).collect(Collectors.toList());
-    Map<Pattern, String> recordAliases = Collections.emptyMap();
-
-    Assert.assertEquals(retriever.retrieveSchemas(topics, recordAliases), expectedSchemas);
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -218,7 +218,7 @@ public class TopicToTableResolverTest {
         "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3,new_topic_(.*)=$1"
     );
     configProperties.put(
-        BigQuerySinkConfig.RECORD_ALIASES_CONFIG,
+        BigQuerySinkConfig.RECORDS_TO_TABLE_POSTFIXES_CONFIG,
         "some\\.record\\.(.*)=$1"
     );
     configProperties.put(
@@ -294,7 +294,7 @@ public class TopicToTableResolverTest {
         "new_topic_(.*)=$1"
     );
     configProperties.put(
-        BigQuerySinkConfig.RECORD_ALIASES_CONFIG,
+        BigQuerySinkConfig.RECORDS_TO_TABLE_POSTFIXES_CONFIG,
         "(.*)=$1,some\\.record\\.(.*)=$1"
     );
     configProperties.put(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TopicToTableResolverTest.java
@@ -18,17 +18,18 @@ package com.wepay.kafka.connect.bigquery.utils;
  */
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.SinkPropertiesFactory;
+import com.wepay.kafka.connect.bigquery.api.TopicAndRecordName;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,14 +58,26 @@ public class TopicToTableResolverTest {
         BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
         "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3"
     );
-    Map<String, TableId> expectedTopicsToTables = new HashMap<>();
-    expectedTopicsToTables.put("sanitize-me", TableId.of("scratch", "sanitize_me"));
-    expectedTopicsToTables.put("db_debezium_identity_profiles_info.foo",
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = new HashMap<>();
+    expectedTopicsToTables.put(TopicAndRecordName.from("sanitize-me"), TableId.of("scratch", "sanitize_me"));
+    expectedTopicsToTables.put(TopicAndRecordName.from("db_debezium_identity_profiles_info.foo"),
         TableId.of("scratch", "info_foo"));
-    expectedTopicsToTables.put("db.core.cluster-0.users", TableId.of("scratch", "core_users"));
+    expectedTopicsToTables.put(TopicAndRecordName.from("db.core.cluster-0.users"), TableId.of("scratch", "core_users"));
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    Map<String, TableId> topicsToTableIds = TopicToTableResolver.getTopicsToTables(testConfig);
+    Map<TopicAndRecordName, TableId> topicsToTableIds = TopicToTableResolver.getTopicsToTables(testConfig);
+
+    assertEquals(expectedTopicsToTables, topicsToTableIds);
+  }
+
+  @Test
+  public void testGetTopicsToTablesEmptyMap() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG, "true");
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = Collections.emptyMap();
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    Map<TopicAndRecordName, TableId> topicsToTableIds = TopicToTableResolver.getTopicsToTables(testConfig);
 
     assertEquals(expectedTopicsToTables, topicsToTableIds);
   }
@@ -125,19 +138,19 @@ public class TopicToTableResolverTest {
         BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
         "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3"
     );
-    Map<String, TableId> topicsToTables = new HashMap<>();
-    topicsToTables.put("sanitize-me", TableId.of("scratch", "sanitize_me"));
-    topicsToTables.put("db_debezium_identity_profiles_info.foo",
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
+    topicsToTables.put(TopicAndRecordName.from("sanitize-me"), TableId.of("scratch", "sanitize_me"));
+    topicsToTables.put(TopicAndRecordName.from("db_debezium_identity_profiles_info.foo"),
         TableId.of("scratch", "info_foo"));
-    topicsToTables.put("db.core.cluster-0.users", TableId.of("scratch", "core_users"));
+    topicsToTables.put(TopicAndRecordName.from("db.core.cluster-0.users"), TableId.of("scratch", "core_users"));
 
-    String testTopicName = "new_topic";
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("new_topic", "some.record.Name");
     // Create shallow copy of map, deep copy not needed.
-    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
-    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", testTopicName));
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicAndRecordName, TableId.of("scratch", testTopicAndRecordName.getTopic()));
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
 
     assertEquals(expectedTopicsToTables, topicsToTables);
   }
@@ -155,14 +168,14 @@ public class TopicToTableResolverTest {
         "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3"
     );
 
-    String testTopicName = "1new.topic";
-    Map<String, TableId> topicsToTables = new HashMap<>();
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("1new.topic", "some.record.Name");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
     // Create shallow copy of map, deep copy not needed.
-    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
-    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", "_1new_topic"));
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicAndRecordName, TableId.of("scratch", "_1new_topic"));
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
 
     assertEquals(expectedTopicsToTables, topicsToTables);
   }
@@ -180,14 +193,50 @@ public class TopicToTableResolverTest {
         "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3,new_topic_(.*)=$1"
     );
 
-    String testTopicName = "new_topic_abc.def";
-    Map<String, TableId> topicsToTables = new HashMap<>();
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("new_topic_abc.def", "some.record.Name");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
     // Create shallow copy of map, deep copy not needed.
-    Map<String, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
-    expectedTopicsToTables.put(testTopicName, TableId.of("scratch", "abc_def"));
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicAndRecordName, TableId.of("scratch", "abc_def"));
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
+
+    assertEquals(expectedTopicsToTables, topicsToTables);
+  }
+
+  @Test
+  public void testUpdateTopicToTableWithRegexAndMultiSchemaTopicsEnabled() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "db_debezium_identity_profiles_(.*)=$1,db\\.(.*)\\.(.*)\\.(.*)=$1_$3,new_topic_(.*)=$1"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.RECORD_ALIASES_CONFIG,
+        "some\\.record\\.(.*)=$1"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG,
+        "true"
+    );
+
+    TopicAndRecordName testTopicWithMatchingRecordName = TopicAndRecordName.from("new_topic_abc.def", "some.record.RecordName");
+    TopicAndRecordName testTopicWithUnexpectedRecordName = TopicAndRecordName.from("new_topic_abc.def", "unexpected.RecordName");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
+    // Create shallow copy of map, deep copy not needed.
+    Map<TopicAndRecordName, TableId> expectedTopicsToTables = new HashMap<>(topicsToTables);
+    expectedTopicsToTables.put(testTopicWithMatchingRecordName, TableId.of("scratch", "abc_def_RecordName"));
+    expectedTopicsToTables.put(testTopicWithUnexpectedRecordName, TableId.of("scratch", "abc_def_unexpected_RecordName"));
+
+    BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicWithMatchingRecordName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicWithUnexpectedRecordName, topicsToTables);
 
     assertEquals(expectedTopicsToTables, topicsToTables);
   }
@@ -205,11 +254,11 @@ public class TopicToTableResolverTest {
         ".*=$1"
     );
 
-    String testTopicName = "new_topic_abc.def";
-    Map<String, TableId> topicsToTables = new HashMap<>();
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("new_topic_abc.def", "some.record.Name");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
   }
 
   @Test(expected = ConfigException.class)
@@ -225,25 +274,39 @@ public class TopicToTableResolverTest {
         "(.*)=$1,new_topic_(.*)=$1"
     );
 
-    String testTopicName = "new_topic_abc.def";
-    Map<String, TableId> topicsToTables = new HashMap<>();
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("new_topic_abc.def", "some.record.Name");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
 
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    TopicToTableResolver.updateTopicToTable(testConfig, testTopicName, topicsToTables);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
   }
 
-  @Test
-  public void testBaseTablesToTopics() {
+  @Test(expected = ConfigException.class)
+  public void testUpdateTopicToTableWithMultipleRecordNameMatches() {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
-    configProperties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
-    configProperties.put(BigQuerySinkConfig.TOPICS_CONFIG, "sanitize-me,leave_me_alone");
+    configProperties.put(
+        BigQuerySinkConfig.DATASETS_CONFIG,
+        ".*=scratch"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.TOPICS_TO_TABLES_CONFIG,
+        "new_topic_(.*)=$1"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.RECORD_ALIASES_CONFIG,
+        "(.*)=$1,some\\.record\\.(.*)=$1"
+    );
+    configProperties.put(
+        BigQuerySinkConfig.SUPPORT_MULTI_SCHEMA_TOPICS_CONFIG,
+        "true"
+    );
+
+    TopicAndRecordName testTopicAndRecordName = TopicAndRecordName.from("new_topic_abc.def", "some.record.Name");
+    Map<TopicAndRecordName, TableId> topicsToTables = new HashMap<>();
+
     BigQuerySinkConfig testConfig = new BigQuerySinkConfig(configProperties);
-    Map<TableId, String> testTablesToSchemas =
-        TopicToTableResolver.getBaseTablesToTopics(testConfig);
-    Map<TableId, String> expectedTablesToSchemas = new HashMap<>();
-    expectedTablesToSchemas.put(TableId.of("scratch", "sanitize_me"), "sanitize-me");
-    expectedTablesToSchemas.put(TableId.of("scratch", "leave_me_alone"), "leave_me_alone");
-    assertEquals(expectedTablesToSchemas, testTablesToSchemas);
+    TopicToTableResolver.updateTopicToTable(testConfig, testTopicAndRecordName, topicsToTables);
   }
+
 }

--- a/kcbq-connector/test/docker/connect/connect-docker.sh
+++ b/kcbq-connector/test/docker/connect/connect-docker.sh
@@ -17,8 +17,17 @@
 tar -C /usr/local/share/kafka/plugins/kafka-connect-bigquery/ -xf /usr/local/share/kafka/plugins/kafka-connect-bigquery/kcbq.tar
 
 connect-standalone \
-    /etc/kafka-connect-bigquery/standalone.properties \
-    /etc/kafka-connect-bigquery/connector.properties &
+    /etc/kafka-connect-bigquery/standalone-single-schema.properties \
+    /etc/kafka-connect-bigquery/connector-single-schema.properties &
+SINGLE_PID=$!
 
 sleep 60
-kill $!
+kill $SINGLE_PID
+
+connect-standalone \
+    /etc/kafka-connect-bigquery/standalone-multi-schema.properties \
+    /etc/kafka-connect-bigquery/connector-multi-schema.properties &
+MULTI_PID=$!
+
+sleep 60
+kill $MULTI_PID

--- a/kcbq-connector/test/docker/populate/Dockerfile
+++ b/kcbq-connector/test/docker/populate/Dockerfile
@@ -24,6 +24,9 @@
 
 FROM confluentinc/cp-schema-registry:4.1.2
 
+RUN ["apt-get", "update"]
+RUN ["apt-get", "install", "jq"]
+
 COPY populate-docker.sh /usr/local/bin/
 
 RUN ["chmod", "+x", "/usr/local/bin/populate-docker.sh"]

--- a/kcbq-connector/test/docker/populate/populate-docker.sh
+++ b/kcbq-connector/test/docker/populate/populate-docker.sh
@@ -15,10 +15,44 @@
 # under the License.
 
 for schema_dir in /tmp/schemas/*; do
+
+  # Feed single schema topics
   kafka-avro-console-producer \
       --topic "kcbq_test_`basename $schema_dir`" \
       --broker-list 'kafka:29092' \
       --property value.schema="`cat \"$schema_dir/schema.json\"`" \
       --property schema.registry.url='http://schema-registry:8081' \
       < "$schema_dir/data.json"
+
+  # Feed multi schema topic
+  MULTI_SCHEMA_TOPIC="kcbq_test_multi"
+  kafka-avro-console-producer \
+      --topic $MULTI_SCHEMA_TOPIC \
+      --broker-list 'kafka:29092' \
+      --property schema.registry.url='http://schema-registry:8081' \
+      --property value.schema="`cat \"$schema_dir/schema.json\"`" \
+      --producer-property value.converter.value.subject.name.strategy=io.confluent.kafka.serializers.subject.TopicRecordNameStrategy \
+      --property value.converter.value.subject.name.strategy=io.confluent.kafka.serializers.subject.TopicRecordNameStrategy \
+      < "$schema_dir/data.json"
+
+  # Since console producer does not support custom subject naming strategies (like TopicRecordName),
+  # we have to instrumentate the schema registry manually.
+  # Also we prevent connector from falling back to TopicName strategy silently.
+  curl -X DELETE http://schema-registry:8081/subjects/$MULTI_SCHEMA_TOPIC-value &> /dev/null
+
+  # Extract new subject name, according to TopicRecordNameStrategy
+  # (https://github.com/confluentinc/schema-registry/blob/4.1.2-post/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java#L39)
+  NAME=`jq -r .name $schema_dir/schema.json`
+  NAMESPACE=`jq -r .namespace $schema_dir/schema.json`
+  SUBJECT=$MULTI_SCHEMA_TOPIC-
+  if [ $NAMESPACE == "null" ]; then
+    SUBJECT=$SUBJECT$NAME
+  else
+    SUBJECT=$SUBJECT$NAMESPACE.$NAME
+  fi
+
+  curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+      --data "{ \"schema\": \"`cat $schema_dir/schema.json | sed -e 's/"/\\\\"/g' | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/ /g'`\"}" \
+      http://schema-registry:8081/subjects/$SUBJECT/versions &> /dev/null
+
 done

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -275,7 +275,7 @@ gcsFolderName=$KCBQ_TEST_FOLDER
 topics=$test_multi_schema_topics
 
 supportMultiSchemaTopics=true
-recordAliases=com.wepay.kafka.connect.bigquery.gcsLoad=gcs_load_aliased,com.wepay.kafka.connect.bigquery.outer_doll=matryoshka_dolls
+recordsToTablePostfixes=com.wepay.kafka.connect.bigquery.gcsLoad=gcs_load_aliased,com.wepay.kafka.connect.bigquery.outer_doll=matryoshka_dolls
 
 EOF
 

--- a/kcbq-connector/test/integrationtest.sh
+++ b/kcbq-connector/test/integrationtest.sh
@@ -213,11 +213,17 @@ warn 'Deleting existing BigQuery test tables and existing GCS bucket'
 
 
 test_tables=
-test_topics=
+test_single_schema_topics=
 for file in "$BASE_DIR"/resources/test_schemas/*; do
         test_tables+="${test_tables:+ }kcbq_test_$(basename "${file/-/_}")"
-        test_topics+="${test_topics:+,}kcbq_test_$(basename "$file")"
+        test_single_schema_topics+="${test_single_schema_topics:+,}kcbq_test_$(basename "$file")"
 done
+test_tables+="${test_tables:+ }kcbq_test_multi_gcs_load_aliased"
+test_tables+="${test_tables:+ }kcbq_test_multi_com_wepay_kafka_connect_bigquery_logicals"
+test_tables+="${test_tables:+ }kcbq_test_multi_matryoshka_dolls"
+test_tables+="${test_tables:+ }kcbq_test_multi_myrecord"
+test_tables+="${test_tables:+ }kcbq_test_multi_com_wepay_kafka_connect_bigquery_primitives"
+test_multi_schema_topics="kcbq_test_multi"
 
 "$GRADLEW" -p "$BASE_DIR/.." \
     -Pkcbq_test_keyfile="$KCBQ_TEST_KEYFILE" \
@@ -238,17 +244,38 @@ statusupdate 'Executing Kafka Connect in Docker'
 [[ ! -e "$DOCKER_DIR/connect/properties" ]] && mkdir "$DOCKER_DIR/connect/properties"
 RESOURCES_DIR="$BASE_DIR/resources"
 
-STANDALONE_PROPS="$DOCKER_DIR/connect/properties/standalone.properties"
-cp "$RESOURCES_DIR/standalone-template.properties" "$STANDALONE_PROPS"
+STANDALONE_SINGLE_SCHEMA_PROPS="$DOCKER_DIR/connect/properties/standalone-single-schema.properties"
+cp "$RESOURCES_DIR/standalone-template.properties" "$STANDALONE_SINGLE_SCHEMA_PROPS"
 
-CONNECTOR_PROPS="$DOCKER_DIR/connect/properties/connector.properties"
-cp "$RESOURCES_DIR/connector-template.properties" "$CONNECTOR_PROPS"
-cat << EOF >> $CONNECTOR_PROPS
+STANDALONE_MULTI_SCHEMA_PROPS="$DOCKER_DIR/connect/properties/standalone-multi-schema.properties"
+cp "$STANDALONE_SINGLE_SCHEMA_PROPS" "$STANDALONE_MULTI_SCHEMA_PROPS"
+cat << EOF >> $STANDALONE_MULTI_SCHEMA_PROPS
+value.converter.value.subject.name.strategy=io.confluent.kafka.serializers.subject.TopicRecordNameStrategy
+
+EOF
+
+CONNECTOR_SINGLE_SCHEMA_PROPS="$DOCKER_DIR/connect/properties/connector-single-schema.properties"
+cp "$RESOURCES_DIR/connector-template.properties" "$CONNECTOR_SINGLE_SCHEMA_PROPS"
+cat << EOF >> $CONNECTOR_SINGLE_SCHEMA_PROPS
 project=$KCBQ_TEST_PROJECT
 datasets=.*=$KCBQ_TEST_DATASET
 gcsBucketName=$KCBQ_TEST_BUCKET
 gcsFolderName=$KCBQ_TEST_FOLDER
-topics=$test_topics
+topics=$test_single_schema_topics
+
+EOF
+
+CONNECTOR_MULTI_SCHEMA_PROPS="$DOCKER_DIR/connect/properties/connector-multi-schema.properties"
+cp "$RESOURCES_DIR/connector-template.properties" "$CONNECTOR_MULTI_SCHEMA_PROPS"
+cat << EOF >> $CONNECTOR_MULTI_SCHEMA_PROPS
+project=$KCBQ_TEST_PROJECT
+datasets=.*=$KCBQ_TEST_DATASET
+gcsBucketName=$KCBQ_TEST_BUCKET
+gcsFolderName=$KCBQ_TEST_FOLDER
+topics=$test_multi_schema_topics
+
+supportMultiSchemaTopics=true
+recordAliases=com.wepay.kafka.connect.bigquery.gcsLoad=gcs_load_aliased,com.wepay.kafka.connect.bigquery.outer_doll=matryoshka_dolls
 
 EOF
 


### PR DESCRIPTION
This contribution makes kafka-connect-bigquery compatible with topics that carry different types of messages, especially when Kafka is used for an event sourcing.

Approach of putting several event types in a single topic is already supported by Kafka and Schema Registry (see https://www.confluent.io/blog/put-several-event-types-kafka-topic/).

This PR has been derived from #219 and rebased on top of the recent changes made by @bingqinzhou