### PR TITLE
Add unit tests for triggering (or not) table existence checks

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -77,6 +77,95 @@ public class BigQuerySinkConnectorTest {
   }
 
   @Test
+  public void testAutoCreateTablesPreventsCheckingExistingTables() {
+    final String dataset = "scratch";
+    final String existingTableTopic = "topic-with-existing-table";
+    final String nonExistingTableTopic = "topic-without-existing-table";
+    final TableId existingTable = TableId.of(dataset, "topic_with_existing_table");
+    final TableId nonExistingTable = TableId.of(dataset, "topic_without_existing_table");
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MockSchemaRetriever.class.getName());
+    properties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+    properties.put(
+        BigQuerySinkConfig.TOPICS_CONFIG,
+        String.format("%s, %s", existingTableTopic, nonExistingTableTopic)
+    );
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table fakeTable = mock(Table.class);
+    when(bigQuery.getTable(existingTable)).thenReturn(fakeTable);
+    when(bigQuery.getTable(nonExistingTable)).thenReturn(null);
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+
+    BigQuerySinkConnector testConnector = new BigQuerySinkConnector(bigQuery, schemaManager);
+    testConnector.start(properties);
+
+    verify(bigQuery, never()).getTable(any(TableId.class));
+    verify(schemaManager, never()).createTable(any(TableId.class), any(TopicAndRecordName.class));
+  }
+
+  @Test
+  public void testNonAutoCreateTablesChecksExistingTables() {
+    final String dataset = "scratch";
+    final String[] topics = new String[] { "topic-one", "topicTwo", "TOPIC_THREE", "topic.four" };
+    final String[] tables = new String[] { "topic_one", "topicTwo", "TOPIC_THREE", "topic_four" };
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    properties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, String.join(",", topics));
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    for (String table : tables) {
+      Table fakeTable = mock(Table.class);
+      when(bigQuery.getTable(TableId.of(dataset, table))).thenReturn(fakeTable);
+    }
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+
+    BigQuerySinkConnector testConnector = new BigQuerySinkConnector(bigQuery, schemaManager);
+    testConnector.start(properties);
+
+    verify(schemaManager, never()).createTable(any(TableId.class), any(TopicAndRecordName.class));
+
+    for (String table : tables) {
+      verify(bigQuery).getTable(TableId.of(dataset, table));
+    }
+  }
+
+  @Test(expected = BigQueryConnectException.class)
+  public void testNonAutoCreateTablesFailure() {
+    final String dataset = "scratch";
+    final String existingTableTopic = "topic-with-existing-table";
+    final String nonExistingTableTopic = "topic-without-existing-table";
+    final TableId existingTable = TableId.of(dataset, "topic_with_existing_table");
+    final TableId nonExistingTable = TableId.of(dataset, "topic_without_existing_table");
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    properties.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
+    properties.put(
+        BigQuerySinkConfig.TOPICS_CONFIG,
+        String.format("%s, %s", existingTableTopic, nonExistingTableTopic)
+    );
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table fakeTable = mock(Table.class);
+    when(bigQuery.getTable(existingTable)).thenReturn(fakeTable);
+    when(bigQuery.getTable(nonExistingTable)).thenReturn(null);
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    BigQuerySinkConnector testConnector = new BigQuerySinkConnector(bigQuery, schemaManager);
+    testConnector.start(properties);
+  }
+
+  @Test
   public void testTaskClass() {
     assertEquals(BigQuerySinkTask.class, new BigQuerySinkConnector().taskClass());
   }


### PR DESCRIPTION
A few additional tests cases that checks if table existence checks are triggered only when autoCreateTable is set to `false` and they fail in case of a missing tables.

**This PR depends on #238** 