### PR TITLE
Update keyfile config to be a PASSWORD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
-    googleAuthVersion = '0.10.0'
+    googleAuthVersion = '0.9.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.3.1'
     junitVersion = '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ project.ext {
     avroVersion = '1.8.1'
     debeziumVersion = '0.6.1'
     googleCloudVersion = '1.79.0'
-    googleAuthVersion = '0.9.0'
+    googleAuthVersion = '0.10.0'
     googleCloudGsonVersion = '2.8.5'
     ioConfluentVersion = '5.3.1'
     junitVersion = '4.12'

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -91,7 +91,7 @@ public class BigQuerySinkConnector extends SinkConnector {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String key = config.getString(config.KEYFILE_CONFIG);
+    String key = config.getKeyFile();
     String keySource = config.getString(config.KEY_SOURCE_CONFIG);
     return new BigQueryHelper().setKeySource(keySource).connect(projectName, key);
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -262,7 +262,7 @@ public class BigQuerySinkTask extends SinkTask {
       return testBigQuery;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String keyFile = config.getString(config.KEYFILE_CONFIG);
+    String keyFile = config.getKeyFile();
     String keySource = config.getString(config.KEY_SOURCE_CONFIG);
     return new BigQueryHelper().setKeySource(keySource).connect(projectName, keyFile);
   }
@@ -299,7 +299,7 @@ public class BigQuerySinkTask extends SinkTask {
       return testGcs;
     }
     String projectName = config.getString(config.PROJECT_CONFIG);
-    String key = config.getString(config.KEYFILE_CONFIG);
+    String key = config.getKeyFile();
     String keySource = config.getString(config.KEY_SOURCE_CONFIG);
     return new GCSBuilder(projectName).setKey(key).setKeySource(keySource).build();
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -133,7 +133,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "A class that can be used for automatically creating tables and/or updating schemas";
 
   public static final String KEYFILE_CONFIG =                     "keyfile";
-  private static final ConfigDef.Type KEYFILE_TYPE =              ConfigDef.Type.STRING;
+  private static final ConfigDef.Type KEYFILE_TYPE =              ConfigDef.Type.PASSWORD;
   public static final String KEYFILE_DEFAULT =                    null;
   private static final ConfigDef.Importance KEYFILE_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
   private static final String KEYFILE_DOC =

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -407,6 +407,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
   }
 
   /**
+   * Returns the keyfile
+   */
+  public String getKeyFile() {
+    return getPassword(KEYFILE_CONFIG).value();
+  }
+
+  /**
    * Parses a config map, which must be provided as a list of Strings of the form
    * '&lt;key&gt;=&lt;value&gt;' into a Map. Locates that list, splits its key and value pairs, and
    * returns they Map they represent.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -28,6 +28,7 @@ import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
@@ -410,7 +411,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * Returns the keyfile
    */
   public String getKeyFile() {
-    return getPassword(KEYFILE_CONFIG).value();
+    return Optional.ofNullable(getPassword(KEYFILE_CONFIG)).map(Password::value).orElse(null);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -63,7 +63,7 @@ public class SinkPropertiesFactory {
     config.getList(config.TOPICS_TO_TABLES_CONFIG);
     config.getList(config.DATASETS_CONFIG);
 
-    config.getString(config.KEYFILE_CONFIG);
+    config.getPassword(config.KEYFILE_CONFIG);
     config.getString(config.PROJECT_CONFIG);
 
     config.getBoolean(config.SANITIZE_TOPICS_CONFIG);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -63,7 +63,7 @@ public class SinkPropertiesFactory {
     config.getList(config.TOPICS_TO_TABLES_CONFIG);
     config.getList(config.DATASETS_CONFIG);
 
-    config.getPassword(config.KEYFILE_CONFIG);
+    config.getKeyFile();
     config.getString(config.PROJECT_CONFIG);
 
     config.getBoolean(config.SANITIZE_TOPICS_CONFIG);


### PR DESCRIPTION
The keyfile config right now is a string. This means that the connector logs are printing the keyfile which is unsafe. 