### PR TITLE
CC-7246: add ability to partition based on timestamp of a record value field

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -96,17 +96,6 @@ public class BigQuerySinkConnector extends SinkConnector {
     return new BigQueryHelper().setKeySource(keySource).connect(projectName, key);
   }
 
-  private SchemaManager getSchemaManager(BigQuery bigQuery) {
-    if (testSchemaManager != null) {
-      return testSchemaManager;
-    }
-    SchemaRetriever schemaRetriever = config.getSchemaRetriever();
-    SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter = config.getSchemaConverter();
-    Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
-    Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
-    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery, kafkaKeyFieldName, kafkaDataFieldName);
-  }
-
   private void ensureExistingTables() {
     BigQuery bigQuery = getBigQuery();
     Map<String, TableId> topicsToTableIds = TopicToTableResolver.getTopicsToTables(config);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -279,7 +279,9 @@ public class BigQuerySinkTask extends SinkTask {
         config.getSchemaConverter();
     Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
     Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
-    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery, kafkaKeyFieldName, kafkaDataFieldName);
+    Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
+    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery, kafkaKeyFieldName,
+        kafkaDataFieldName, timestampPartitionFieldName);
   }
 
   private BigQueryWriter getBigQueryWriter() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -281,7 +281,7 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
     Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
     return new SchemaManager(schemaRetriever, schemaConverter, bigQuery, kafkaKeyFieldName,
-        kafkaDataFieldName, timestampPartitionFieldName);
+                             kafkaDataFieldName, timestampPartitionFieldName);
   }
 
   private BigQueryWriter getBigQueryWriter() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 
@@ -33,45 +34,71 @@ import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import org.apache.kafka.connect.data.Schema;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Optional;
 
 public class SchemaManagerTest {
 
+  private String testTableName = "testTable";
+  private String testDatasetName = "testDataset";
+  private String testDoc = "test doc";
+  private TableId tableId = TableId.of(testDatasetName, testTableName);
+
+  private SchemaRetriever mockSchemaRetriever;
+  private SchemaConverter<com.google.cloud.bigquery.Schema> mockSchemaConverter;
+  private BigQuery mockBigQuery;
+  private Schema mockKafkaSchema;
+  private com.google.cloud.bigquery.Schema fakeBigQuerySchema;
+
+  @Before
+  public void before() {
+    mockSchemaRetriever = mock(SchemaRetriever.class);
+    mockSchemaConverter =
+        (SchemaConverter<com.google.cloud.bigquery.Schema>) mock(SchemaConverter.class);
+    mockBigQuery = mock(BigQuery.class);
+    mockKafkaSchema = mock(Schema.class);
+    fakeBigQuerySchema = com.google.cloud.bigquery.Schema.of(
+        Field.of("mock field", LegacySQLTypeName.STRING));
+  }
+
   @Test
   public void testBQTableDescription() {
-    final String testTableName = "testTable";
-    final String testDatasetName = "testDataset";
-    final String testDoc = "test doc";
-    final TableId tableId = TableId.of(testDatasetName, testTableName);
-
-    SchemaRetriever mockSchemaRetriever = mock(SchemaRetriever.class);
-    @SuppressWarnings("unchecked")
-    SchemaConverter<com.google.cloud.bigquery.Schema> mockSchemaConverter =
-        (SchemaConverter<com.google.cloud.bigquery.Schema>) mock(SchemaConverter.class);
-    BigQuery mockBigQuery = mock(BigQuery.class);
-
     Optional<String> kafkaKeyFieldName = Optional.of("kafkaKey");
     Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
-
-    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever,
-                                                    mockSchemaConverter,
-                                                    mockBigQuery,
-                                                    kafkaKeyFieldName,
-                                                    kafkaDataFieldName);
-
-    Schema mockKafkaSchema = mock(Schema.class);
-    // we would prefer to mock this class, but it is final.
-    com.google.cloud.bigquery.Schema fakeBigQuerySchema =
-        com.google.cloud.bigquery.Schema.of(Field.of("mock field", LegacySQLTypeName.STRING));
+    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
+        mockBigQuery, kafkaKeyFieldName, kafkaDataFieldName, Optional.empty());
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
-    TableInfo tableInfo = schemaManager.constructTableInfo(tableId, mockKafkaSchema, mockKafkaSchema);
+    TableInfo tableInfo = schemaManager
+        .constructTableInfo(tableId, mockKafkaSchema, mockKafkaSchema);
 
     Assert.assertEquals("Kafka doc does not match BigQuery table description",
-                        testDoc, tableInfo.getDescription());
+        testDoc, tableInfo.getDescription());
+    Assert.assertNull("Timestamp partition field name is not null",
+        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getField());
   }
+
+  @Test
+  public void testTimestampPartitionSet() {
+    Optional<String> testField = Optional.of("testField");
+    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
+        mockBigQuery, Optional.empty(), Optional.empty(), testField);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
+    when(mockKafkaSchema.doc()).thenReturn(testDoc);
+
+    TableInfo tableInfo = schemaManager
+        .constructTableInfo(tableId, mockKafkaSchema, mockKafkaSchema);
+
+    Assert.assertEquals("Kafka doc does not match BigQuery table description",
+        testDoc, tableInfo.getDescription());
+    Assert.assertEquals("The field name does not match the field name of time partition",
+        testField.get(),
+        ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning().getField());
+  }
+
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -97,8 +97,6 @@ public class BigQuerySinkTaskConfigTest {
     assertFalse(testConfig.getBoolean(BigQuerySinkTaskConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG));
   }
 
-
-
   @Test(expected = ConfigException.class)
   public void testAutoSchemaUpdateWithoutRetriever() {
     Map<String, String> badConfigProperties = propertiesFactory.getProperties();

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -65,7 +65,7 @@ public class BigQuerySinkTaskConfigTest {
   }
 
   /**
-   * Test the the default for the field name is not present.
+   * Test the default for the field name is not present.
    */
   @Test
   public void testEmptyTimestampPartitionFieldName() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -18,6 +18,8 @@ package com.wepay.kafka.connect.bigquery.config;
  */
 
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
@@ -61,6 +63,41 @@ public class BigQuerySinkTaskConfigTest {
     new BigQuerySinkTaskConfig(badProperties);
     */
   }
+
+  /**
+   * Test the the default for the field name is not present.
+   */
+  @Test
+  public void testEmptyTimestampPartitionFieldName() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    BigQuerySinkTaskConfig testConfig = new BigQuerySinkTaskConfig(configProperties);
+    assertFalse(testConfig.getTimestampPartitionFieldName().isPresent());
+  }
+
+  /**
+   * Test if the field name being non-empty and the decorator default (true) errors correctly.
+   */
+  @Test (expected = ConfigException.class)
+  public void testTimestampPartitionFieldNameError() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkTaskConfig.BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG, "name");
+    new BigQuerySinkTaskConfig(configProperties);
+  }
+
+  /**
+   * Test the field name being non-empty and the decorator set to false works correctly.
+   */
+  @Test
+  public void testTimestampPartitionFieldName() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkTaskConfig.BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG, "name");
+    configProperties.put(BigQuerySinkTaskConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "false");
+    BigQuerySinkTaskConfig testConfig = new BigQuerySinkTaskConfig(configProperties);
+    assertTrue(testConfig.getTimestampPartitionFieldName().isPresent());
+    assertFalse(testConfig.getBoolean(BigQuerySinkTaskConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG));
+  }
+
+
 
   @Test(expected = ConfigException.class)
   public void testAutoSchemaUpdateWithoutRetriever() {


### PR DESCRIPTION
Replaces #214. Implements additional validation for the configs to either use decorators or field name for partitioning. Adds ability to partition BQ tables based on a field name that contains timestamp information. 

**Performed Manual Integration Tests** 

Tokens `PROJECT_ID`, `DATASET_ID`, `TABLE_ID` are used as substitutes in this example for the actual IDs.  

1. Start connector on local confluent cluster with the configurations:
```
name=bigquery-connector
connector.class=com.wepay.kafka.connect.bigquery.BigQuerySinkConnector
tasks.max=1

topics=TABLE_ID
sanitizeTopics=true

autoUpdateSchemas=true
bigQueryPartitionDecorator=false
timestampPartitionFieldName=f2

schemaRetriever=com.wepay.kafka.connect.bigquery.schemaregistry.schemaretriever.SchemaRegistrySchemaRetriever
schemaRegistryLocation=http://localhost:8081

bufferSize=100000
maxWriteSize=10000
tableWriteWait=1000

########################################### Fill me in! ###########################################
# The name of the BigQuery project to write to
project=PROJECT_ID
# The name of the BigQuery dataset to write to (leave the '.*=' at the beginning, enter your
# dataset after it)
datasets=.*=DATASET_ID
# The location of a BigQuery service account JSON key file
keyfile=FILEPATH
```
 
2. Send a few records using the avro producer, with various different dates, for example: 

```
echo '{"f1":"Testing the Kafka-BigQuery partitioning!", "f2": 1580513872000}' | ./kafka-avro-console-producer --broker-list localhost:9092 --topic TABLE_ID --property value.schema='{"type": "record", "name": "myrecord", "fields": [{ "name": "f1","type": "string"},{"name": "f2","type": {"connect.name": "org.apache.kafka.connect.data.Timestamp","connect.version": 1,"logicalType": "timestamp-millis","type":"long"}}]}'
```

3. Using the BigQuery console, run the following query to verify the existing partitions: 
```
SELECT f2 as pt, FORMAT_TIMESTAMP("%Y%m%d", f2) as partition_id
FROM `PROJECT_ID.DATASET_ID.TABLE_ID`
GROUP BY f2
ORDER BY f2
```

The output will list all the rows that have different dates, with an additional column of `partition_id`. Records that have a timestamp within a day's range will have the same `partition_id` as expected.  