### PR TITLE
Check if table exists based on each TableWriterBuilder.

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -163,8 +163,8 @@ public class BigQuerySinkTask extends SinkTask {
 
   /**
    * Create the table which doesn't exist in BigQuery for a (record's) topic when autoCreateTables config is set to true.
-   * @param topic Kafka Sink Record topic.
    * @param baseTableId BaseTableId in BigQuery.
+   * @param topic Kafka Sink Record topic.
    */
   private void maybeCreateTable(TableId baseTableId, String topic) {
     BigQuery bigQuery = getBigQuery();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -166,7 +166,7 @@ public class BigQuerySinkTask extends SinkTask {
    * @param baseTableId BaseTableId in BigQuery.
    * @param topic Kafka Sink Record topic.
    */
-  private void maybeCreateTable(TableId baseTableId, String topic) {
+  private void createTableIfNecessary(TableId baseTableId, String topic) {
     BigQuery bigQuery = getBigQuery();
     boolean autoCreateTables = config.getBoolean(config.TABLE_CREATE_CONFIG);
     if (autoCreateTables && bigQuery.getTable(baseTableId) == null) {
@@ -247,7 +247,7 @@ public class BigQuerySinkTask extends SinkTask {
 
     // add tableWriters to the executor work queue
     for (TableWriterBuilder builder : tableWriterBuilders.values()) {
-      maybeCreateTable(builder.getBaseTableId(), builder.getTopic());
+      createTableIfNecessary(builder.getBaseTableId(), builder.getTopic());
       executor.execute(builder.build());
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Batch Table Writer that uploads records to GCS as a blob
@@ -87,6 +86,7 @@ public class GCSBatchTableWriter implements Runnable {
   public static class Builder implements TableWriterBuilder {
     private final String bucketName;
     private String blobName;
+    private String topic;
 
     private final TableId tableId;
 
@@ -107,10 +107,12 @@ public class GCSBatchTableWriter implements Runnable {
                    TableId tableId,
                    String gcsBucketName,
                    String gcsBlobName,
+                   String topic,
                    RecordConverter<Map<String, Object>> recordConverter) {
 
       this.bucketName = gcsBucketName;
       this.blobName = gcsBlobName;
+      this.topic = topic;
 
       this.tableId = tableId;
 
@@ -134,6 +136,16 @@ public class GCSBatchTableWriter implements Runnable {
 
     public GCSBatchTableWriter build() {
       return new GCSBatchTableWriter(rows, writer, tableId, bucketName, blobName);
+    }
+
+    @Override
+    public TableId getBaseTableId() {
+      return tableId;
+    }
+
+    @Override
+    public String getTopic() {
+      return topic;
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -20,13 +20,13 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.TableId;
 
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -185,6 +185,16 @@ public class TableWriter implements Runnable {
      */
     public TableWriter build() {
       return new TableWriter(writer, table, rows, topic);
+    }
+
+    @Override
+    public TableId getBaseTableId() {
+      return table.getBaseTableId();
+    }
+
+    @Override
+    public String getTopic() {
+      return topic;
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
@@ -19,6 +19,7 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.TableId;
 
 /**
  * Interface for building a {@link TableWriter} or TableWriterGCS.
@@ -36,4 +37,8 @@ public interface TableWriterBuilder {
    * @return a TableWriter containing the given writer, table, topic, and all added rows.
    */
   Runnable build();
+
+  TableId getBaseTableId();
+
+  String getTopic();
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriter.java
@@ -101,13 +101,6 @@ public class GCSToBQWriter {
     BlobInfo blobInfo =
          BlobInfo.newBuilder(blobId).setContentType("text/json").setMetadata(metadata).build();
 
-    // Check if the table specified exists
-    // This error shouldn't be thrown. All tables should be created by the connector at startup
-    if (bigQuery.getTable(tableId) == null) {
-      throw new ConnectException(
-          String.format("Table with TableId %s does not exist.", tableId.getTable()));
-    }
-
     int attemptCount = 0;
     boolean success = false;
     while (!success && (attemptCount <= retries)) {


### PR DESCRIPTION
- Do not check if table exists based on each Kafka record, instead, based on each TableWriterBuilder.

- The situation is already covered by current integration tests.