### PR TITLE
Handling NPE when schema registry details not required

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -304,9 +304,12 @@ public class BigQuerySinkTask extends SinkTask {
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
     boolean autoCreateTables = config.getBoolean(config.TABLE_CREATE_CONFIG);
+    // schemaManager shall only be needed for creating table hence do not fetch instance if not
+    // needed.
+    SchemaManager schemaManager = autoCreateTables ? getSchemaManager(bigQuery) : null;
     return new GCSToBQWriter(getGcs(),
                          bigQuery,
-                         getSchemaManager(bigQuery),
+                         schemaManager,
                          retry,
                          retryWait,
                          autoCreateTables);


### PR DESCRIPTION
- `getSchemaManager()` requires schema registry class details which might not be required when `autoCreateTables` is set to `false`. Failing to provide `schema` details, `NullPointerException` is being thrown hence the connector becomes unusable with any format other than `avro`.

- Ideally we shall have `extended` different class overriding base feature class and adding functionality for `autoCreateTables` with `schemaManager`. To unblock the connector for release added `null` check to handle issue. 

```org.apache.kafka.common.config.ConfigException: Cannot request new instance of SchemaRetriever when class has not been specified
	at com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.getSchemaRetriever(BigQuerySinkConfig.java:555)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.getSchemaManager(BigQuerySinkTask.java:263)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.getGcsWriter(BigQuerySinkTask.java:309)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.start(BigQuerySinkTask.java:330)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:300)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:189)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
[2020-03-02 20:04:16,203] ERROR WorkerSinkTask{id=bigquery-connector-9} Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask:180)
[2020-03-02 20:04:16,203] WARN Could not stop task (org.apache.kafka.connect.runtime.WorkerSinkTask:160)
java.lang.NullPointerException
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.stop(BigQuerySinkTask.java:366)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.close(WorkerSinkTask.java:158)
	at org.apache.kafka.connect.runtime.WorkerTask.doClose(WorkerTask.java:156)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:183)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)