### PR TITLE
Only list gcs folder blobs in GCSToBQLoadRunnable

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -350,6 +350,7 @@ public class BigQuerySinkTask extends SinkTask {
     logger.info("Attempting to start GCS Load Executor.");
     gcsLoadExecutor = Executors.newScheduledThreadPool(1);
     String bucketName = config.getString(config.GCS_BUCKET_NAME_CONFIG);
+    String folderName = config.getString(config.GCS_FOLDER_NAME_CONFIG);
     Storage gcs = getGcs();
     // get the bucket, or create it if it does not exist.
     Bucket bucket = gcs.get(bucketName);
@@ -359,7 +360,8 @@ public class BigQuerySinkTask extends SinkTask {
       BucketInfo bucketInfo = BucketInfo.of(bucketName);
       bucket = gcs.create(bucketInfo);
     }
-    GCSToBQLoadRunnable loadRunnable = new GCSToBQLoadRunnable(getBigQuery(), bucket);
+    Storage.BlobListOption folderPrefixOption = Storage.BlobListOption.prefix(folderName);
+    GCSToBQLoadRunnable loadRunnable = new GCSToBQLoadRunnable(getBigQuery(), bucket, folderPrefixOption);
 
     int intervalSec = config.getInt(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG);
     gcsLoadExecutor.scheduleAtFixedRate(loadRunnable, intervalSec, intervalSec, TimeUnit.SECONDS);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GCSToBQLoadRunnable.java
@@ -29,6 +29,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.Storage.BlobListOption;
 
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 
@@ -58,6 +59,7 @@ public class GCSToBQLoadRunnable implements Runnable {
 
   private final BigQuery bigQuery;
   private final Bucket bucket;
+  private final BlobListOption folderPrefixOption;
   private final Map<Job, List<BlobId>> activeJobs;
   private final Set<BlobId> claimedBlobIds;
   private final Set<BlobId> deletableBlobIds;
@@ -79,9 +81,10 @@ public class GCSToBQLoadRunnable implements Runnable {
    * @param bigQuery the {@link BigQuery} instance.
    * @param bucket the the GCS bucket to read from.
    */
-  public GCSToBQLoadRunnable(BigQuery bigQuery, Bucket bucket) {
+  public GCSToBQLoadRunnable(BigQuery bigQuery, Bucket bucket, BlobListOption folderPrefixOption) {
     this.bigQuery = bigQuery;
     this.bucket = bucket;
+    this.folderPrefixOption = folderPrefixOption;
     this.activeJobs = new HashMap<>();
     this.claimedBlobIds = new HashSet<>();
     this.deletableBlobIds = new HashSet<>();
@@ -101,7 +104,7 @@ public class GCSToBQLoadRunnable implements Runnable {
     Map<TableId, Long> tableToCurrentLoadSize = new HashMap<>();
 
     logger.trace("Starting GCS bucket list");
-    Page<Blob> list = bucket.list();
+    Page<Blob> list = bucket.list(folderPrefixOption);
     logger.trace("Finished GCS bucket list");
 
     for (Blob blob : list.iterateAll()) {


### PR DESCRIPTION
Functionality for specifying a GCS folder within the bucket to dump objects into was added [here](https://github.com/wepay/kafka-connect-bigquery/pull/164). 

However we ran into a problem when using the GCS->BQ batch mode of the connector; each connector schedules it's own instance of the `GCSToBQLoadRunnable` which does not use the folder when listing objects to load into BigQuery. Because of this, if you have multiple connectors using the same bucket but different folders they all load all the data and so you receive many duplicates and have trouble when deleting gcs objects.

I have passed through the folder prefix as a list option to the `GCSToBQLoadRunnable`, and all tests seem to be passing for me with the update. However a new integration test should added to recreate the issue and confirms this works fixes it. However this is not a straight forward addition of data and schema, as detailed in the readme section for adding integration tests. I thought it was best raised here for how it should be implemented however I would imagine it working as follows:
- Add some objects in same GCS bucket but in a folder next to the target folder of connector
- Run connector
- Assert rows in target folder appeared
- Assert rows in other folder did not appear