### PR TITLE
CC-9148: Implement DLQ Functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ project(':kcbq-connector') {
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
     }
 
@@ -200,16 +201,18 @@ project(':kcbq-connector') {
     }
 
     dependencies {
+        implementation('org.apache.kafka:connect-api:2.6.0-SNAPSHOT') {
+            force = true
+        }
+        
         compile (
                 project(':kcbq-api'),
-
+                "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
                 "com.google.cloud:google-cloud-storage:$googleCloudVersion",
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
                 "io.debezium:debezium-core:$debeziumVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion",
-                "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",
         )
 
@@ -256,9 +259,9 @@ project('kcbq-api') {
     }
 
     dependencies {
+        implementation("org.apache.kafka:connect-api:2.6.0-SNAPSHOT")
         compile (
                 "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion"
         )
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Jun 01 16:39:15 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryConnectException.java
@@ -20,8 +20,10 @@ package com.wepay.kafka.connect.bigquery.exception;
 
 import com.google.cloud.bigquery.BigQueryError;
 
+import com.google.cloud.bigquery.InsertAllRequest;
 import org.apache.kafka.connect.errors.ConnectException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +32,10 @@ import java.util.Map;
  * update failures, and table insertion failures.
  */
 public class BigQueryConnectException extends ConnectException {
+
+  private List<InsertAllRequest.RowToInsert> failedRows = new ArrayList<>();
+  private boolean invalidSchema = false;
+
   public BigQueryConnectException(String msg) {
     super(msg);
   }
@@ -44,6 +50,23 @@ public class BigQueryConnectException extends ConnectException {
 
   public BigQueryConnectException(Map<Long, List<BigQueryError>> errors) {
     super(formatInsertAllErrors(errors));
+  }
+
+  public BigQueryConnectException(
+      Map<Long, List<BigQueryError>> errors,
+      List<InsertAllRequest.RowToInsert> failedRows
+  ) {
+    super(formatInsertAllErrors(errors));
+    this.failedRows = failedRows;
+    this.invalidSchema = true;
+  }
+
+  public List<InsertAllRequest.RowToInsert> getFailedRows() {
+    return failedRows;
+  }
+
+  public boolean isInvalidSchema() {
+    return invalidSchema;
   }
 
   private static String formatInsertAllErrors(Map<Long, List<BigQueryError>> errorsMap) {


### PR DESCRIPTION
Implement error reporter functionality in the BigQuery Sink Connector for the following criteria:

- The data is not a struct map (happens when using JSON)
- When connector is not able to write to table because of schema mismatches

Signed-off-by: Aakash Shah <ashah@confluent.io>