### PR TITLE
Remove Kafka artifacts from the connector's packaged tar artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,12 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+def withoutKafka = {
+    exclude group: 'org.apache.kafka', module: 'connect-api'
+    exclude group: 'org.apache.kafka', module: 'connect-transforms'
+    exclude group: 'org.apache.kafka', module: 'kafka-clients'
+}
+
 // END ALL PROJECTS
 
 project.ext {
@@ -207,17 +213,20 @@ project(':kcbq-connector') {
                 "com.google.cloud:google-cloud-storage:$googleCloudVersion",
                 "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion",
                 "com.google.code.gson:gson:$googleCloudGsonVersion",
-                "io.debezium:debezium-core:$debeziumVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion",
-                "org.apache.kafka:kafka-clients:$kafkaVersion",
-                "org.apache.kafka:connect-runtime:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",
+        )
+
+        compile "io.debezium:debezium-core:$debeziumVersion", withoutKafka
+
+        compileOnly (
+                "org.apache.kafka:connect-api:$kafkaVersion"
         )
 
         testCompile (
                 "junit:junit:$junitVersion",
                 "org.mockito:mockito-core:$mockitoVersion",
-                "org.mockito:mockito-inline:$mockitoVersion"
+                "org.mockito:mockito-inline:$mockitoVersion",
+                "org.apache.kafka:connect-api:$kafkaVersion"
         )
     }
 
@@ -257,10 +266,9 @@ project('kcbq-api') {
     }
 
     dependencies {
-        compile (
-                "com.google.cloud:google-cloud-bigquery:$googleCloudVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion"
-        )
+        compile "com.google.cloud:google-cloud-bigquery:$googleCloudVersion"
+
+        compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     }
 
     artifacts {
@@ -283,13 +291,6 @@ project('kcbq-api') {
 
 project('kcbq-confluent') {
     apply plugin: 'distribution'
-
-    configurations.all {
-        resolutionStrategy {
-            // depending on debezium results in us pulling in the most recent kafka version.
-            force 'org.apache.kafka:connect-api:2.5.0', 'org.apache.kafka:kafka-clients:2.5.0'
-        }
-    }
 
     distributions {
         main {
@@ -321,23 +322,30 @@ project('kcbq-confluent') {
     }
 
     dependencies {
-        runtime project(':kcbq-connector')
 
         compile (
+                project(':kcbq-connector'),
                 project(':kcbq-api'),
 
-                "io.confluent:kafka-connect-avro-converter:$ioConfluentVersion",
-                "io.confluent:kafka-schema-registry-client:$ioConfluentVersion",
                 "org.apache.avro:avro:$avroVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion",
-                "org.apache.kafka:kafka-clients:$kafkaVersion",
                 "org.slf4j:slf4j-api:$slf4jVersion",
+        )
+
+        compile "io.confluent:kafka-connect-avro-converter:$ioConfluentVersion", withoutKafka
+        compile "io.confluent:kafka-schema-registry-client:$ioConfluentVersion", withoutKafka
+
+        compileOnly (
+                "org.apache.kafka:connect-api:$kafkaVersion",
+                "org.apache.kafka:kafka-clients:$kafkaVersion"
         )
 
         testCompile (
                 "junit:junit:$junitVersion",
                 "org.mockito:mockito-core:$mockitoVersion",
-                "org.mockito:mockito-inline:$mockitoVersion"
+                "org.mockito:mockito-inline:$mockitoVersion",
+                "org.apache.kafka:connect-api:$kafkaVersion",
+                "org.apache.kafka:kafka-clients:$kafkaVersion"
+
         )
     }
 


### PR DESCRIPTION
The changes in https://github.com/wepay/kafka-connect-bigquery/pull/279 might be a good temporary workaround for some very specific environments but in general are not optimal for a connector that's going to be used by a wide variety of users working in different environments. Here's why:

1. Including the Connect runtime as a dependency is only going to affect users who include connectors on the worker's classpath, which is unstable, no longer recommended, and should be avoided in favor of the isolated plugin loading mechanism introduced in [KIP-146](https://cwiki.apache.org/confluence/display/KAFKA/KIP-146+-+Classloading+Isolation+in+Connect) and available since the 0.11.0 release of Connect.

2. Even if the connector is being run on the classpath of the worker, it's not guaranteed that the version of the `connect-runtime` artifact that the connector is packaged with is what's going to be run if the classpath has another version of that artifact contained on it (which, given the standard deployment model for the Connect framework, is extremely likely).

3. Even if the version that gets packaged with the connector is picked up and used, users may want to use a later version of the Connect framework that contains bug fixes or features that are only available in a later release than whatever the connector happens to be packaged with.

4. It's better to cut down on unneeded dependencies (such as `kafka-clients`, `connect-api`, and `connect-transformations`) than add on another dependency. The total difference is a few MB, which although not critical, is definitely better than the alternative.

This PR removes `connect-runtime` as a dependency and also prevents the Kafka artifacts `kafka-clients`, `connect-api`, and `connect-transforms` from being included in the packaged tarball for the connector. This should address the issues that led to https://github.com/wepay/kafka-connect-bigquery/pull/279 and work for many other environments as well.