### PR TITLE
CC-8804: Add integration tests for upsert/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,41 @@ adjusting flags given to the Avro Console Producer and tweaking the config setti
 
 ## Integration Testing the Connector
 
+There is a legacy Docker-based integration test for the connector, and newer integration tests that
+programmatically instantiate an embedded Connect cluster.
+
+### Embedded integration tests
+
+Currently these tests only verify the connector's upsert/delete feature. They should eventually
+replace all of the existing Docker-based tests.
+
+#### Configuring the tests
+
+You must supply the following environment variables in order to run the tests:
+
+- `$KCBQ_TEST_PROJECT`: The name of the BigQuery project to use for the test
+- `$KCBQ_TEST_DATASET`: The name of the BigQuery dataset to use for the test
+- `$KCBQ_TEST_KEYFILE`: The key (either file or raw contents) used to authenticate with BigQuery
+during the test
+
+Additionally, the `$KCBQ_TEST_KEYSOURCE` variable can be supplied to specify whether the value of
+`$KCBQ_TEST_KEYFILE` are a path to a key file (if set to `FILE`) or the raw contents of a key file
+(if set to `JSON`). The default is `FILE`.
+
+#### Running the Integration Tests
+
+```bash
+./gradlew embeddedIntegrationTest
+```
+
+### Docker-based tests
+
 > **NOTE**: You must have [Docker] installed and running on your machine in order to run integration
 tests for the connector.
 
 This all takes place in the `kcbq-connector` directory.
 
-### How Integration Testing Works
+#### How Integration Testing Works
 
 Integration tests run by creating [Docker] instances for [Zookeeper], [Kafka], [Schema Registry], 
 and the BigQuery Connector itself, then verifying the results using a [JUnit] test.
@@ -148,7 +177,7 @@ The project and dataset they write to, as well as the specific JSON key file the
 specified by command-line flag, environment variable, or configuration file — the exact details of
 each can be found by running the integration test script with the `-?` flag.
 
-### Data Corruption Concerns
+#### Data Corruption Concerns
 
 In order to ensure the validity of each test, any table that will be written to in the course of
 integration testing is preemptively deleted before the connector is run. This will only be an issue
@@ -161,7 +190,7 @@ tests will corrupt any existing data that is already on your machine, and there 
 free up any of your ports that might currently be in use by real instances of the programs that are 
 faked in the process of testing.
 
-### Running the Integration Tests
+#### Running the Integration Tests
 
 Running the series of integration tests is easy:
 
@@ -176,7 +205,7 @@ the `--help` flag.
 > **NOTE:** You must have a recent version of [boot2docker], [Docker Machine], [Docker], etc.
 installed. Older versions will hang when cleaning containers, and linking doesn't work properly.
 
-### Adding New Integration Tests
+#### Adding New Integration Tests
 
 Adding an integration test is a little more involved, and consists of two major steps: specifying
 Avro data to be sent to Kafka, and specifying via JUnit test how to verify that such data made 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ project.ext {
     ioConfluentVersion = '5.5.0'
     junitVersion = '4.12'
     kafkaVersion = '2.5.0'
+    kafkaScalaVersion = '2.12' // For integration testing only
     mockitoVersion = '3.2.4'
     slf4jVersion = '1.6.1'
 }
@@ -153,6 +154,26 @@ project(':kcbq-connector') {
         }
     }
 
+    test {
+        useJUnit {
+            // Exclude embedded integration tests from normal testing since they require BigQuery
+            // credentials and can take a while
+            excludeCategories 'org.apache.kafka.test.IntegrationTest'
+        }
+    }
+
+    task embeddedIntegrationTest(type: Test) {
+        useJUnit {
+            includeCategories 'org.apache.kafka.test.IntegrationTest'
+        }
+
+        // Enable logging for integration tests
+        testLogging {
+            outputs.upToDateWhen {false}
+            showStandardStreams = true
+        }
+    }
+
     task integrationTestPrep() {
         dependsOn 'integrationTestTablePrep'
         dependsOn 'integrationTestBucketPrep'
@@ -226,7 +247,12 @@ project(':kcbq-connector') {
                 "junit:junit:$junitVersion",
                 "org.mockito:mockito-core:$mockitoVersion",
                 "org.mockito:mockito-inline:$mockitoVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion"
+                "org.apache.kafka:kafka_$kafkaScalaVersion:$kafkaVersion",
+                "org.apache.kafka:kafka_$kafkaScalaVersion:$kafkaVersion:test",
+                "org.apache.kafka:kafka-clients:$kafkaVersion:test",
+                "org.apache.kafka:connect-api:$kafkaVersion",
+                "org.apache.kafka:connect-runtime:$kafkaVersion",
+                "org.apache.kafka:connect-runtime:$kafkaVersion:test",
         )
     }
 

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -16,7 +16,7 @@ public interface SchemaRetriever {
    * {@link org.apache.kafka.connect.sink.SinkConnector#start(Map)} method.
    * @param properties The configuration settings of the connector.
    */
-  public void configure(Map<String, String> properties);
+  void configure(Map<String, String> properties);
 
   /**
    * Retrieve the most current schema for the given topic.
@@ -25,13 +25,30 @@ public interface SchemaRetriever {
    * @param schemaType The type of kafka schema, either "value" or "key".
    * @return The Schema for the given table.
    */
-  public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType);
+  Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType);
 
   /**
-   * Set the last seen schema for a given topic
+   * Set the last seen schema for a given topic.
    * @param table The table that will be created.
    * @param topic The topic to retrieve a schema for.
    * @param schema The last seen Kafka Connect Schema
    */
-  public void setLastSeenSchema(TableId table, String topic, Schema schema);
+  void setLastSeenSchema(TableId table, String topic, Schema schema);
+
+  /**
+   * Set the last seen schema for a given topic and record type.
+   * In order to preserve backwards compatibility, will invoke
+   * {@link #setLastSeenSchema(TableId, String, Schema)} by default if the schema is for a record
+   * value, and otherwise be a no-op.
+   * @param table The table that will be created.
+   * @param topic The topic to retrieve a schema for.
+   * @param schema The last seen Kafka Connect Schema.
+   * @param schemaType The type of the schema (key or value).
+   * @since 1.7.0
+   */
+  default void setLastSeenSchema(TableId table, String topic, Schema schema, KafkaSchemaRecordType schemaType) {
+    if (KafkaSchemaRecordType.VALUE.equals(schemaType)) {
+      setLastSeenSchema(table, topic, schema, KafkaSchemaRecordType.VALUE);
+    }
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -25,6 +25,7 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
@@ -143,12 +144,12 @@ public class BigQuerySinkConnector extends SinkConnector {
     logger.trace("connector.taskConfigs()");
     List<Map<String, String>> taskConfigs = new ArrayList<>();
     for (int i = 0; i < maxTasks; i++) {
-      // Copy configProperties so that tasks can't interfere with each others' configurations
       HashMap<String, String> taskConfig = new HashMap<>(configProperties);
       if (i == 0 && !config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).isEmpty()) {
         // if batch loading is enabled, configure first task to do the GCS -> BQ loading
         taskConfig.put(GCS_BQ_TASK_CONFIG_KEY, "true");
       }
+      taskConfig.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, Integer.toString(i));
       taskConfigs.add(taskConfig);
     }
     return taskConfigs;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -1,0 +1,336 @@
+package com.wepay.kafka.connect.bigquery;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MergeQueries {
+  public static final String INTERMEDIATE_TABLE_KEY_FIELD_NAME = "key";
+  public static final String INTERMEDIATE_TABLE_VALUE_FIELD_NAME = "value";
+  public static final String INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME = "partitionTime";
+  public static final String INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD = "batchNumber";
+
+  private static final Logger logger = LoggerFactory.getLogger(MergeQueries.class);
+
+  private final String keyFieldName;
+  private final boolean usePartitionDecorator;
+  private final boolean upsertEnabled;
+  private final boolean deleteEnabled;
+  private final MergeBatches mergeBatches;
+  private final ExecutorService executor;
+  private final BigQuery bigQuery;
+  private final SchemaManager schemaManager;
+  private final SinkTaskContext context;
+
+  public MergeQueries(BigQuerySinkTaskConfig config,
+                      MergeBatches mergeBatches,
+                      ExecutorService executor,
+                      BigQuery bigQuery,
+                      SchemaManager schemaManager,
+                      SinkTaskContext context) {
+    this.keyFieldName = config.getKafkaKeyFieldName().orElseThrow(() ->
+        new ConnectException("Kafka key field must be configured when upsert/delete is enabled")
+    );
+    this.usePartitionDecorator = config.getBoolean(config.BIGQUERY_PARTITION_DECORATOR_CONFIG);
+    this.upsertEnabled = config.getBoolean(config.UPSERT_ENABLED_CONFIG);
+    this.deleteEnabled = config.getBoolean(config.DELETE_ENABLED_CONFIG);
+
+    this.mergeBatches = mergeBatches;
+    this.executor = executor;
+    this.bigQuery = bigQuery;
+    this.schemaManager = schemaManager;
+    this.context = context;
+  }
+
+  public void mergeFlushAll() {
+    logger.debug("Triggering merge flush for all tables");
+    mergeBatches.intermediateTables().forEach(this::mergeFlush);
+  }
+
+  public void mergeFlush(TableId intermediateTable) {
+    final TableId destinationTable = mergeBatches.destinationTableFor(intermediateTable);
+    final int batchNumber = mergeBatches.incrementBatch(intermediateTable);
+    logger.trace("Triggering merge flush from intermediate table {} to destination table {} for batch {}",
+        intermediateTable, destinationTable, batchNumber);
+
+    executor.submit(() -> {
+      // If there are rows to flush in this batch, flush them
+      if (mergeBatches.prepareToFlush(intermediateTable, batchNumber)) {
+        try {
+          logger.debug("Running merge query on batch {} from intermediate table {}",
+              batchNumber, intermediateTable);
+          String mergeFlushQuery = mergeFlushQuery(intermediateTable, destinationTable, batchNumber);
+          logger.trace(mergeFlushQuery);
+          bigQuery.query(QueryJobConfiguration.of(mergeFlushQuery));
+          logger.trace("Merge from intermediate table {} to destination table {} completed",
+              intermediateTable, destinationTable);
+        } catch (Throwable t) {
+          logger.warn("Failed on merge flush from intermediate table {} to destination table {}",
+              intermediateTable, destinationTable, t);
+          throw new ConnectException(
+              String.format("Failed to perform merge flush from intermediate table %s to destination table %s",
+                  intermediateTable,
+                  destinationTable),
+              t);
+        }
+
+        logger.debug("Recording flush success for batch {} from {}",
+            batchNumber, intermediateTable);
+        mergeBatches.recordSuccessfulFlush(intermediateTable, batchNumber);
+
+        // Commit those offsets ASAP
+        context.requestCommit();
+
+        logger.info("Completed merge flush of batch {} from {} to {}",
+            batchNumber, intermediateTable, destinationTable);
+      }
+
+      // After, regardless of whether we flushed or not, clean up old batches from the intermediate
+      // table. Some rows may be several batches old but still in the table if they were in the
+      // streaming buffer during the last purge.
+      try {
+        logger.trace("Clearing batches from {} on back from intermediate table {}", batchNumber, intermediateTable);
+        String tableClearQuery = clearBatchQuery(intermediateTable, batchNumber);
+        logger.trace(tableClearQuery);
+        bigQuery.query(QueryJobConfiguration.of(tableClearQuery));
+      } catch (Throwable t) {
+        logger.error("Failed to clear old batches from intermediate table {}", intermediateTable, t);
+        throw new ConnectException(
+            String.format("Failed to clear old batches from intermediate table %s",
+                intermediateTable),
+            t);
+      }
+    });
+  }
+
+  /*
+
+    upsert+delete:
+
+    MERGE `<dataset>`.`<destinationTable>`
+    USING (
+      SELECT * FROM (
+        SELECT ARRAY_AGG(
+          x ORDER BY partitionTime DESC LIMIT 1
+        )[OFFSET(0)] src
+        FROM `<dataset>`.`<intermediateTable>` x
+        WHERE batchNumber=<batchNumber>
+        GROUP BY key.<field>[, key.<field>...]
+      )
+    )
+    ON `<destinationTable>`.<keyField>=`src`.key
+    WHEN MATCHED AND `src`.value IS NOT NULL
+      THEN UPDATE SET <valueField>=`src`.value.<field>[, <valueField>=`src`.value.<field>...]
+    WHEN MATCHED AND `src`.value IS NULL
+      THEN DELETE
+    WHEN NOT MATCHED AND `src`.value IS NOT NULL
+      THEN INSERT (<keyField>, _PARTITIONTIME, <valueField>[, <valueField>])
+      VALUES (
+        `src`.key,
+        CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP),
+        `src`.value.<field>[, `src`.value.<field>...]
+      );
+
+
+    delete only:
+
+    MERGE `<dataset>`.`<destinationTable>`
+    USING (
+      SELECT * FROM (
+        SELECT ARRAY_AGG(
+          x ORDER BY partitionTime DESC LIMIT 1
+        )[OFFSET(0)] src
+        FROM `<dataset>`.`<intermediateTable>` x
+        WHERE batchNumber=<batchNumber>
+        GROUP BY key.<field>[, key.<field>...]
+      )
+    )
+    ON `<destinationTable>`.<keyField>=`src`.key AND `src`.value IS NULL
+    WHEN MATCHED
+      THEN DELETE
+    WHEN NOT MATCHED
+      THEN INSERT (<keyField>, _PARTITIONTIME, <valueField>[, <valueField>])
+      VALUES (
+        `src`.key,
+        CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP),
+        `src`.value.<field>[, `src`.value.<field>...]
+      );
+
+
+    upsert only:
+
+    MERGE `<dataset>`.`<destinationTable>`
+    USING (
+      SELECT * FROM (
+        SELECT ARRAY_AGG(
+          x ORDER BY partitionTime DESC LIMIT 1
+        )[OFFSET(0)] src
+        FROM `<dataset>`.`<intermediateTable>` x
+        WHERE batchNumber=<batchNumber>
+        GROUP BY key.<field>[, key.<field>...]
+      )
+    )
+    ON `<destinationTable>`.<keyField>=`src`.key
+    WHEN MATCHED
+      THEN UPDATE SET <valueField>=`src`.value.<field>[, <valueField=`src.value.<field>...]
+    WHEN NOT MATCHED
+      THEN INSERT (<keyField, _PARTITIONTIME, <valueField[, <valueField])
+      VALUES (
+        `src`.key,
+        CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP),
+        `src`.value.<field>[, `src`.value.<field>...]
+      );
+
+   */
+  private String mergeFlushQuery(TableId intermediateTable, TableId destinationTable, int batchNumber) {
+    Schema intermediateSchema = schemaManager.cachedSchema(intermediateTable);
+
+    String srcKey = INTERMEDIATE_TABLE_KEY_FIELD_NAME;
+
+    List<String> keyFields = listFields(
+        intermediateSchema.getFields().get(keyFieldName).getSubFields(),
+        srcKey + "."
+    );
+    List<String> dstValueFields = intermediateSchema.getFields().get(INTERMEDIATE_TABLE_VALUE_FIELD_NAME).getSubFields()
+        .stream()
+        .map(Field::getName)
+        .collect(Collectors.toList());
+
+    List<String> srcValueFields = dstValueFields.stream()
+        .map(field -> "`src`." + INTERMEDIATE_TABLE_VALUE_FIELD_NAME + "." + field)
+        .collect(Collectors.toList());
+    List<String> updateValues = dstValueFields.stream()
+        .map(field -> field + "=`src`." + INTERMEDIATE_TABLE_VALUE_FIELD_NAME + "." + field)
+        .collect(Collectors.toList());
+
+    String partitionTimeField = usePartitionDecorator ? "_PARTITIONTIME, " : "";
+    String partitionTimeValue = usePartitionDecorator
+        ? "CAST(CAST(DATE(`src`." + INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME + ") AS DATE) AS TIMESTAMP), "
+        : "";
+
+    String dst = destinationTable.getTable();
+
+    StringBuilder keysMatch = new StringBuilder("`").append(dst).append("`.").append(keyFieldName).append("=`src`.").append(srcKey);
+
+    StringBuilder mergeOpening = new StringBuilder("MERGE `").append(destinationTable.getDataset()).append("`.`").append(destinationTable.getTable()).append("` ")
+        .append("USING (")
+          .append("SELECT * FROM (")
+            .append("SELECT ARRAY_AGG(")
+              .append("x ORDER BY ").append(INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME).append(" DESC LIMIT 1")
+            .append(")[OFFSET(0)] src ")
+            .append("FROM `").append(intermediateTable.getDataset()).append("`.`").append(intermediateTable.getTable()).append("` x ")
+            .append("WHERE ").append(INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD).append("=").append(batchNumber).append(" ")
+            .append("GROUP BY ").append(String.join(", ", keyFields))
+          .append(")")
+        .append(") ");
+
+    StringBuilder insertClause = new StringBuilder("THEN INSERT (")
+          .append(keyFieldName).append(", ")
+          .append(partitionTimeField)
+          .append(String.join(", ", dstValueFields))
+        .append(") ")
+        .append("VALUES (")
+          .append("`src`.").append(srcKey).append(", ")
+          .append(partitionTimeValue)
+          .append(String.join(", ", srcValueFields))
+        .append(")");
+
+    StringBuilder updateClause = new StringBuilder("THEN UPDATE SET ")
+        .append(String.join(", ", updateValues));
+
+    StringBuilder valueIs = new StringBuilder("`src`.").append(INTERMEDIATE_TABLE_VALUE_FIELD_NAME).append(" IS ");
+
+    if (upsertEnabled && deleteEnabled) {
+      // Delete rows with null values, and upsert all others
+      return mergeOpening
+          .append("ON ").append(keysMatch).append(" ")
+          .append("WHEN MATCHED AND ").append(valueIs).append("NOT NULL ")
+            .append(updateClause).append(" ")
+          .append("WHEN MATCHED AND ").append(valueIs).append("NULL ")
+            .append("THEN DELETE ")
+          .append("WHEN NOT MATCHED AND ").append(valueIs).append("NOT NULL ")
+            .append(insertClause)
+          .append(";")
+          .toString();
+    } else if (deleteEnabled) {
+      // Delete rows with null values, and insert all others
+      return mergeOpening
+          .append("ON ").append(keysMatch).append(" ")
+            .append("AND ").append(valueIs).append("NULL ")
+          .append("WHEN MATCHED ")
+            .append("THEN DELETE ")
+          .append("WHEN NOT MATCHED ")
+            .append(insertClause)
+          .append(";")
+          .toString();
+    } else if (upsertEnabled) {
+      // Assume all rows have non-null values and upsert them all
+      return mergeOpening
+          .append("ON ").append(keysMatch).append(" ")
+          .append("WHEN MATCHED")
+            .append(updateClause).append(" ")
+          .append("WHEN NOT MATCHED")
+            .append(insertClause)
+          .append(";")
+          .toString();
+    } else {
+      throw new IllegalStateException("At least one of upsert or delete must be enabled for merge flushing to occur.");
+    }
+  }
+
+  // DELETE FROM `<intermediateTable>` WHERE batchNumber <= <batchNumber> AND _PARTITIONTIME IS NOT NULL;
+  private static String clearBatchQuery(TableId intermediateTable, int batchNumber) {
+    return new StringBuilder("DELETE FROM `").append(intermediateTable.getDataset()).append("`.`").append(intermediateTable.getTable()).append("` ")
+        .append("WHERE ")
+          .append(INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD).append(" <= ").append(batchNumber).append(" ")
+          // Use this clause to filter out rows that are still in the streaming buffer, which should
+          // not be subjected to UPDATE or DELETE operations or the query will FAIL
+          .append("AND _PARTITIONTIME IS NOT NULL")
+        .append(";")
+        .toString();
+  }
+
+  private static List<String> listFields(FieldList keyFields, String prefix) {
+    return keyFields.stream()
+        .flatMap(field -> {
+          String fieldName = prefix + field.getName();
+          FieldList subFields = field.getSubFields();
+          if (subFields == null) {
+            return Stream.of(fieldName);
+          }
+          return listFields(subFields, fieldName + ".").stream();
+        }).collect(Collectors.toList());
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -146,11 +146,12 @@ public class SchemaManager {
     synchronized (lock(tableCreateLocks, table)) {
       if (bigQuery.getTable(table) == null) {
         logger.debug("{} doesn't exist; creating instead of updating", table(table));
-        createTable(table, topic);
-        return;
+        if (createTable(table, topic)) {
+          return;
+        }
       }
     }
-    
+
     // Table already existed; attempt to update instead
     logger.debug("{} already exists; updating instead of creating", table(table));
     updateSchema(table, topic);
@@ -160,13 +161,14 @@ public class SchemaManager {
    * Create a new table in BigQuery.
    * @param table The BigQuery table to create.
    * @param topic The Kafka topic used to determine the schema.
+   * @return whether the table had to be created; if the table already existed, will return false
    */
-  public void createTable(TableId table, String topic) {
+  public boolean createTable(TableId table, String topic) {
     synchronized (lock(tableCreateLocks, table)) {
       if (schemaCache.containsKey(table)) {
         // Table already exists; noop
         logger.debug("Skipping create of {} as it should already exist or appear very soon", table(table));
-        return;
+        return false;
       }
 
       TableInfo tableInfo = constructTableInfo(table, topic);
@@ -176,11 +178,14 @@ public class SchemaManager {
         bigQuery.create(tableInfo);
         logger.debug("Successfully created {}", table(table));
         schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        return true;
       } catch (BigQueryException e) {
         if (e.getCode() == 409) {
           logger.debug("Failed to create {} as it already exists (possibly created by another task)", table(table));
           schemaCache.put(table, readTableSchema(table));
+          return false;
         }
+        throw e;
       }
     }
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -290,7 +290,8 @@ public class SchemaManager {
 
     com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
     Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keySchema.getFields())
-        .setMode(Field.Mode.REQUIRED).build();
+        .setMode(Field.Mode.REQUIRED)
+        .build();
     result.add(kafkaKeyField);
 
     Field partitionTimeField = Field

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -300,6 +300,12 @@ public class SchemaManager {
         .build();
     result.add(kafkaKeyField);
 
+    Field iterationField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_ITERATION_FIELD_NAME, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    result.add(iterationField);
+
     Field partitionTimeField = Field
         .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
         .setMode(Field.Mode.NULLABLE)

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -2,6 +2,7 @@ package com.wepay.kafka.connect.bigquery;
 
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardTableDefinition;
@@ -12,9 +13,11 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +25,14 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Class for managing Schemas of BigQuery tables (creating and updating).
  */
 public class SchemaManager {
+
   private static final Logger logger = LoggerFactory.getLogger(SchemaManager.class);
 
   private final SchemaRetriever schemaRetriever;
@@ -36,6 +42,10 @@ public class SchemaManager {
   private final Optional<String> kafkaDataFieldName;
   private final Optional<String> timestampPartitionFieldName;
   private final Optional<List<String>> clusteringFieldName;
+  private final boolean intermediateTables;
+  private final ConcurrentMap<TableId, Object> tableCreateLocks;
+  private final ConcurrentMap<TableId, Object> tableUpdateLocks;
+  private final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache;
 
   /**
    * @param schemaRetriever Used to determine the Kafka Connect Schema that should be used for a
@@ -43,9 +53,14 @@ public class SchemaManager {
    * @param schemaConverter Used to convert Kafka Connect Schemas into BigQuery format.
    * @param bigQuery Used to communicate create/update requests to BigQuery.
    * @param kafkaKeyFieldName The name of kafka key field to be used in BigQuery.
-   *                         If set to null, Kafka Key Field will not be included in BigQuery.
+   *                          If set to null, Kafka Key Field will not be included in BigQuery.
    * @param kafkaDataFieldName The name of kafka data field to be used in BigQuery.
    *                           If set to null, Kafka Data Field will not be included in BigQuery.
+   * @param timestampPartitionFieldName The name of the field to use for column-based time
+   *                                    partitioning in BigQuery.
+   *                                    If set to null, ingestion time-based partitioning will be
+   *                                    used instead.
+   * @param clusteringFieldName
    */
   public SchemaManager(
       SchemaRetriever schemaRetriever,
@@ -55,6 +70,32 @@ public class SchemaManager {
       Optional<String> kafkaDataFieldName,
       Optional<String> timestampPartitionFieldName,
       Optional<List<String>> clusteringFieldName) {
+    this(
+        schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        kafkaKeyFieldName,
+        kafkaDataFieldName,
+        timestampPartitionFieldName,
+        clusteringFieldName,
+        false,
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>());
+  }
+
+  private SchemaManager(
+      SchemaRetriever schemaRetriever,
+      SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter,
+      BigQuery bigQuery,
+      Optional<String> kafkaKeyFieldName,
+      Optional<String> kafkaDataFieldName,
+      Optional<String> timestampPartitionFieldName,
+      Optional<List<String>> clusteringFieldName,
+      boolean intermediateTables,
+      ConcurrentMap<TableId, Object> tableCreateLocks,
+      ConcurrentMap<TableId, Object> tableUpdateLocks,
+      ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache) {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
@@ -62,6 +103,57 @@ public class SchemaManager {
     this.kafkaDataFieldName = kafkaDataFieldName;
     this.timestampPartitionFieldName = timestampPartitionFieldName;
     this.clusteringFieldName = clusteringFieldName;
+    this.intermediateTables = intermediateTables;
+    this.tableCreateLocks = tableCreateLocks;
+    this.tableUpdateLocks = tableUpdateLocks;
+    this.schemaCache = schemaCache;
+  }
+
+  public SchemaManager forIntermediateTables() {
+    return new SchemaManager(
+        schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        kafkaKeyFieldName,
+        kafkaDataFieldName,
+        timestampPartitionFieldName,
+        clusteringFieldName,
+        true,
+        tableCreateLocks,
+        tableUpdateLocks,
+        schemaCache
+    );
+  }
+
+  /**
+   * Fetch the most recent schema for the given table, assuming it has been created and/or updated
+   * over the lifetime of this schema manager.
+   * @param table the table to fetch the schema for; may be null
+   * @return the latest schema for that table; may be null if the table does not exist or has not
+   * been created or updated by this schema manager
+   */
+  public com.google.cloud.bigquery.Schema cachedSchema(TableId table) {
+    return schemaCache.get(table);
+  }
+
+  /**
+   * Create a new table in BigQuery, if it doesn't already exist. Otherwise, update the existing
+   * table to use the most-current schema.
+   * @param table The BigQuery table to create,
+   * @param topic The Kafka topic used to determine the schema.
+   */
+  public void createOrUpdateTable(TableId table, String topic) {
+    synchronized (lock(tableCreateLocks, table)) {
+      if (bigQuery.getTable(table) == null) {
+        logger.debug("{} doesn't exist; creating instead of updating", table(table));
+        createTable(table, topic);
+        return;
+      }
+    }
+    
+    // Table already existed; attempt to update instead
+    logger.debug("{} already exists; updating instead of creating", table(table));
+    updateSchema(table, topic);
   }
 
   /**
@@ -70,9 +162,29 @@ public class SchemaManager {
    * @param topic The Kafka topic used to determine the schema.
    */
   public void createTable(TableId table, String topic) {
-    Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
-    Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
-    bigQuery.create(constructTableInfo(table, kafkaKeySchema, kafkaValueSchema));
+    synchronized (lock(tableCreateLocks, table)) {
+      if (schemaCache.containsKey(table)) {
+        // Table already exists; noop
+        logger.debug("Skipping create of {} as it should already exist or appear very soon", table(table));
+        return;
+      }
+      Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
+      Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
+      TableInfo tableInfo = constructTableInfo(table, kafkaKeySchema, kafkaValueSchema);
+      logger.info("Attempting to create {} with schema {}",
+          table(table), tableInfo.getDefinition().getSchema());
+      try {
+        bigQuery.create(tableInfo);
+        logger.debug("Successfully created {}", table(table));
+        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+      } catch (BigQueryException e) {
+        if (e.getCode() == 409) {
+          logger.debug("Failed to create {} as it already exists (possibly created by another task)", table(table));
+          com.google.cloud.bigquery.Schema schema = bigQuery.getTable(table).getDefinition().getSchema();
+          schemaCache.put(table, schema);
+        }
+      }
+    }
   }
 
   /**
@@ -81,58 +193,146 @@ public class SchemaManager {
    * @param topic The Kafka topic used to determine the schema.
    */
   public void updateSchema(TableId table, String topic) {
-    Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
-    Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
-    TableInfo tableInfo = constructTableInfo(table, kafkaKeySchema, kafkaValueSchema);
-    logger.info("Attempting to update table `{}` with schema {}",
-        table, tableInfo.getDefinition().getSchema());
-    bigQuery.update(tableInfo);
+    synchronized (tableUpdateLocks.computeIfAbsent(table, t -> new Object())) {
+      Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
+      Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
+      TableInfo tableInfo = constructTableInfo(table, kafkaKeySchema, kafkaValueSchema);
+  
+      if (!schemaCache.containsKey(table)) {
+        logger.debug("Reading schema for {}", table(table));
+        schemaCache.put(table, bigQuery.getTable(table).getDefinition().getSchema());
+      }
+  
+      if (!schemaCache.get(table).equals(tableInfo.getDefinition().getSchema())) {
+        logger.info("Attempting to update {} with schema {}",
+            table(table), tableInfo.getDefinition().getSchema());
+        bigQuery.update(tableInfo);
+        logger.debug("Successfully updated {}", table(table));
+        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+      } else {
+        logger.debug("Skipping update of {} since current schema should be compatible", table(table));
+      }
+    }
   }
 
   // package private for testing.
   TableInfo constructTableInfo(TableId table, Schema kafkaKeySchema, Schema kafkaValueSchema) {
-    com.google.cloud.bigquery.Schema bigQuerySchema = getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
-
-    TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
-    if (timestampPartitionFieldName.isPresent()) {
-      timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName.get()).build();
-    }
+    com.google.cloud.bigquery.Schema bigQuerySchema =
+        getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
 
     StandardTableDefinition.Builder builder = StandardTableDefinition.newBuilder()
-        .setSchema(bigQuerySchema)
-        .setTimePartitioning(timePartitioning);
+        .setSchema(bigQuerySchema);
 
-    if (timestampPartitionFieldName.isPresent() && clusteringFieldName.isPresent()) {
-      Clustering clustering = Clustering.newBuilder()
-          .setFields(clusteringFieldName.get())
-          .build();
-      builder.setClustering(clustering);
+    if (intermediateTables) {
+      // Shameful hack: make the table ingestion time-partitioned here so that the _PARTITIONTIME
+      // pseudocolumn can be queried to filter out rows that are still in the streaming buffer
+      builder.setTimePartitioning(TimePartitioning.of(Type.DAY));
+    } else {
+      TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
+      if (timestampPartitionFieldName.isPresent()) {
+        timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName.get()).build();
+      }
+  
+      builder.setTimePartitioning(timePartitioning);
+
+      if (timestampPartitionFieldName.isPresent() && clusteringFieldName.isPresent()) {
+        Clustering clustering = Clustering.newBuilder()
+            .setFields(clusteringFieldName.get())
+            .build();
+        builder.setClustering(clustering);
+      }
     }
 
     StandardTableDefinition tableDefinition = builder.build();
     TableInfo.Builder tableInfoBuilder =
         TableInfo.newBuilder(table, tableDefinition);
-    if (kafkaValueSchema.doc() != null) {
+    
+    if (intermediateTables) {
+      tableInfoBuilder.setDescription("Temporary table");
+    } else if (kafkaValueSchema.doc() != null) {
       tableInfoBuilder.setDescription(kafkaValueSchema.doc());
     }
     return tableInfoBuilder.build();
   }
 
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
-      List<Field> allFields = new ArrayList<> ();
-      com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
-      allFields.addAll(valueSchema.getFields());
-      if (kafkaKeyFieldName.isPresent()) {
-          com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
-          Field kafkaKeyField = Field.newBuilder(kafkaKeyFieldName.get(), LegacySQLTypeName.RECORD, keySchema.getFields())
-                  .setMode(Field.Mode.NULLABLE).build();
-          allFields.add(kafkaKeyField);
-      }
-      if (kafkaDataFieldName.isPresent()) {
-          Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
-          allFields.add(kafkaDataField);
-      }
-      return com.google.cloud.bigquery.Schema.of(allFields);
+    com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
+
+    List<Field> schemaFields = intermediateTables
+        ? getIntermediateSchemaFields(valueSchema, kafkaKeySchema)
+        : getRegularSchemaFields(valueSchema, kafkaKeySchema);
+
+    return com.google.cloud.bigquery.Schema.of(schemaFields);
   }
 
+  private List<Field> getIntermediateSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+    if (kafkaKeySchema == null) {
+      throw new BigQueryConnectException(String.format(
+          "Cannot create intermediate table without specifying a value for '%s'",
+          BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG
+      ));
+    }
+
+    List<Field> result = new ArrayList<>();
+
+    List<Field> valueFields = new ArrayList<>(valueSchema.getFields());
+    if (kafkaDataFieldName.isPresent()) {
+      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
+      valueFields.add(kafkaDataField);
+    }
+
+    // Wrap the sink record value (and possibly also its Kafka data) in a struct in order to support deletes
+    Field wrappedValueField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueFields.toArray(new Field[0]))
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    result.add(wrappedValueField);
+
+    com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
+    Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keySchema.getFields())
+        .setMode(Field.Mode.REQUIRED).build();
+    result.add(kafkaKeyField);
+
+    Field partitionTimeField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    result.add(partitionTimeField);
+
+    Field batchNumberField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    result.add(batchNumberField);
+
+    return result;
+  }
+
+  private List<Field> getRegularSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+    List<Field> result = new ArrayList<>(valueSchema.getFields());
+
+    if (kafkaDataFieldName.isPresent()) {
+      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
+      result.add(kafkaDataField);
+    }
+
+    if (kafkaKeyFieldName.isPresent()) {
+      com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
+      Field kafkaKeyField = Field.newBuilder(kafkaKeyFieldName.get(), LegacySQLTypeName.RECORD, keySchema.getFields())
+          .setMode(Field.Mode.NULLABLE).build();
+      result.add(kafkaKeyField);
+    }
+
+    return result;
+  }
+
+  private String table(TableId table) {
+    return (intermediateTables ? "intermediate " : "")
+        + "table "
+        + table;
+  }
+
+  private Object lock(ConcurrentMap<TableId, Object> locks, TableId table) {
+    return locks.computeIfAbsent(table, t -> new Object());
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -255,7 +255,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Type INTERMEDIATE_TABLE_SUFFIX_TYPE =              ConfigDef.Type.STRING;
   public static final String INTERMEDIATE_TABLE_SUFFIX_DEFAULT =                    "tmp";
   private static final ConfigDef.Validator INTERMEDIATE_TABLE_SUFFIX_VALIDATOR =    new ConfigDef.NonEmptyString();
-  private static final ConfigDef.Importance INTERMEDIATE_TTABLE_SUFFIX_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final ConfigDef.Importance INTERMEDIATE_TABLE_SUFFIX_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String INTERMEDIATE_TABLE_SUFFIX_DOC =
       "A suffix that will be appended to the names of destination tables to create the names for " 
       + "the corresponding intermediate tables. Multiple intermediate tables may be created for a " 
@@ -435,7 +435,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
             INTERMEDIATE_TABLE_SUFFIX_TYPE,
             INTERMEDIATE_TABLE_SUFFIX_DEFAULT,
             INTERMEDIATE_TABLE_SUFFIX_VALIDATOR,
-            INTERMEDIATE_TTABLE_SUFFIX_IMPORTANCE,
+            INTERMEDIATE_TABLE_SUFFIX_IMPORTANCE,
             INTERMEDIATE_TABLE_SUFFIX_DOC
         ).define(
             MERGE_INTERVAL_MS_CONFIG,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Optional;
@@ -471,6 +472,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
         }
 
         if (upsertDeleteEnabled(props)) {
+            if (gcsBatchLoadingEnabled(props)) {
+              throw new ConfigException("Cannot enable both upsert/delete and GCS batch loading");
+            }
+
             String mergeIntervalStr = Optional.ofNullable(props.get(MERGE_INTERVAL_MS_CONFIG))
                 .map(String::trim)
                 .orElse(Long.toString(MERGE_INTERVAL_MS_DEFAULT));
@@ -512,6 +517,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
         String deleteStr = props.get(DELETE_ENABLED_CONFIG);
         return Boolean.TRUE.toString().equalsIgnoreCase(upsertStr)
             || Boolean.TRUE.toString().equalsIgnoreCase(deleteStr);
+    }
+
+    public static boolean gcsBatchLoadingEnabled(Map<String, String> props) {
+        String batchLoadStr = props.get(ENABLE_BATCH_CONFIG);
+        return batchLoadStr != null && !batchLoadStr.isEmpty();
     }
 
   @SuppressWarnings("unchecked")

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -53,7 +53,6 @@ import java.util.Optional;
  * Base class for connector and task configs; contains properties shared between the two of them.
  */
 public class BigQuerySinkConfig extends AbstractConfig {
-  private static final ConfigDef config;
   private static final Validator validator = new Validator();
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkConfig.class);
 
@@ -281,8 +280,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "How many records to write to an intermediate table before performing a merge flush, if " 
       + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing.";
 
-  static {
-    config = new ConfigDef()
+  /**
+   * Return a ConfigDef object used to define this config's fields.
+   *
+   * @return A ConfigDef object used to define this config's fields.
+   */
+  public static ConfigDef getConfig() {
+    return new ConfigDef()
         .define(
             TOPICS_CONFIG,
             TOPICS_TYPE,
@@ -810,22 +814,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
     }
   }
 
-  /**
-   * Return the ConfigDef object used to define this config's fields.
-   *
-   * @return The ConfigDef object used to define this config's fields.
-   */
-  public static ConfigDef getConfig() {
-    return config;
-  }
-
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
     verifyBucketSpecified();
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
-    super(config, properties);
+    super(getConfig(), properties);
     verifyBucketSpecified();
     checkAutoCreateTables();
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -233,6 +233,54 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String TABLE_CREATE_DOC =
           "Automatically create BigQuery tables if they don't already exist";
 
+  public static final String UPSERT_ENABLED_CONFIG =                    "upsertEnabled";
+  private static final ConfigDef.Type UPSERT_ENABLED_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final boolean UPSERT_ENABLED_DEFAULT =                  false;
+  private static final ConfigDef.Importance UPSERT_ENABLED_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String UPSERT_ENABLED_DOC =
+      "Enable upsert functionality on the connector through the use of record keys, intermediate "
+      + "tables, and periodic merge flushes. Row-matching will be performed based on the contents " 
+      + "of record keys.";
+
+  public static final String DELETE_ENABLED_CONFIG =                    "deleteEnabled";
+  private static final ConfigDef.Type DELETE_ENABLED_TYPE =             ConfigDef.Type.BOOLEAN;
+  public static final boolean DELETE_ENABLED_DEFAULT =                  false;
+  private static final ConfigDef.Importance DELETE_ENABLED_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String DELETE_ENABLED_DOC =
+      "Enable delete functionality on the connector through the use of record keys, intermediate " 
+      + "tables, and periodic merge flushes. A delete will be performed when a record with a null " 
+      + "value (i.e., a tombstone record) is read.";
+
+  public static final String INTERMEDIATE_TABLE_SUFFIX_CONFIG =                     "intermediateTableSuffix";
+  private static final ConfigDef.Type INTERMEDIATE_TABLE_SUFFIX_TYPE =              ConfigDef.Type.STRING;
+  public static final String INTERMEDIATE_TABLE_SUFFIX_DEFAULT =                    "tmp";
+  private static final ConfigDef.Validator INTERMEDIATE_TABLE_SUFFIX_VALIDATOR =    new ConfigDef.NonEmptyString();
+  private static final ConfigDef.Importance INTERMEDIATE_TTABLE_SUFFIX_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String INTERMEDIATE_TABLE_SUFFIX_DOC =
+      "A suffix that will be appended to the names of destination tables to create the names for " 
+      + "the corresponding intermediate tables. Multiple intermediate tables may be created for a " 
+      + "single destination table, but their names will always start with the name of the " 
+      + "destination table, followed by this suffix, and possibly followed by an additional " 
+      + "suffix.";
+
+  public static final String MERGE_INTERVAL_MS_CONFIG =                    "mergeIntervalMs";
+  private static final ConfigDef.Type MERGE_INTERVAL_MS_TYPE =              ConfigDef.Type.LONG;
+  public static final long MERGE_INTERVAL_MS_DEFAULT =                     60_000L;
+  private static final ConfigDef.Validator MERGE_INTERVAL_MS_VALIDATOR =   ConfigDef.Range.atLeast(-1);
+  private static final ConfigDef.Importance MERGE_INTERVAL_MS_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String MERGE_INTERVAL_MS_DOC =
+      "How often (in milliseconds) to perform a merge flush, if upsert/delete is enabled. Can be "
+      + "set to -1 to disable periodic flushing.";
+
+  public static final String MERGE_RECORDS_THRESHOLD_CONFIG =                    "mergeRecordsThreshold";
+  private static final ConfigDef.Type MERGE_RECORDS_THRESHOLD_TYPE =             ConfigDef.Type.LONG;
+  public static final long MERGE_RECORDS_THRESHOLD_DEFAULT =                     -1;
+  private static final ConfigDef.Validator MERGE_RECORDS_THRESHOLD_VALIDATOR =   ConfigDef.Range.atLeast(-1);
+  private static final ConfigDef.Importance MERGE_RECORDS_THRESHOLD_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String MERGE_RECORDS_THRESHOLD_DOC =
+      "How many records to write to an intermediate table before performing a merge flush, if " 
+      + "upsert/delete is enabled. Can be set to -1 to disable record count-based flushing.";
+
   static {
     config = new ConfigDef()
         .define(
@@ -365,6 +413,39 @@ public class BigQuerySinkConfig extends AbstractConfig {
             TABLE_CREATE_DEFAULT,
             TABLE_CREATE_IMPORTANCE,
             TABLE_CREATE_DOC
+        ).define(
+            UPSERT_ENABLED_CONFIG,
+            UPSERT_ENABLED_TYPE,
+            UPSERT_ENABLED_DEFAULT,
+            UPSERT_ENABLED_IMPORTANCE,
+            UPSERT_ENABLED_DOC
+        ).define(
+            DELETE_ENABLED_CONFIG,
+            DELETE_ENABLED_TYPE,
+            DELETE_ENABLED_DEFAULT,
+            DELETE_ENABLED_IMPORTANCE,
+            DELETE_ENABLED_DOC
+        ).define(
+            INTERMEDIATE_TABLE_SUFFIX_CONFIG,
+            INTERMEDIATE_TABLE_SUFFIX_TYPE,
+            INTERMEDIATE_TABLE_SUFFIX_DEFAULT,
+            INTERMEDIATE_TABLE_SUFFIX_VALIDATOR,
+            INTERMEDIATE_TTABLE_SUFFIX_IMPORTANCE,
+            INTERMEDIATE_TABLE_SUFFIX_DOC
+        ).define(
+            MERGE_INTERVAL_MS_CONFIG,
+            MERGE_INTERVAL_MS_TYPE,
+            MERGE_INTERVAL_MS_DEFAULT,
+            MERGE_INTERVAL_MS_VALIDATOR,
+            MERGE_INTERVAL_MS_IMPORTANCE,
+            MERGE_INTERVAL_MS_DOC
+        ).define(
+            MERGE_RECORDS_THRESHOLD_CONFIG,
+            MERGE_RECORDS_THRESHOLD_TYPE,
+            MERGE_RECORDS_THRESHOLD_DEFAULT,
+            MERGE_RECORDS_THRESHOLD_VALIDATOR,
+            MERGE_RECORDS_THRESHOLD_IMPORTANCE,
+            MERGE_RECORDS_THRESHOLD_DOC
         );
   }
     /**
@@ -384,6 +465,32 @@ public class BigQuerySinkConfig extends AbstractConfig {
             throw new ConfigException("Must configure one of " +
                 TOPICS_CONFIG + " or " + TOPICS_REGEX_CONFIG);
         }
+
+        if (upsertDeleteEnabled(props)) {
+            String mergeIntervalStr = Optional.ofNullable(props.get(MERGE_INTERVAL_MS_CONFIG))
+                .map(String::trim)
+                .orElse(Long.toString(MERGE_INTERVAL_MS_DEFAULT));
+            String mergeRecordsThresholdStr = Optional.ofNullable(props.get(MERGE_RECORDS_THRESHOLD_CONFIG))
+                .map(String::trim)
+                .orElse(Long.toString(MERGE_RECORDS_THRESHOLD_DEFAULT));
+            if ("-1".equals(mergeIntervalStr) && "-1".equals(mergeRecordsThresholdStr)) {
+              throw new ConfigException(MERGE_INTERVAL_MS_CONFIG + " and "
+                  + MERGE_RECORDS_THRESHOLD_CONFIG + " cannot both be -1");
+            }
+
+            if ("0".equals(mergeIntervalStr)) {
+              throw new ConfigException(MERGE_INTERVAL_MS_CONFIG, mergeIntervalStr, "cannot be zero");
+            }
+            if ("0".equals(mergeRecordsThresholdStr)) {
+              throw new ConfigException(MERGE_RECORDS_THRESHOLD_CONFIG, mergeRecordsThresholdStr, "cannot be zero");
+            }
+
+            String kafkaKeyFieldStr = props.get(KAFKA_KEY_FIELD_NAME_CONFIG);
+            if (kafkaKeyFieldStr == null || kafkaKeyFieldStr.trim().isEmpty()) {
+              throw new ConfigException(KAFKA_KEY_FIELD_NAME_CONFIG + " must be specified when "
+                  + UPSERT_ENABLED_CONFIG + " and/or " + DELETE_ENABLED_CONFIG + " are set to true");
+            }
+        }
     }
 
     public static boolean hasTopicsConfig(Map<String, String> props) {
@@ -394,6 +501,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
     public static boolean hasTopicsRegexConfig(Map<String, String> props) {
         String topicsRegexStr = props.get(TOPICS_REGEX_CONFIG);
         return topicsRegexStr != null && !topicsRegexStr.trim().isEmpty();
+    }
+
+    public static boolean upsertDeleteEnabled(Map<String, String> props) {
+        String upsertStr = props.get(UPSERT_ENABLED_CONFIG);
+        String deleteStr = props.get(DELETE_ENABLED_CONFIG);
+        return Boolean.TRUE.toString().equalsIgnoreCase(upsertStr)
+            || Boolean.TRUE.toString().equalsIgnoreCase(deleteStr);
     }
 
   @SuppressWarnings("unchecked")

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -62,7 +62,7 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
       "The maximum size (or -1 for no maximum size) of the worker queue for bigQuery write "
       + "requests before all topics are paused. This is a soft limit; the size of the queue can "
       + "go over this before topics are paused. All topics will be resumed once a flush is "
-      + "requested or the size of the queue drops under half of the maximum size.";
+      + "triggered or the size of the queue drops under half of the maximum size.";
 
   public static final String BIGQUERY_RETRY_CONFIG =                    "bigQueryRetry";
   private static final ConfigDef.Type BIGQUERY_RETRY_TYPE =             ConfigDef.Type.INT;
@@ -127,6 +127,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_CLUSTERING_FIELD_NAMES_DOC =
       "List of fields on which data should be clustered by in BigQuery, separated by commas";
 
+  public static final String TASK_ID_CONFIG =                   "taskId";
+  private static final ConfigDef.Type TASK_ID_TYPE =            ConfigDef.Type.INT;
+  public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String TASK_ID_DOC =                     "A unique for each task created by the connector";
+
   static {
     config = BigQuerySinkConfig.getConfig()
         .define(
@@ -187,6 +192,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
             BIGQUERY_CLUSTERING_FIELD_NAMES_DEFAULT,
             BIGQUERY_CLUSTERING_FIELD_NAMES_IMPORTANCE,
             BIGQUERY_CLUSTERING_FIELD_NAMES_DOC
+        ).define(
+            TASK_ID_CONFIG,
+            TASK_ID_TYPE,
+            TASK_ID_IMPORTANCE,
+            TASK_ID_DOC
         );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -32,7 +32,6 @@ import java.util.Map;
  * Class for task-specific configuration properties.
  */
 public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
-  private static final ConfigDef config;
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkTaskConfig.class);
 
   public static final String SCHEMA_UPDATE_CONFIG =                     "autoUpdateSchemas";
@@ -132,8 +131,13 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String TASK_ID_DOC =                     "A unique for each task created by the connector";
 
-  static {
-    config = BigQuerySinkConfig.getConfig()
+  /**
+   * Return a ConfigDef object used to define this config's fields.
+   *
+   * @return A ConfigDef object used to define this config's fields.
+   */
+  public static ConfigDef getConfig() {
+    return BigQuerySinkConfig.getConfig()
         .define(
             SCHEMA_UPDATE_CONFIG,
             SCHEMA_UPDATE_TYPE,
@@ -263,15 +267,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
     }
   }
 
-  public static ConfigDef getConfig() {
-    return config;
-  }
-
   /**
    * @param properties A Map detailing configuration properties and their respective values.
    */
   public BigQuerySinkTaskConfig(Map<String, String> properties) {
-    super(config, properties);
+    super(getConfig(), properties);
     checkAutoUpdateSchemas();
     checkPartitionConfigs();
     checkClusteringConfigs();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -103,10 +103,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       return convertBytes(value);
     }
     if (value instanceof List) {
-      return
-          ((List) value).stream().map(
-                  v -> convertSchemalessRecord(v)
-          ).collect(Collectors.toList());
+      return ((List<?>) value).stream()
+          .map(this::convertSchemalessRecord)
+          .collect(Collectors.toList());
     }
     if (value instanceof Map) {
       return
@@ -128,7 +127,6 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         " found in schemaless record data. Can't convert record to bigQuery format");
   }
 
-  @SuppressWarnings("unchecked")
   private Object convertObject(Object kafkaConnectObject, Schema kafkaConnectSchema) {
     if (kafkaConnectObject == null) {
       if (kafkaConnectSchema.isOptional()) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -97,6 +97,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
    *         existing one.
    */
   public com.google.cloud.bigquery.Schema convertSchema(Schema kafkaConnectSchema) {
+    // TODO: Permit non-struct keys
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new
           ConversionConnectException("Top-level Kafka Connect schema must be of type 'struct'");

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -21,8 +21,6 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.TableId;
 
-import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
-
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -31,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Batch Table Writer that uploads records to GCS as a blob
@@ -95,7 +92,6 @@ public class GCSBatchTableWriter implements Runnable {
     private final TableId tableId;
 
     private List<RowToInsert> rows;
-    private final RecordConverter<Map<String, Object>> recordConverter;
     private final GCSToBQWriter writer;
 
     /**
@@ -106,29 +102,19 @@ public class GCSBatchTableWriter implements Runnable {
      * @param gcsBucketName The GCS bucket to write to.
      * @param gcsBlobName The name of the GCS blob to write.
      * @param topic Kafka record topic
-     * @param recordConverter the {@link RecordConverter} to use.
      */
     public Builder(GCSToBQWriter writer,
                    TableId tableId,
                    String gcsBucketName,
                    String gcsBlobName,
-                   String topic,
-                   RecordConverter<Map<String, Object>> recordConverter) {
-
+                   String topic) {
+      this.writer = writer;
+      this.tableId = tableId;
       this.bucketName = gcsBucketName;
       this.blobName = gcsBlobName;
       this.topic = topic;
 
-      this.tableId = tableId;
-
       this.rows = new ArrayList<>();
-      this.recordConverter = recordConverter;
-      this.writer = writer;
-    }
-
-    public Builder setBlobName(String blobName) {
-      this.blobName = blobName;
-      return this;
     }
 
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -91,11 +91,21 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
       execute(new CountDownRunnable(countDownLatch));
     }
     countDownLatch.await();
+    maybeThrowEncounteredErrors();
+  }
+
+  /**
+   * Immediately throw an exception if any unrecoverable errors were encountered by any of the write
+   * tasks.
+   *
+   * @throws BigQueryConnectException if any of the tasks failed.
+   */
+  public void maybeThrowEncounteredErrors() {
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
       encounteredErrors.clear();
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
-                                         + errorString + "; See logs for more detail");
+          + errorString + "; See logs for more detail");
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -110,10 +111,8 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   }
 
   private static String createErrorString(Collection<Throwable> errors) {
-    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
-    exceptionTypeStrings.addAll(errors.stream()
-                        .map(throwable -> throwable.getClass().getName())
-                        .collect(Collectors.toList()));
-    return String.join(", ", exceptionTypeStrings);
+    return errors.stream()
+                 .map(Objects::toString)
+                 .collect(Collectors.joining(", "));
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -1,0 +1,333 @@
+package com.wepay.kafka.connect.bigquery.write.batch;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.TableId;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+import com.wepay.kafka.connect.bigquery.MergeQueries;
+import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class MergeBatches {
+  private static final Logger logger = LoggerFactory.getLogger(MergeBatches.class);
+  private static final long STREAMING_BUFFER_AVAILABILITY_WAIT_MS = 10_000L;
+
+  private final String intermediateTableSuffix;
+  private final BiMap<TableId, TableId> intermediateToDestinationTables;
+  private final ConcurrentMap<TableId, AtomicInteger> batchNumbers;
+  private final ConcurrentMap<TableId, ConcurrentMap<Integer, Batch>> batches;
+  private final Map<TopicPartition, Long> offsets;
+
+  public MergeBatches(String intermediateTableSuffix) {
+    this.intermediateTableSuffix = intermediateTableSuffix;
+
+    this.intermediateToDestinationTables = Maps.synchronizedBiMap(HashBiMap.create());
+    this.batchNumbers = new ConcurrentHashMap<>();
+    this.batches = new ConcurrentHashMap<>();
+    this.offsets = new HashMap<>();
+  }
+
+  /**
+   * Get the latest safe-to-commit offsets for every topic partition that has had at least one
+   * record make its way to a destination table.
+   * @return the offsets map which can be used in
+   * {@link org.apache.kafka.connect.sink.SinkTask#preCommit(Map)}; never null
+   */
+  public Map<TopicPartition, OffsetAndMetadata> latestOffsets() {
+    synchronized (offsets) {
+      return offsets.entrySet().stream().collect(Collectors.toMap(
+          Map.Entry::getKey,
+          entry -> new OffsetAndMetadata(entry.getValue())
+      ));
+    }
+  }
+
+  /**
+   * @return a thread-safe map from intermediate tables to destination tables; never null
+   */
+  public Map<TableId, TableId> intermediateToDestinationTables() {
+    return intermediateToDestinationTables;
+  }
+
+  /**
+   * @return a collection of all currently-in-use intermediate tables; never null
+   */
+  public Collection<TableId> intermediateTables() {
+    return intermediateToDestinationTables.keySet();
+  }
+
+  /**
+   * Get the intermediate table for a given destination table, computing a new one if necessary
+   * @param destinationTable the destination table to fetch an intermediate table for
+   * @return the {@link TableId} of the intermediate table; never null
+   */
+  public TableId intermediateTableFor(TableId destinationTable) {
+    return intermediateToDestinationTables.inverse()
+        .computeIfAbsent(destinationTable, this::newIntermediateTable);
+  }
+
+  private TableId newIntermediateTable(TableId destinationTable) {
+    String tableName = FieldNameSanitizer.sanitizeName(
+        destinationTable.getTable() + intermediateTableSuffix
+    );
+    TableId result = TableId.of(
+        destinationTable.getDataset(),
+        tableName
+    );
+
+    batchNumbers.put(result, new AtomicInteger());
+    batches.put(result, new ConcurrentHashMap<>());
+
+    return result;  }
+
+  public TableId destinationTableFor(TableId intermediateTable) {
+    return intermediateToDestinationTables.get(intermediateTable);
+  }
+
+  /**
+   * Find a batch number for the record, insert that number into the converted value, record the
+   * offset for that record, and return the total size of that batch.
+   * @param record the record for the batch
+   * @param intermediateTable the intermediate table the record will be streamed into
+   * @param convertedRecord the converted record that will be passed to the BigQuery client
+   * @return the total number of records in the batch that this record is added to
+   */
+  public long addToBatch(SinkRecord record, TableId intermediateTable, Map<String, Object> convertedRecord) {
+    AtomicInteger batchCount = batchNumbers.get(intermediateTable);
+    // Synchronize here to ensure that the batch number isn't bumped in the middle of this method.
+    // On its own, that wouldn't be such a bad thing, but since a merge flush is supposed to
+    // immediately follow that bump, it might cause some trouble if we want to add this row to the
+    // batch but a merge flush on that batch has already started. This way, either the batch number
+    // is bumped before we add the row to the batch (in which case, the row is added to the fresh
+    // batch), or the row is added to the batch before preparation for the flush takes place and it
+    // is safely counted and tracked there.
+    synchronized (batchCount) {
+      int batchNumber = batchCount.get();
+      convertedRecord.put(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, batchNumber);
+
+      Batch batch = batches.get(intermediateTable).computeIfAbsent(batchNumber, n -> new Batch());
+      batch.recordOffsetFor(record);
+
+      long pendingBatchSize = batch.increment();
+      logger.trace("Added record to batch {} for intermediate table {}; {} rows are currently pending",
+          batchNumber, intermediateTable, pendingBatchSize);
+      return batch.total();
+    }
+  }
+
+  /**
+   * Record a successful write of a list of rows to the given intermediate table, and decrease the
+   * pending record counts for every applicable batch accordingly.
+   * @param intermediateTable the intermediate table
+   * @param rows the rows
+   */
+  public void onRowWrites(TableId intermediateTable, List<InsertAllRequest.RowToInsert> rows) {
+    Map<Integer, Long> rowsByBatch = rows.stream().collect(Collectors.groupingBy(
+        row -> (Integer) row.getContent().get(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD),
+        Collectors.counting()
+    ));
+
+    rowsByBatch.forEach((batchNumber, batchSize) -> {
+      Batch batch = batch(intermediateTable, batchNumber);
+      synchronized (batch) {
+        long remainder = batch.recordWrites(batchSize);
+        batch.notifyAll();
+        logger.trace("Notified merge flush executor of successful write of {} rows "
+                + "for batch {} for intermediate table {}; {} rows remaining",
+            batchSize, batchNumber, intermediateTable, remainder);
+      }
+    });
+  }
+
+  /**
+   * Increment the batch number for the given table, and return the old batch number.
+   * @param intermediateTable the table whose batch number should be incremented
+   * @return the batch number for the table, pre-increment
+   */
+  public int incrementBatch(TableId intermediateTable) {
+    AtomicInteger batchCount = batchNumbers.get(intermediateTable);
+    // See addToBatch for an explanation of the synchronization here
+    synchronized (batchCount) {
+      return batchCount.getAndIncrement();
+    }
+  }
+
+  /**
+   * Prepare to merge the batch for the given table, by ensuring that all prior batches for that
+   * table have completed and that all rows for the batch itself have been written.
+   * @param intermediateTable the table for the batch
+   * @param batchNumber the batch number to prepare to flush
+   * @return whether a flush is necessary (will be false if no rows were present in the given batch)
+   */
+  public boolean prepareToFlush(TableId intermediateTable, int batchNumber) {
+    final ConcurrentMap<Integer, Batch> allBatchesForTable = batches.get(intermediateTable);
+    if (batchNumber != 0) {
+      final int priorBatchNumber = batchNumber - 1;
+      synchronized (allBatchesForTable) {
+        logger.debug("Ensuring batch {} is completed for intermediate table {} before flushing batch {}",
+            priorBatchNumber, intermediateTable, batchNumber);
+        while (allBatchesForTable.containsKey(priorBatchNumber)) {
+          try {
+            allBatchesForTable.wait();
+          } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for batch {} to complete for intermediate table {}",
+                batchNumber, intermediateTable);
+            throw new ConnectException(String.format(
+                "Interrupted while waiting for batch %d to complete for intermediate tabld %s",
+                batchNumber, intermediateTable
+            ));
+          }
+        }
+      }
+    } else {
+      logger.debug("Flushing first batch for intermediate table {}", intermediateTable);
+    }
+
+    final Batch currentBatch = allBatchesForTable.get(batchNumber);
+    if (currentBatch == null) {
+      logger.trace("No rows to write in batch {} for intermediate table {}", batchNumber, intermediateTable);
+      return false;
+    }
+
+    synchronized (currentBatch) {
+      logger.debug("{} rows currently remaining for batch {} for intermediate table {}",
+          currentBatch.pending(), batchNumber, intermediateTable);
+      while (currentBatch.pending() != 0) {
+        logger.trace("Waiting for all rows for batch {} from intermediate table {} to be written before flushing; {} remaining",
+            batchNumber, intermediateTable, currentBatch.pending());
+        try {
+          currentBatch.wait();
+        } catch (InterruptedException e) {
+          logger.warn("Interrupted while waiting for all rows for batch {} from intermediate table {} to be written",
+              batchNumber, intermediateTable);
+          throw new ConnectException(String.format(
+              "Interrupted while waiting for all rows for batch %d from intermediate table %s to be written",
+              batchNumber, intermediateTable
+          ));
+        }
+      }
+    }
+
+    try {
+      logger.trace(
+          "Waiting {} seconds before running merge query on batch {} from intermediate table {} "
+              + "in order to ensure that all rows are available in the streaming buffer",
+          STREAMING_BUFFER_AVAILABILITY_WAIT_MS, batchNumber, intermediateTable);
+      Thread.sleep(STREAMING_BUFFER_AVAILABILITY_WAIT_MS);
+    } catch (InterruptedException e) {
+      logger.warn("Interrupted while waiting before merge flushing batch {} for intermediate table {}",
+          batchNumber, intermediateTable);
+      throw new ConnectException(String.format(
+          "Interrupted while waiting before merge flushing batch %d for intermediate table %s",
+          batchNumber, intermediateTable
+      ));
+    }
+    return true;
+  }
+
+  /**
+   * Record a successful merge flush of all of the rows for the given batch in the intermediate
+   * table, alert any waiting merge flushes that are predicated on the completion of this merge
+   * flush, and marke the offsets for all of those rows as safe to commit.
+   * @param intermediateTable the source of the merge flush
+   * @param batchNumber the batch for the merge flush
+   */
+  public void recordSuccessfulFlush(TableId intermediateTable, int batchNumber) {
+    logger.trace("Successfully merge flushed batch {} for intermediate table {}",
+        batchNumber, intermediateTable);
+    final ConcurrentMap<Integer, Batch> allBatchesForTable = batches.get(intermediateTable);
+    Batch batch = allBatchesForTable.remove(batchNumber);
+
+    synchronized (allBatchesForTable) {
+      allBatchesForTable.notifyAll();
+    }
+
+    synchronized (offsets) {
+      offsets.putAll(batch.offsets());
+    }
+  }
+
+  private Batch batch(TableId intermediateTable, int batchNumber) {
+    return batches.get(intermediateTable).get(batchNumber);
+  }
+
+  private static class Batch {
+    private final AtomicLong pending;
+    private final AtomicLong total;
+    private final Map<TopicPartition, Long> offsets;
+
+    public Batch() {
+      this.total = new AtomicLong();
+      this.pending = new AtomicLong();
+      this.offsets = new HashMap<>();
+    }
+
+    public long pending() {
+      return pending.get();
+    }
+
+    public long total() {
+      return total.get();
+    }
+
+    public Map<TopicPartition, Long> offsets() {
+      return offsets;
+    }
+
+    public void recordOffsetFor(SinkRecord record) {
+      offsets.put(
+          new TopicPartition(record.topic(), record.kafkaPartition()),
+          // Use the offset of the record plus one here since that'll be the offset that we'll
+          // resume at if/when this record is the last-committed record and then the task is
+          // restarted
+          record.kafkaOffset() + 1);
+    }
+
+    /**
+     * Increment the total and pending number of records, and return the number of pending records
+     * @return the number of pending records for this batch
+     */
+    public long increment() {
+      total.incrementAndGet();
+      return pending.incrementAndGet();
+    }
+
+    public long recordWrites(long numRows) {
+      return pending.addAndGet(-numRows);
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -20,6 +20,7 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.TableId;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Maps;
@@ -46,11 +47,23 @@ public class MergeBatches {
   private static final Logger logger = LoggerFactory.getLogger(MergeBatches.class);
   private static final long STREAMING_BUFFER_AVAILABILITY_WAIT_MS = 10_000L;
 
+  private static long streamingBufferAvailabilityWaitMs = STREAMING_BUFFER_AVAILABILITY_WAIT_MS;
+
   private final String intermediateTableSuffix;
   private final BiMap<TableId, TableId> intermediateToDestinationTables;
   private final ConcurrentMap<TableId, AtomicInteger> batchNumbers;
   private final ConcurrentMap<TableId, ConcurrentMap<Integer, Batch>> batches;
   private final Map<TopicPartition, Long> offsets;
+
+  @VisibleForTesting
+  public static void setStreamingBufferAvailabilityWait(long waitMs) {
+    streamingBufferAvailabilityWaitMs = waitMs;
+  }
+
+  @VisibleForTesting
+  public static void resetStreamingBufferAvailabilityWait() {
+    streamingBufferAvailabilityWaitMs = STREAMING_BUFFER_AVAILABILITY_WAIT_MS;
+  }
 
   public MergeBatches(String intermediateTableSuffix) {
     this.intermediateTableSuffix = intermediateTableSuffix;
@@ -244,10 +257,10 @@ public class MergeBatches {
 
     try {
       logger.trace(
-          "Waiting {} seconds before running merge query on batch {} from intermediate table {} "
+          "Waiting {}ms before running merge query on batch {} from intermediate table {} "
               + "in order to ensure that all rows are available in the streaming buffer",
-          STREAMING_BUFFER_AVAILABILITY_WAIT_MS, batchNumber, intermediateTable);
-      Thread.sleep(STREAMING_BUFFER_AVAILABILITY_WAIT_MS);
+          streamingBufferAvailabilityWaitMs, batchNumber, intermediateTable);
+      Thread.sleep(streamingBufferAvailabilityWaitMs);
     } catch (InterruptedException e) {
       logger.warn("Interrupted while waiting before merge flushing batch {} for intermediate table {}",
           batchNumber, intermediateTable);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -125,7 +125,8 @@ public class MergeBatches {
     batchNumbers.put(result, new AtomicInteger());
     batches.put(result, new ConcurrentHashMap<>());
 
-    return result;  }
+    return result;
+  }
 
   public TableId destinationTableFor(TableId intermediateTable) {
     return intermediateToDestinationTables.get(intermediateTable);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -33,6 +33,11 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 /**
  * Simple Table Writer that attempts to write all the rows it is given at once.
@@ -48,21 +53,26 @@ public class TableWriter implements Runnable {
   private final PartitionedTableId table;
   private final List<RowToInsert> rows;
   private final String topic;
+  private final Consumer<List<RowToInsert>> onFinish;
 
   /**
    * @param writer the {@link BigQueryWriter} to use.
    * @param table the BigQuery table to write to.
    * @param rows the rows to write.
    * @param topic the kafka source topic of this data.
+   * @param onFinish a callback to invoke after all rows have been written successfully, which is
+   *                 called with all the rows written by the writer
    */
   public TableWriter(BigQueryWriter writer,
                      PartitionedTableId table,
                      List<RowToInsert> rows,
-                     String topic) {
+                     String topic,
+                     Consumer<List<RowToInsert>> onFinish) {
     this.writer = writer;
     this.table = table;
     this.rows = rows;
     this.topic = topic;
+    this.onFinish = onFinish;
   }
 
   @Override
@@ -102,6 +112,7 @@ public class TableWriter implements Runnable {
       logger.debug(logMessage, rows.size(), successCount, failureCount);
     }
 
+    onFinish.accept(rows);
   }
 
   private static int getNewBatchSize(int currentBatchSize) {
@@ -150,25 +161,21 @@ public class TableWriter implements Runnable {
     private final PartitionedTableId table;
     private final String topic;
 
+    private Consumer<List<RowToInsert>> onFinish;
     private List<RowToInsert> rows;
-
-    private RecordConverter<Map<String, Object>> recordConverter;
 
     /**
      * @param writer the BigQueryWriter to use
      * @param table the BigQuery table to write to.
      * @param topic the kafka source topic associated with the given table.
-     * @param recordConverter the record converter used to convert records to rows
      */
-    public Builder(BigQueryWriter writer, PartitionedTableId table, String topic,
-                   RecordConverter<Map<String, Object>> recordConverter) {
+    public Builder(BigQueryWriter writer, PartitionedTableId table, String topic) {
       this.writer = writer;
       this.table = table;
       this.topic = topic;
 
+      this.onFinish = null;
       this.rows = new ArrayList<>();
-
-      this.recordConverter = recordConverter;
     }
 
     /**
@@ -180,11 +187,24 @@ public class TableWriter implements Runnable {
     }
 
     /**
+     * Specify a callback to be invoked after all rows have been written. The callback will be
+     * invoked with the full list of rows written by this table writer.
+     * @param onFinish the callback to invoke; may not be null
+     * @throws IllegalStateException if invoked more than once on a single builder instance
+     */
+    public void onFinish(Consumer<List<RowToInsert>> onFinish) {
+      if (this.onFinish != null) {
+        throw new IllegalStateException("Cannot overwrite existing finish callback");
+      }
+      this.onFinish = Objects.requireNonNull(onFinish, "Finish callback cannot be null");
+    }
+
+    /**
      * Create a {@link TableWriter} from this builder.
      * @return a TableWriter containing the given writer, table, topic, and all added rows.
      */
     public TableWriter build() {
-      return new TableWriter(writer, table, rows, topic);
+      return new TableWriter(writer, table, rows, topic, onFinish != null ? onFinish : n -> { });
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -133,6 +133,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
           writeResponse = bigQuery.insertAll(request);
         } catch (BigQueryException exception) {
           // no-op, we want to keep retrying the insert
+          logger.trace("insertion failed", exception);
         }
       } else {
         return writeResponse.getInsertErrors();
@@ -181,6 +182,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
    * This is why we can't have nice things, Google.
    */
   private boolean onlyContainsInvalidSchemaErrors(Map<Long, List<BigQueryError>> errors) {
+    logger.trace("write response contained errors: \n{}", errors);
     boolean invalidSchemaError = false;
     for (List<BigQueryError> errorList : errors.values()) {
       for (BigQueryError error : errorList) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -1,0 +1,94 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
+
+  private final SchemaManager schemaManager;
+  private final boolean autoCreateTables;
+  private final Map<TableId, TableId> intermediateToDestinationTables;
+
+  /**
+   * @param bigQuery Used to send write requests to BigQuery.
+   * @param schemaManager Used to update BigQuery tables.
+   * @param retry How many retries to make in the event of a 500/503 error.
+   * @param retryWait How long to wait in between retries.
+   * @param autoUpdateSchemas Whether destination table schemas should be automatically updated
+   * @param autoCreateTables Whether destination tables should be automatically created
+   * @param intermediateToDestinationTables A mapping used to determine the destination table for
+   *                                        given intermediate tables; used for create/update
+   *                                        operations in order to propagate them to the destination
+   *                                        table
+   */
+  public UpsertDeleteBigQueryWriter(BigQuery bigQuery,
+                                    SchemaManager schemaManager,
+                                    int retry,
+                                    long retryWait,
+                                    boolean autoUpdateSchemas,
+                                    boolean autoCreateTables,
+                                    Map<TableId, TableId> intermediateToDestinationTables) {
+    // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
+    // automatically created
+    // The super class will handle all of the logic for writing to, creating, and updating
+    // intermediate tables; this class will handle logic for creating/updating the destination table
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, autoUpdateSchemas, true);
+    this.schemaManager = schemaManager;
+    this.autoCreateTables = autoCreateTables;
+    this.intermediateToDestinationTables = intermediateToDestinationTables;
+  }
+
+  @Override
+  protected void attemptSchemaUpdate(PartitionedTableId tableId, String topic) {
+    // Update the intermediate table here...
+    super.attemptSchemaUpdate(tableId, topic);
+    try {
+      // ... and update the destination table here
+      schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), topic);
+    } catch (BigQueryException exception) {
+      throw new BigQueryConnectException(
+          "Failed to update destination table schema for: " + tableId.getBaseTableId(), exception);
+    }
+  }
+
+  @Override
+  protected void attemptTableCreate(TableId tableId, String topic) {
+    // Create the intermediate table here...
+    super.attemptTableCreate(tableId, topic);
+    if (autoCreateTables) {
+      try {
+        // ... and create or update the destination table here, if it doesn't already exist and auto
+        // table creation is enabled
+        schemaManager.createOrUpdateTable(intermediateToDestinationTables.get(tableId), topic);
+      } catch (BigQueryException exception) {
+        throw new BigQueryConnectException(
+            "Failed to create table " + tableId, exception);
+      }
+    }
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -38,6 +38,7 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import org.apache.kafka.common.config.ConfigException;
@@ -101,6 +102,7 @@ public class BigQuerySinkConnectorTest {
       List<Map<String, String>> taskConfigs = testConnector.taskConfigs(i);
       assertEquals(i, taskConfigs.size());
       for (int j = 0; j < i; j++) {
+        expectedProperties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, Integer.toString(j));
         assertEquals(
             "Connector properties should match task configs",
             expectedProperties,
@@ -126,7 +128,7 @@ public class BigQuerySinkConnectorTest {
 
   @Test
   public void testConfig() {
-    assertEquals(BigQuerySinkConfig.getConfig(), new BigQuerySinkConnector().config());
+    assertNotNull(new BigQuerySinkConnector().config());
   }
 
   // Make sure that a config exception is properly translated into a SinkConfigConnectException

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
@@ -40,6 +41,7 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.Storage;
 
+import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
@@ -141,11 +143,15 @@ public class BigQuerySinkTaskTest {
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
-    testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
+    SinkRecord spoofedRecord =
+        spoofSinkRecord(topic, "k", "key", "v", "value", TimestampType.NO_TIMESTAMP_TYPE, null);
+    testTask.put(Collections.singletonList(spoofedRecord));
     testTask.flush(Collections.emptyMap());
     verify(bigQuery, times(1)).insertAll(any(InsertAllRequest.class));
-    verify(schemaRetriever, times(1)).setLastSeenSchema(any(TableId.class),
-        any(String.class), any(Schema.class));
+    verify(schemaRetriever, times(1)).setLastSeenSchema(
+        any(TableId.class), any(String.class), any(Schema.class), eq(KafkaSchemaRecordType.KEY));
+    verify(schemaRetriever, times(1)).setLastSeenSchema(
+        any(TableId.class), any(String.class), any(Schema.class), eq(KafkaSchemaRecordType.VALUE));
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -298,7 +298,7 @@ public class BigQuerySinkTaskTest {
         TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
-  // It's important that the buffer be completely wiped after a call to flush, since any execption
+  // It's important that the buffer be completely wiped after a call to flush, since any exception
   // thrown during flush causes Kafka Connect to not commit the offsets for any records sent to the
   // task since the last flush
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -20,6 +20,7 @@ package com.wepay.kafka.connect.bigquery;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
@@ -31,8 +32,11 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.Storage;
 
@@ -41,6 +45,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.apache.kafka.common.record.TimestampType;
@@ -51,15 +56,20 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class BigQuerySinkTaskTest {
   private static SinkTaskPropertiesFactory propertiesFactory;
@@ -67,6 +77,16 @@ public class BigQuerySinkTaskTest {
   @BeforeClass
   public static void initializePropertiesFactory() {
     propertiesFactory = new SinkTaskPropertiesFactory();
+  }
+
+  @Before
+  public void setUp() {
+    MergeBatches.setStreamingBufferAvailabilityWait(0);
+  }
+
+  @After
+  public void cleanUp() {
+    MergeBatches.resetStreamingBufferAvailabilityWait();
   }
 
   @Test
@@ -166,8 +186,6 @@ public class BigQuerySinkTaskTest {
 
     testTask.put(Collections.singletonList(emptyRecord));
   }
-
-  @Captor ArgumentCaptor<InsertAllRequest> captor;
 
   @Test
   public void testPutWhenPartitioningOnMessageTime() {
@@ -296,6 +314,77 @@ public class BigQuerySinkTaskTest {
 
     testTask.put(Collections.singletonList(spoofSinkRecord(topic, "value", "message text",
         TimestampType.NO_TIMESTAMP_TYPE, null)));
+  }
+
+  @Test
+  public void testPutWithUpsertDelete() throws Exception {
+    final String topic = "test-topic";
+    final String key = "kafkaKey";
+    final String value = "recordValue";
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
+    properties.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG, "-1");
+    properties.put(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG, "2");
+    properties.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, key);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+    when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Field keyField = Field.of(key, LegacySQLTypeName.STRING);
+    Field valueField = Field.of(value, LegacySQLTypeName.STRING);
+    com.google.cloud.bigquery.Schema intermediateSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+            .setMode(Field.Mode.REQUIRED)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.NULLABLE)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keyField)
+            .setMode(Field.Mode.REQUIRED)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueField)
+            .build()
+    );
+    when(schemaManager.cachedSchema(any())).thenReturn(intermediateSchema);
+
+    CountDownLatch executedMerges = new CountDownLatch(2);
+    CountDownLatch executedBatchClears = new CountDownLatch(2);
+
+    when(bigQuery.query(any(QueryJobConfiguration.class))).then(invocation -> {
+      String query = invocation.getArgument(0, QueryJobConfiguration.class).getQuery();
+      if (query.startsWith("MERGE")) {
+        executedMerges.countDown();
+      } else if (query.startsWith("DELETE")) {
+        executedBatchClears.countDown();
+      }
+      return null;
+    });
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    // Insert a few regular records and one tombstone record
+    testTask.put(Arrays.asList(
+        spoofSinkRecord(topic, key, "4761", "value", "message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "489", "value", "other message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "28980", "value", "more message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "4761", null, null, TimestampType.NO_TIMESTAMP_TYPE, null)
+    ));
+
+    assertTrue("Merge queries should be executed", executedMerges.await(5, TimeUnit.SECONDS));
+    assertTrue("Batch clears should be executed", executedBatchClears.await(1, TimeUnit.SECONDS));
   }
 
   // It's important that the buffer be completely wiped after a call to flush, since any exception
@@ -548,38 +637,57 @@ public class BigQuerySinkTaskTest {
   }
 
   /**
-   * Utility method for spoofing InsertAllRequests that should be sent to a BigQuery object.
-   * @param table The table to write to.
-   * @param rows The rows to write.
-   * @return The spoofed InsertAllRequest.
+   * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+   * @param topic The topic of the record.
+   * @param keyField The field name for the record key; may be null.
+   * @param key The content of the record key; may be null.
+   * @param valueField The field name for the record value; may be null
+   * @param value The content of the record value; may be null
+   * @param timestampType The type of timestamp embedded in the message
+   * @param timestamp The timestamp in milliseconds
+   * @return The spoofed SinkRecord.
    */
-  public static InsertAllRequest buildExpectedInsertAllRequest(
-      TableId table,
-      InsertAllRequest.RowToInsert... rows) {
-    return InsertAllRequest.newBuilder(table, rows)
-        .setIgnoreUnknownValues(false)
-        .setSkipInvalidRows(false)
-        .build();
+  public static SinkRecord spoofSinkRecord(String topic, String keyField, String key,
+                                           String valueField, String value,
+                                           TimestampType timestampType, Long timestamp) {
+    Schema basicKeySchema = null;
+    Struct basicKey = null;
+    if (keyField != null) {
+      basicKeySchema = SchemaBuilder
+          .struct()
+          .field(keyField, Schema.STRING_SCHEMA)
+          .build();
+      basicKey = new Struct(basicKeySchema);
+      basicKey.put(keyField, key);
+    }
+
+    Schema basicValueSchema = null;
+    Struct basicValue = null;
+    if (valueField != null) {
+      basicValueSchema = SchemaBuilder
+          .struct()
+          .field(valueField, Schema.STRING_SCHEMA)
+          .build();
+      basicValue = new Struct(basicValueSchema);
+      basicValue.put(valueField, value);
+    }
+
+    return new SinkRecord(topic, 0, basicKeySchema, basicKey,
+        basicValueSchema, basicValue, 0, timestamp, timestampType);
   }
 
   /**
    * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
    * @param topic The topic of the record.
-   * @param value The content of the record.
+   * @param field The field name for the record value.
+   * @param value The content of the record value.
    * @param timestampType The type of timestamp embedded in the message
    * @param timestamp The timestamp in milliseconds
    * @return The spoofed SinkRecord.
    */
   public static SinkRecord spoofSinkRecord(String topic, String field, String value,
                                            TimestampType timestampType, Long timestamp) {
-    Schema basicRowSchema = SchemaBuilder
-            .struct()
-            .field(field, Schema.STRING_SCHEMA)
-            .build();
-    Struct basicRowValue = new Struct(basicRowSchema);
-    basicRowValue.put(field, value);
-    return new SinkRecord(topic, 0, null, null,
-        basicRowSchema, basicRowValue, 0, timestamp, timestampType);
+    return spoofSinkRecord(topic, null, null, field, value, timestampType, timestamp);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
@@ -1,0 +1,272 @@
+package com.wepay.kafka.connect.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MergeQueriesTest {
+
+  private static final String KEY = "kafkaKey";
+
+  private static final int BATCH_NUMBER = 42;
+  private static final TableId DESTINATION_TABLE = TableId.of("ds1", "t");
+  private static final TableId INTERMEDIATE_TABLE = TableId.of("ds1", "t_tmp_6_uuid_epoch");
+  private static final Schema INTERMEDIATE_TABLE_SCHEMA = constructIntermediateTable();
+
+  @Mock private MergeBatches mergeBatches;
+  @Mock private KCBQThreadPoolExecutor executor;
+  @Mock private BigQuery bigQuery;
+  @Mock private SchemaManager schemaManager;
+  @Mock private SinkTaskContext context;
+
+  @Before
+  public void setUp() {
+    when(schemaManager.cachedSchema(INTERMEDIATE_TABLE)).thenReturn(INTERMEDIATE_TABLE_SCHEMA);
+  }
+
+  private MergeQueries mergeQueries(boolean insertPartitionTime, boolean upsert, boolean delete) {
+    return new MergeQueries(
+        KEY, insertPartitionTime, upsert, delete, mergeBatches, executor, bigQuery, schemaManager, context
+    );
+  }
+
+  private static Schema constructIntermediateTable() {
+    List<Field> fields = new ArrayList<>();
+
+    List<Field> valueFields = Arrays.asList(
+        Field.of("f1", LegacySQLTypeName.STRING),
+        Field.of("f2", LegacySQLTypeName.RECORD,
+            Field.of("nested_f1", LegacySQLTypeName.INTEGER)
+        ),
+        Field.of("f3", LegacySQLTypeName.BOOLEAN),
+        Field.of("f4", LegacySQLTypeName.BYTES)
+    );
+    Field wrappedValueField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueFields.toArray(new Field[0]))
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    fields.add(wrappedValueField);
+
+    List<Field> keyFields = Arrays.asList(
+        Field.of("k1", LegacySQLTypeName.STRING),
+        Field.of("k2", LegacySQLTypeName.RECORD,
+            Field.of("nested_k1", LegacySQLTypeName.RECORD,
+                Field.of("doubly_nested_k", LegacySQLTypeName.BOOLEAN)
+            ),
+            Field.of("nested_k2", LegacySQLTypeName.INTEGER)
+        )
+    );
+    Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keyFields.toArray(new Field[0]))
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    fields.add(kafkaKeyField);
+
+    Field partitionTimeField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    fields.add(partitionTimeField);
+
+    Field batchNumberField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    fields.add(batchNumberField);
+
+    return Schema.of(fields);
+  }
+
+  @Test
+  public void testUpsertQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key "
+          + "WHEN MATCHED "
+            + "THEN UPDATE SET f1=`src`.value.f1, f2=`src`.value.f2, f3=`src`.value.f3, f4=`src`.value.f4 "
+          + "WHEN NOT MATCHED "
+            + "THEN INSERT (" 
+              + KEY + ", "
+              + "_PARTITIONTIME, " 
+              + "f1, f2, f3, f4) "
+            + "VALUES (" 
+              + "`src`.key, " 
+              + "CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP), " 
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4" 
+            + ");";
+    String actualQuery = mergeQueries(true, true, false)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key "
+          + "WHEN MATCHED "
+            + "THEN UPDATE SET f1=`src`.value.f1, f2=`src`.value.f2, f3=`src`.value.f3, f4=`src`.value.f4 "
+          + "WHEN NOT MATCHED "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "`src`.key, "
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(false, true, false)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testDeleteQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src " 
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " " 
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) " 
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key AND `src`.value IS NULL " 
+          + "WHEN MATCHED " 
+            + "THEN DELETE " 
+          + "WHEN NOT MATCHED " 
+            + "THEN INSERT (" 
+              + KEY + ", "
+              + "_PARTITIONTIME, " 
+              + "f1, f2, f3, f4) " 
+            + "VALUES (" 
+              + "`src`.key, " 
+              + "CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP), " 
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4" 
+            + ");";
+    String actualQuery = mergeQueries(true, false, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testDeleteQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key AND `src`.value IS NULL "
+          + "WHEN MATCHED "
+            + "THEN DELETE "
+          + "WHEN NOT MATCHED "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "`src`.key, "
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(false, false, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertDeleteQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src " 
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x " 
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) " 
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key " 
+          + "WHEN MATCHED AND `src`.value IS NOT NULL " 
+            + "THEN UPDATE SET f1=`src`.value.f1, f2=`src`.value.f2, f3=`src`.value.f3, f4=`src`.value.f4 " 
+          + "WHEN MATCHED AND `src`.value IS NULL " 
+            + "THEN DELETE " 
+          + "WHEN NOT MATCHED AND `src`.value IS NOT NULL " 
+            + "THEN INSERT (" 
+              + KEY + ", " 
+              + "_PARTITIONTIME, " 
+              + "f1, f2, f3, f4) " 
+            + "VALUES (" 
+              + "`src`.key, " 
+              + "CAST(CAST(DATE(`src`.partitionTime) AS DATE) AS TIMESTAMP), " 
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4" 
+            + ");";
+    String actualQuery = mergeQueries(true, true, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertDeleteQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY partitionTime DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`.kafkaKey=`src`.key "
+          + "WHEN MATCHED AND `src`.value IS NOT NULL "
+            + "THEN UPDATE SET f1=`src`.value.f1, f2=`src`.value.f2, f3=`src`.value.f3, f4=`src`.value.f4 "
+          + "WHEN MATCHED AND `src`.value IS NULL "
+            + "THEN DELETE "
+          + "WHEN NOT MATCHED AND `src`.value IS NOT NULL "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "`src`.key, "
+              + "`src`.value.f1, `src`.value.f2, `src`.value.f3, `src`.value.f4"
+            + ");";    String actualQuery = mergeQueries(false, true, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testBatchClearQuery() {
+    String expectedQuery = 
+        "DELETE FROM " + table(INTERMEDIATE_TABLE)
+          + " WHERE batchNumber <= " + BATCH_NUMBER
+          + " AND _PARTITIONTIME IS NOT NULL;";
+    // No difference in batch clearing between upsert, delete, and both, or with or without partition time
+    String actualQuery = mergeQueries(false, false, false)
+        .batchClearQuery(INTERMEDIATE_TABLE, BATCH_NUMBER);
+    System.out.println(actualQuery);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  private String table(TableId table) {
+    return String.format("`%s`.`%s`", table.getDataset(), table.getTable());
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -19,6 +19,7 @@ package com.wepay.kafka.connect.bigquery;
 
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkPropertiesFactory.java
@@ -19,7 +19,6 @@ package com.wepay.kafka.connect.bigquery;
 
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
-import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkTaskPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkTaskPropertiesFactory.java
@@ -30,6 +30,7 @@ public class SinkTaskPropertiesFactory extends SinkPropertiesFactory {
 
     properties.put(BigQuerySinkTaskConfig.SCHEMA_UPDATE_CONFIG, "false");
     properties.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "4");
 
     return properties;
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -1,0 +1,349 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableResult;
+import com.wepay.kafka.connect.bigquery.BigQueryHelper;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.cloud.bigquery.LegacySQLTypeName.BOOLEAN;
+import static com.google.cloud.bigquery.LegacySQLTypeName.BYTES;
+import static com.google.cloud.bigquery.LegacySQLTypeName.DATE;
+import static com.google.cloud.bigquery.LegacySQLTypeName.FLOAT;
+import static com.google.cloud.bigquery.LegacySQLTypeName.INTEGER;
+import static com.google.cloud.bigquery.LegacySQLTypeName.STRING;
+import static com.google.cloud.bigquery.LegacySQLTypeName.TIMESTAMP;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertTrue;
+
+@Category(IntegrationTest.class)
+public abstract class BaseConnectorIT {
+  private static final Logger logger = LoggerFactory.getLogger(BaseConnectorIT.class);
+
+  private static final String KEYFILE_ENV_VAR = "KCBQ_TEST_KEYFILE";
+  private static final String PROJECT_ENV_VAR = "KCBQ_TEST_PROJECT";
+  private static final String DATASET_ENV_VAR = "KCBQ_TEST_DATASET";
+  private static final String KEYSOURCE_ENV_VAR = "KCBQ_TEST_KEYSOURCE";
+
+  protected static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
+  protected static final long COMMIT_MAX_DURATION_MS = TimeUnit.MINUTES.toMillis(5);
+  protected static final long OFFSETS_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+  protected static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+
+  protected EmbeddedConnectCluster connect;
+  private Admin kafkaAdminClient;
+
+  protected void startConnect() {
+    Map<String, String> workerProps = new HashMap<>();
+    workerProps.put(
+        WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, Long.toString(OFFSET_COMMIT_INTERVAL_MS));
+    // Allow per-connector consumer configuration for throughput testing
+    workerProps.put(
+        WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, "All");
+
+    connect = new EmbeddedConnectCluster.Builder()
+        .name("kcbq-connect-cluster")
+        .workerProps(workerProps)
+        .build();
+
+    // start the clusters
+    connect.start();
+
+    kafkaAdminClient = connect.kafka().createAdminClient();
+  }
+
+  protected void stopConnect() {
+    if (kafkaAdminClient !=  null) {
+      kafkaAdminClient.close();
+      kafkaAdminClient = null;
+    }
+
+    // stop all Connect, Kafka and Zk threads.
+    if (connect != null) {
+      connect.stop();
+      connect = null;
+    }
+  }
+
+  protected Map<String, String> baseConnectorProps(int tasksMax) {
+    Map<String, String> result = new HashMap<>();
+
+    result.put(CONNECTOR_CLASS_CONFIG, "BigQuerySinkConnector");
+    result.put(TASKS_MAX_CONFIG, Integer.toString(tasksMax));
+
+    result.put(BigQuerySinkConfig.PROJECT_CONFIG, project());
+    result.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=" + dataset());
+    result.put(BigQuerySinkConfig.KEYFILE_CONFIG, keyFile());
+    result.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource());
+
+    return result;
+  }
+
+  protected BigQuery newBigQuery() {
+    return new BigQueryHelper()
+        .setKeySource(keySource())
+        .connect(project(), keyFile());
+  }
+
+  protected void clearPriorTable(BigQuery bigQuery, String table) {
+    boolean deleted = bigQuery.delete(TableId.of(dataset(), table));
+    if (deleted) {
+      logger.info("Deleted existing test table `{}`.`{}`", dataset(), table);
+    }
+  }
+
+  protected void waitForCommittedRecords(
+      String connector, String topic, long numRecords, int numTasks
+  ) throws InterruptedException {
+    waitForCommittedRecords(connector, topic, numRecords, numTasks, COMMIT_MAX_DURATION_MS);
+  }
+
+  protected void waitForCommittedRecords(
+      String connector, String topic, long numRecords, int numTasks, long timeoutMs) throws InterruptedException {
+    waitForCondition(
+        () -> {
+          long totalCommittedRecords = totalCommittedRecords(connector, topic);
+          if (totalCommittedRecords >= numRecords) {
+            return true;
+          } else {
+            // Check to make sure the connector is still running. If not, fail fast
+            assertTrue(
+                "Connector or one of its tasks failed during testing",
+                assertConnectorAndTasksRunning(connector, numTasks).orElse(false));
+            logger.debug("Connector has only committed {} records for topic {} so far; {} expected",
+                totalCommittedRecords, topic, numRecords);
+            // Sleep here so as not to spam Kafka with list-offsets requests
+            Thread.sleep(OFFSET_COMMIT_INTERVAL_MS / 2);
+            return false;
+          }
+        },
+        timeoutMs,
+        "Either the connector failed, or the message commit duration expired without all expected messages committed");
+  }
+
+  protected synchronized long totalCommittedRecords(String connector, String topic) throws TimeoutException, ExecutionException, InterruptedException {
+    // See https://github.com/apache/kafka/blob/f7c38d83c727310f4b0678886ba410ae2fae9379/connect/runtime/src/main/java/org/apache/kafka/connect/util/SinkUtils.java
+    // for how the consumer group ID is constructed for sink connectors
+    Map<TopicPartition, OffsetAndMetadata> offsets = kafkaAdminClient
+        .listConsumerGroupOffsets("connect-" + connector)
+        .partitionsToOffsetAndMetadata()
+        .get(OFFSETS_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+    logger.trace("Connector {} has so far committed offsets {}", connector, offsets);
+
+    return offsets.entrySet().stream()
+        .filter(entry -> topic.equals(entry.getKey().topic()))
+        .mapToLong(entry -> entry.getValue().offset())
+        .sum();
+  }
+
+  /**
+   * Read all rows from the given table.
+   * @param bigQuery used to connect to BigQuery
+   * @param tableName the table to read
+   * @param sortColumn a column to sort rows by (can use dot notation to refer to nested fields)
+   * @return a list of all rows from the table, in random order.
+   */
+  protected List<List<Object>> readAllRows(
+      BigQuery bigQuery, String tableName, String sortColumn) throws InterruptedException {
+
+    Table table = bigQuery.getTable(dataset(), tableName);
+    Schema schema = table.getDefinition().getSchema();
+
+    TableResult tableResult = bigQuery.query(QueryJobConfiguration.of(String.format(
+        "SELECT * FROM `%s`.`%s` ORDER BY %s ASC",
+        dataset(),
+        tableName,
+        sortColumn
+    )));
+
+    return StreamSupport.stream(tableResult.iterateAll().spliterator(), false)
+        .map(fieldValues -> convertRow(schema.getFields(), fieldValues))
+        .collect(Collectors.toList());
+  }
+
+  private static List<Byte> boxByteArray(byte[] bytes) {
+    Byte[] result = new Byte[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      result[i] = bytes[i];
+    }
+    return Arrays.asList(result);
+  }
+
+  private Object convertField(Field fieldSchema, FieldValue field) {
+    if (field.isNull()) {
+      return null;
+    }
+    switch (field.getAttribute()) {
+      case PRIMITIVE:
+        if (fieldSchema.getType().equals(BOOLEAN)) {
+          return field.getBooleanValue();
+        } else if (fieldSchema.getType().equals(BYTES)) {
+          // Do this in order for assertEquals() to work when this is an element of two compared
+          // lists
+          return boxByteArray(field.getBytesValue());
+        } else if (fieldSchema.getType().equals(DATE)) {
+          DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+          return LocalDate.parse(field.getStringValue(), dateFormatter)
+              .atStartOfDay(ZoneOffset.UTC)
+              .toInstant()
+              .toEpochMilli();
+        } else if (fieldSchema.getType().equals(FLOAT)) {
+          return field.getDoubleValue();
+        } else if (fieldSchema.getType().equals(INTEGER)) {
+          return field.getLongValue();
+        } else if (fieldSchema.getType().equals(STRING)) {
+          return field.getStringValue();
+        } else if (fieldSchema.getType().equals(TIMESTAMP)) {
+          return field.getTimestampValue();
+        } else {
+          throw new RuntimeException("Cannot convert primitive field type "
+              + fieldSchema.getType());
+        }
+      case REPEATED:
+        List<Object> result = new ArrayList<>();
+        for (FieldValue arrayField : field.getRepeatedValue()) {
+          result.add(convertField(fieldSchema, arrayField));
+        }
+        return result;
+      case RECORD:
+        List<Field> recordSchemas = fieldSchema.getSubFields();
+        List<FieldValue> recordFields = field.getRecordValue();
+        return convertRow(recordSchemas, recordFields);
+      default:
+        throw new RuntimeException("Unknown field attribute: " + field.getAttribute());
+    }
+  }
+
+  private List<Object> convertRow(List<Field> rowSchema, List<FieldValue> row) {
+    List<Object> result = new ArrayList<>();
+    assert (rowSchema.size() == row.size());
+
+    for (int i = 0; i < rowSchema.size(); i++) {
+      result.add(convertField(rowSchema.get(i), row.get(i)));
+    }
+
+    return result;
+  }
+
+  /**
+   * Wait up to {@link #CONNECTOR_STARTUP_DURATION_MS maximum time limit} for the connector with the given
+   * name to start the specified number of tasks.
+   *
+   * @param name the name of the connector
+   * @param numTasks the minimum number of tasks that are expected
+   * @return the time this method discovered the connector has started, in milliseconds past epoch
+   * @throws InterruptedException if this was interrupted
+   */
+  protected long waitForConnectorToStart(String name, int numTasks) throws InterruptedException {
+    TestUtils.waitForCondition(
+        () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
+        CONNECTOR_STARTUP_DURATION_MS,
+        "Connector tasks did not start in time."
+    );
+    return System.currentTimeMillis();
+  }
+
+  /**
+   * Confirm that a connector with an exact number of tasks is running.
+   *
+   * @param connectorName the connector
+   * @param numTasks the minimum number of tasks
+   * @return true if the connector and tasks are in RUNNING state; false otherwise
+   */
+  protected Optional<Boolean> assertConnectorAndTasksRunning(String connectorName, int numTasks) {
+    try {
+      ConnectorStateInfo info = connect.connectorStatus(connectorName);
+      boolean result = info != null
+                       && info.tasks().size() >= numTasks
+                       && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
+                       && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
+      return Optional.of(result);
+    } catch (Exception e) {
+      logger.error("Could not check connector state info.", e);
+      return Optional.empty();
+    }
+  }
+
+  private String readEnvVar(String var) {
+    String result = System.getenv(var);
+    if (result == null) {
+      throw new IllegalStateException(String.format(
+          "Environment variable '%s' must be supplied to run integration tests",
+          var));
+    }
+    return result;
+  }
+
+  private String readEnvVar(String var, String defaultVal) {
+    return System.getenv().getOrDefault(var, defaultVal);
+  }
+
+  protected String keyFile() {
+    return readEnvVar(KEYFILE_ENV_VAR);
+  }
+
+  protected String project() {
+    return readEnvVar(PROJECT_ENV_VAR);
+  }
+
+  protected String dataset() {
+    return readEnvVar(DATASET_ENV_VAR);
+  }
+
+  protected String keySource() {
+    return readEnvVar(KEYSOURCE_ENV_VAR, BigQuerySinkConfig.KEY_SOURCE_DEFAULT);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -1,0 +1,408 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.retrieve.MemorySchemaRetriever;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.Assert.assertEquals;
+
+@Category(IntegrationTest.class)
+public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(UpsertDeleteBigQuerySinkConnectorIT.class);
+
+  private static final String CONNECTOR_NAME = "kcbq-sink-connector";
+  private static final long NUM_RECORDS_PRODUCED = 20;
+  private static final int TASKS_MAX = 3;
+  private static final String KAFKA_FIELD_NAME = "kafkaKey";
+
+  private BigQuery bigQuery;
+
+  @Before
+  public void setup() {
+    bigQuery = newBigQuery();
+    startConnect();
+  }
+
+  @After
+  public void close() {
+    bigQuery = null;
+    stopConnect();
+  }
+
+  private Map<String, String> upsertDeleteProps(
+      boolean upsert,
+      boolean delete,
+      long mergeRecordsThreshold) {
+    if (!upsert && !delete) {
+      throw new IllegalArgumentException("At least one of upsert or delete must be enabled");
+    }
+
+    Map<String, String> result = new HashMap<>();
+
+    // use the JSON converter with schemas enabled
+    result.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    result.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    if (upsert) {
+      result.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    }
+    if (delete) {
+      result.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+    }
+
+    // Hardcode merge flushes to just use number of records for now, as it's more deterministic and
+    // faster to test
+    result.put(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG, "-1");
+    result.put(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG, Long.toString(mergeRecordsThreshold));
+
+    result.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, KAFKA_FIELD_NAME);
+
+    return result;
+  }
+
+  @Test
+  public void testUpsert() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-upsert";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_upsert";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable only upsert and not delete, and merge flush every other record
+    props.putAll(upsertDeleteProps(true, false, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      String kafkaValue = value(valueConverter, topic, i, false);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED / 2)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            (i - 1) % 3 == 0,
+            (i * 2 + 1) / 0.69,
+            Collections.singletonList(i)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  public void testDelete() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-delete";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_delete";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable only delete and not upsert, and merge flush every other record
+    props.putAll(upsertDeleteProps(false, true, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Because upsert is not enabled, no deduplication will take place
+      // and, unless a tombstone is written for that key, both will be inserted
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED)
+        .filter(i -> i % 4 < 2)
+        .mapToObj(i -> Arrays.asList(
+            i % 4 == 0 ? "a string" : "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  public void testUpsertDelete() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-upsert-delete";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_upsert_delete";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable upsert and delete, and merge flush every other record
+    props.putAll(upsertDeleteProps(true, true, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  @Ignore("Skipped during regular testing; comment-out annotation to run")
+  public void testUpsertDeleteHighThroughput() throws Throwable {
+    final long numRecords = 1_000_000L;
+    final int numPartitions = 10;
+    final int tasksMax = 1;
+
+    // create topic in Kafka
+    final String topic = "test-upsert-delete-throughput";
+    connect.kafka().createTopic(topic, numPartitions);
+
+    final String table = "test_upsert_delete_throughput";
+    clearPriorTable(bigQuery, table);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka. Pre-populate Kafka before starting the connector as we want to measure
+    // the connector's throughput cleanly
+    logger.info("Pre-populating Kafka with test data");
+    for (int i = 0; i < numRecords; i++) {
+      if (i % 10000 == 0) {
+        logger.info("{} records produced so far", i);
+      }
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will
+      // be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // setup props for the sink connector
+    // use a single task
+    Map<String, String> props = baseConnectorProps(tasksMax);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+    // Allow for at most 10,000 records per call to poll
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+        "10000");
+    // Try to get at least 1 MB per partition with each request
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
+        Integer.toString(ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES * numPartitions));
+    // Wait up to one second for each batch to reach the requested size
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG,
+        "1000"
+    );
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable upsert and delete, and schedule ten total flushes
+    props.putAll(upsertDeleteProps(true, true, numRecords / 10));
+
+    logger.info("Pre-population complete; creating connector");
+    long start = System.currentTimeMillis();
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, tasksMax);
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, numRecords, tasksMax, TimeUnit.MINUTES.toMillis(10));
+    long time = System.currentTimeMillis() - start;
+    logger.info("All records have been read and committed by the connector; "
+        + "total time from start to finish: {} seconds", time / 1000.0);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, numRecords)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  private Converter converter(boolean isKey) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, true);
+    Converter result = new JsonConverter();
+    result.configure(props, isKey);
+    return result;
+  }
+
+  private String key(Converter converter, String topic, long iteration) {
+    final Schema schema = SchemaBuilder.struct()
+        .field("k1", Schema.INT64_SCHEMA)
+        .build();
+
+    final Struct struct = new Struct(schema)
+        .put("k1", iteration);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String value(Converter converter, String topic, long iteration, boolean tombstone) {
+    final Schema schema = SchemaBuilder.struct()
+        .optional()
+        .field("f1", Schema.STRING_SCHEMA)
+        .field("f2", Schema.BOOLEAN_SCHEMA)
+        .field("f3", Schema.FLOAT64_SCHEMA)
+        .build();
+
+    if (tombstone) {
+      return new String(converter.fromConnectData(topic, schema, null));
+    }
+
+    final Struct struct = new Struct(schema)
+        .put("f1", iteration % 2 == 0 ? "a string" : "another string")
+        .put("f2", iteration % 3 == 0)
+        .put("f3", iteration / 0.69);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
@@ -26,7 +26,7 @@ public class MemorySchemaRetrieverTest {
     final TableId tableId = getTableId("testTable", "testDataset");
     SchemaRetriever retriever = new MemorySchemaRetriever();
     retriever.configure(new HashMap<>());
-    Assert.assertEquals(retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE), SchemaBuilder.struct().build());
+    Assert.assertEquals(SchemaBuilder.struct().build(), retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -39,7 +39,7 @@ public class MemorySchemaRetrieverTest {
     Schema expectedSchema = Schema.OPTIONAL_FLOAT32_SCHEMA;
     retriever.setLastSeenSchema(tableId, topic, expectedSchema);
 
-    Assert.assertEquals(retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.KEY), expectedSchema);
+    Assert.assertEquals(expectedSchema, retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -56,9 +56,10 @@ public class MemorySchemaRetrieverTest {
     retriever.setLastSeenSchema(floatTableId, floatSchemaTopic, expectedFloatSchema);
     retriever.setLastSeenSchema(intTableId, intSchemaTopic, expectedIntSchema);
 
-    Assert.assertEquals(
-        retriever.retrieveSchema(floatTableId, floatSchemaTopic, KafkaSchemaRecordType.KEY), expectedFloatSchema);
-    Assert.assertEquals(retriever.retrieveSchema(intTableId, intSchemaTopic, KafkaSchemaRecordType.KEY), expectedIntSchema);
+    Assert.assertEquals(expectedFloatSchema,
+        retriever.retrieveSchema(floatTableId, floatSchemaTopic, KafkaSchemaRecordType.VALUE));
+    Assert.assertEquals(expectedIntSchema,
+        retriever.retrieveSchema(intTableId, intSchemaTopic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -73,6 +74,25 @@ public class MemorySchemaRetrieverTest {
     retriever.setLastSeenSchema(tableId, intSchemaTopic, firstSchema);
     retriever.setLastSeenSchema(tableId, intSchemaTopic, secondSchema);
 
-    Assert.assertEquals(retriever.retrieveSchema(tableId, intSchemaTopic, KafkaSchemaRecordType.VALUE), secondSchema);
+    Assert.assertEquals(secondSchema,
+        retriever.retrieveSchema(tableId, intSchemaTopic, KafkaSchemaRecordType.VALUE));
+  }
+
+  @Test
+  public void testRetrieveKeyAndValueSchema() {
+    final String schemaTopic = "test-key-and-value";
+    final TableId tableId = getTableId("testTable", "testDataset");
+    SchemaRetriever retriever = new MemorySchemaRetriever();
+    retriever.configure(new HashMap<>());
+
+    Schema keySchema = Schema.STRING_SCHEMA;
+    Schema valueSchema = Schema.OPTIONAL_BOOLEAN_SCHEMA;
+    retriever.setLastSeenSchema(tableId, schemaTopic, keySchema, KafkaSchemaRecordType.KEY);
+    retriever.setLastSeenSchema(tableId, schemaTopic, valueSchema, KafkaSchemaRecordType.VALUE);
+
+    Assert.assertEquals(keySchema,
+        retriever.retrieveSchema(tableId, schemaTopic, KafkaSchemaRecordType.KEY));
+    Assert.assertEquals(valueSchema,
+        retriever.retrieveSchema(tableId, schemaTopic, KafkaSchemaRecordType.VALUE));
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -287,6 +287,7 @@ public class BigQueryWriterTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "6");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
     return properties;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -163,6 +163,7 @@ public class GCSToBQWriterTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "9");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
     // gcs config

--- a/kcbq-connector/src/test/resources/log4j.properties
+++ b/kcbq-connector/src/test/resources/log4j.properties
@@ -1,0 +1,20 @@
+log4j.rootLogger=INFO, stdout
+
+# Send the logs to the console.
+#
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
+
+# These are used in the log4j properties file that ships by default with Connect
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.reflections=ERROR
+
+# We see a lot of WARN-level messages from this class when a table is created by the connector and
+# then written to shortly after. No need for that much noise during routine tests
+log4j.logger.com.wepay.kafka.connect.bigquery.write.batch.TableWriter=ERROR
+# Logs a message at INFO on every http request
+log4j.logger.org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster=WARN


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-8804)

Adds integration tests for upsert/delete and fixes a small bug in the connector's `SchemaRetriever` API. For instructions on running the tests, see the changes to the `README`.

The tests cover:

- Connector running in upsert-only mode, delete-only mode, and upsert-delete mode, with ingestion-time partitioning, automatic table creation (via the `MemorySchemaRetriever`), and correctness-of-content verification for all three.

There's also an ignored-by-default throughput test that generates 1,000,000 records into Kafka, runs the connector in upsert-delete mode, and outputs the time taken between starting the connector and commit of offsets for every record produced.