### PR TITLE
Throw original error if batch size is reduced to be smaller than 1

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -84,6 +84,9 @@ public class TableWriter implements Runnable {
           logger.warn("Could not write batch of size {} to BigQuery.", currentBatch.size(), err);
           if (isBatchSizeError(err)) {
             failureCount++;
+            if (currentBatchSize == 1) {
+              throw err;
+            }
             currentBatchSize = getNewBatchSize(currentBatchSize);
           }
         }


### PR DESCRIPTION
## Problem
When we get responses from BQ that seem like batch size too large issues (but this is not very accurate logic), we cut the batch size, until we get to zero, then throw ConnectException:
```
    if (currentBatchSize == 1) {
      // todo correct exception type?
      throw new ConnectException("Attempted to reduce batch size below 1.");
    }
```
In the case where we mis-diagnose the error response from BQ, this logic obscures the actual response. In practice, I have production issues that are not batch issues, that show up in my logs and exceptions as batch issues because of this logic.

## Solution
The quick-fix here is to throw the original BQ exception instead of trying to reduce batch size below 1, to at least make reading the logs and debugging easier. The deeper fix would be to actually improve the `isBatchSizeError` function, but I don't think we'll always plug any hole, so this PR is a definite improvement, and improvements to `isBatchSizeError` method can be improved in future PRs.

## Refs
https://cloud.google.com/bigquery/docs/error-messages
https://cloud.google.com/bigquery/quotas