### PR TITLE
GH-264: Add support for upsert/delete via periodic merge flushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,41 @@ adjusting flags given to the Avro Console Producer and tweaking the config setti
 
 ## Integration Testing the Connector
 
+There is a legacy Docker-based integration test for the connector, and newer integration tests that
+programmatically instantiate an embedded Connect cluster.
+
+### Embedded integration tests
+
+Currently these tests only verify the connector's upsert/delete feature. They should eventually
+replace all of the existing Docker-based tests.
+
+#### Configuring the tests
+
+You must supply the following environment variables in order to run the tests:
+
+- `$KCBQ_TEST_PROJECT`: The name of the BigQuery project to use for the test
+- `$KCBQ_TEST_DATASET`: The name of the BigQuery dataset to use for the test
+- `$KCBQ_TEST_KEYFILE`: The key (either file or raw contents) used to authenticate with BigQuery
+during the test
+
+Additionally, the `$KCBQ_TEST_KEYSOURCE` variable can be supplied to specify whether the value of
+`$KCBQ_TEST_KEYFILE` are a path to a key file (if set to `FILE`) or the raw contents of a key file
+(if set to `JSON`). The default is `FILE`.
+
+#### Running the Integration Tests
+
+```bash
+./gradlew embeddedIntegrationTest
+```
+
+### Docker-based tests
+
 > **NOTE**: You must have [Docker] installed and running on your machine in order to run integration
 tests for the connector.
 
 This all takes place in the `kcbq-connector` directory.
 
-### How Integration Testing Works
+#### How Integration Testing Works
 
 Integration tests run by creating [Docker] instances for [Zookeeper], [Kafka], [Schema Registry], 
 and the BigQuery Connector itself, then verifying the results using a [JUnit] test.
@@ -148,7 +177,7 @@ The project and dataset they write to, as well as the specific JSON key file the
 specified by command-line flag, environment variable, or configuration file — the exact details of
 each can be found by running the integration test script with the `-?` flag.
 
-### Data Corruption Concerns
+#### Data Corruption Concerns
 
 In order to ensure the validity of each test, any table that will be written to in the course of
 integration testing is preemptively deleted before the connector is run. This will only be an issue
@@ -161,7 +190,7 @@ tests will corrupt any existing data that is already on your machine, and there 
 free up any of your ports that might currently be in use by real instances of the programs that are 
 faked in the process of testing.
 
-### Running the Integration Tests
+#### Running the Integration Tests
 
 Running the series of integration tests is easy:
 
@@ -176,7 +205,7 @@ the `--help` flag.
 > **NOTE:** You must have a recent version of [boot2docker], [Docker Machine], [Docker], etc.
 installed. Older versions will hang when cleaning containers, and linking doesn't work properly.
 
-### Adding New Integration Tests
+#### Adding New Integration Tests
 
 Adding an integration test is a little more involved, and consists of two major steps: specifying
 Avro data to be sent to Kafka, and specifying via JUnit test how to verify that such data made 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ project.ext {
     ioConfluentVersion = '5.5.0'
     junitVersion = '4.12'
     kafkaVersion = '2.5.0'
+    kafkaScalaVersion = '2.12' // For integration testing only
     mockitoVersion = '3.2.4'
     slf4jVersion = '1.6.1'
 }
@@ -153,6 +154,26 @@ project(':kcbq-connector') {
         }
     }
 
+    test {
+        useJUnit {
+            // Exclude embedded integration tests from normal testing since they require BigQuery
+            // credentials and can take a while
+            excludeCategories 'org.apache.kafka.test.IntegrationTest'
+        }
+    }
+
+    task embeddedIntegrationTest(type: Test) {
+        useJUnit {
+            includeCategories 'org.apache.kafka.test.IntegrationTest'
+        }
+
+        // Enable logging for integration tests
+        testLogging {
+            outputs.upToDateWhen {false}
+            showStandardStreams = true
+        }
+    }
+
     task integrationTestPrep() {
         dependsOn 'integrationTestTablePrep'
         dependsOn 'integrationTestBucketPrep'
@@ -226,7 +247,12 @@ project(':kcbq-connector') {
                 "junit:junit:$junitVersion",
                 "org.mockito:mockito-core:$mockitoVersion",
                 "org.mockito:mockito-inline:$mockitoVersion",
-                "org.apache.kafka:connect-api:$kafkaVersion"
+                "org.apache.kafka:kafka_$kafkaScalaVersion:$kafkaVersion",
+                "org.apache.kafka:kafka_$kafkaScalaVersion:$kafkaVersion:test",
+                "org.apache.kafka:kafka-clients:$kafkaVersion:test",
+                "org.apache.kafka:connect-api:$kafkaVersion",
+                "org.apache.kafka:connect-runtime:$kafkaVersion",
+                "org.apache.kafka:connect-runtime:$kafkaVersion:test",
         )
     }
 

--- a/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
+++ b/kcbq-api/src/main/java/com/wepay/kafka/connect/bigquery/api/SchemaRetriever.java
@@ -16,7 +16,7 @@ public interface SchemaRetriever {
    * {@link org.apache.kafka.connect.sink.SinkConnector#start(Map)} method.
    * @param properties The configuration settings of the connector.
    */
-  public void configure(Map<String, String> properties);
+  void configure(Map<String, String> properties);
 
   /**
    * Retrieve the most current schema for the given topic.
@@ -25,13 +25,30 @@ public interface SchemaRetriever {
    * @param schemaType The type of kafka schema, either "value" or "key".
    * @return The Schema for the given table.
    */
-  public Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType);
+  Schema retrieveSchema(TableId table, String topic, KafkaSchemaRecordType schemaType);
 
   /**
-   * Set the last seen schema for a given topic
+   * Set the last seen schema for a given topic.
    * @param table The table that will be created.
    * @param topic The topic to retrieve a schema for.
    * @param schema The last seen Kafka Connect Schema
    */
-  public void setLastSeenSchema(TableId table, String topic, Schema schema);
+  void setLastSeenSchema(TableId table, String topic, Schema schema);
+
+  /**
+   * Set the last seen schema for a given topic and record type.
+   * In order to preserve backwards compatibility, will invoke
+   * {@link #setLastSeenSchema(TableId, String, Schema)} by default if the schema is for a record
+   * value, and otherwise be a no-op.
+   * @param table The table that will be created.
+   * @param topic The topic to retrieve a schema for.
+   * @param schema The last seen Kafka Connect Schema.
+   * @param schemaType The type of the schema (key or value).
+   * @since 1.7.0
+   */
+  default void setLastSeenSchema(TableId table, String topic, Schema schema, KafkaSchemaRecordType schemaType) {
+    if (KafkaSchemaRecordType.VALUE.equals(schemaType)) {
+      setLastSeenSchema(table, topic, schema);
+    }
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -25,6 +25,7 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
@@ -143,12 +144,12 @@ public class BigQuerySinkConnector extends SinkConnector {
     logger.trace("connector.taskConfigs()");
     List<Map<String, String>> taskConfigs = new ArrayList<>();
     for (int i = 0; i < maxTasks; i++) {
-      // Copy configProperties so that tasks can't interfere with each others' configurations
       HashMap<String, String> taskConfig = new HashMap<>(configProperties);
       if (i == 0 && !config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).isEmpty()) {
         // if batch loading is enabled, configure first task to do the GCS -> BQ loading
         taskConfig.put(GCS_BQ_TASK_CONFIG_KEY, "true");
       }
+      taskConfig.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, Integer.toString(i));
       taskConfigs.add(taskConfig);
     }
     return taskConfigs;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -39,12 +39,14 @@ import com.wepay.kafka.connect.bigquery.utils.TopicToTableResolver;
 import com.wepay.kafka.connect.bigquery.utils.Version;
 import com.wepay.kafka.connect.bigquery.write.batch.GCSBatchTableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriter;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import com.wepay.kafka.connect.bigquery.write.row.SimpleBigQueryWriter;
+import com.wepay.kafka.connect.bigquery.write.row.UpsertDeleteBigQueryWriter;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
@@ -62,11 +64,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.intTable;
 
 /**
  * A {@link SinkTask} used to translate Kafka Connect {@link SinkRecord SinkRecords} into BigQuery
@@ -75,6 +81,8 @@ import java.util.Optional;
 public class BigQuerySinkTask extends SinkTask {
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkTask.class);
 
+  private AtomicReference<BigQuery> bigQuery;
+  private AtomicReference<SchemaManager> schemaManager;
   private SchemaRetriever schemaRetriever;
   private BigQueryWriter bigQueryWriter;
   private GCSToBQWriter gcsToBQWriter;
@@ -83,6 +91,10 @@ public class BigQuerySinkTask extends SinkTask {
   private Map<String, TableId> topicsToBaseTableIds;
   private boolean useMessageTimeDatePartitioning;
   private boolean usePartitionDecorator;
+  private boolean upsertDelete;
+  private MergeBatches mergeBatches;
+  private MergeQueries mergeQueries;
+  private long mergeRecordsThreshold;
 
   private TopicPartitionManager topicPartitionManager;
 
@@ -94,7 +106,7 @@ public class BigQuerySinkTask extends SinkTask {
   private final SchemaManager testSchemaManager;
 
   private final UUID uuid = UUID.randomUUID();
-  private ScheduledExecutorService gcsLoadExecutor;
+  private ScheduledExecutorService loadExecutor;
 
   /**
    * Create a new BigquerySinkTask.
@@ -124,6 +136,11 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    if (upsertDelete) {
+      throw new ConnectException("This connector cannot perform upsert/delete on older versions of "
+          + "the Connect framework; please upgrade to version 0.10.2.0 or later");
+    }
+
     try {
       executor.awaitCurrentTasks();
     } catch (InterruptedException err) {
@@ -131,6 +148,18 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     topicPartitionManager.resumeAll();
+  }
+
+  @Override
+  public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    if (upsertDelete) {
+      Map<TopicPartition, OffsetAndMetadata> result = mergeBatches.latestOffsets();
+      checkQueueSize();
+      return result;
+    }
+
+    flush(offsets);
+    return offsets;
   }
 
   private PartitionedTableId getRecordTable(SinkRecord record) {
@@ -142,10 +171,19 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     TableId baseTableId = topicsToBaseTableIds.get(record.topic());
+    if (upsertDelete) {
+
+      // Notify the schema retriever of the schema for the destination table (it will be notified
+      // for the intermediate table in the put() loop)
+      recordLastSeenSchemas(baseTableId, record);
+
+      TableId intermediateTableId = mergeBatches.intermediateTableFor(baseTableId);
+      // If upsert/delete is enabled, we want to stream into a non-partitioned intermediate table
+      return new PartitionedTableId.Builder(intermediateTableId).build();
+    }
 
     PartitionedTableId.Builder builder = new PartitionedTableId.Builder(baseTableId);
     if (usePartitionDecorator) {
-
       if (useMessageTimeDatePartitioning) {
         if (record.timestampType() == TimestampType.NO_TIMESTAMP_TYPE) {
           throw new ConnectException(
@@ -160,20 +198,75 @@ public class BigQuerySinkTask extends SinkTask {
     return builder.build();
   }
 
-  private RowToInsert getRecordRow(SinkRecord record) {
-    Map<String, Object> convertedRecord = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
-    Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
-    if (kafkaKeyFieldName.isPresent()) {
-      convertedRecord.put(kafkaKeyFieldName.get(), recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY));
+  private RowToInsert getRecordRow(SinkRecord record, TableId table) {
+    Map<String, Object> convertedRecord = upsertDelete
+        ? getUpsertDeleteRow(record, table)
+        : getRegularRow(record);
+
+    Map<String, Object> result = config.getBoolean(config.SANITIZE_FIELD_NAME_CONFIG)
+        ? FieldNameSanitizer.replaceInvalidKeys(convertedRecord)
+        : convertedRecord;
+
+    return RowToInsert.of(getRowId(record), result);
+  }
+
+  private Map<String, Object> getUpsertDeleteRow(SinkRecord record, TableId table) {
+    // Unconditionally allow tombstone records if delete is enabled.
+    Map<String, Object> convertedValue = config.getBoolean(config.DELETE_ENABLED_CONFIG) && record.value() == null
+        ? null
+        : recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
+
+    if (convertedValue != null) {
+      config.getKafkaDataFieldName().ifPresent(
+          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record))
+      );
     }
-    Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
-    if (kafkaDataFieldName.isPresent()) {
-      convertedRecord.put(kafkaDataFieldName.get(), KafkaDataBuilder.buildKafkaDataRecord(record));
+
+    Map<String, Object> result = new HashMap<>();
+    long totalBatchSize = mergeBatches.addToBatch(record, table, result);
+    if (mergeRecordsThreshold != -1 && totalBatchSize >= mergeRecordsThreshold) {
+      logger.debug("Triggering merge flush for table {} since the size of its current batch has "
+              + "exceeded the configured threshold of {}}",
+          table, mergeRecordsThreshold);
+      mergeQueries.mergeFlush(table);
     }
-    if (config.getBoolean(config.SANITIZE_FIELD_NAME_CONFIG)) {
-      convertedRecord = FieldNameSanitizer.replaceInvalidKeys(convertedRecord);
+
+    Map<String, Object> convertedKey = recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY);
+    if (convertedKey == null) {
+      throw new ConnectException("Record keys must be non-null when upsert/delete is enabled");
     }
-    return RowToInsert.of(getRowId(record), convertedRecord);
+
+    result.put(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, convertedKey);
+    result.put(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, convertedValue);
+    result.put(MergeQueries.INTERMEDIATE_TABLE_ITERATION_FIELD_NAME, totalBatchSize);
+    if (usePartitionDecorator && useMessageTimeDatePartitioning) {
+      if (record.timestampType() == TimestampType.NO_TIMESTAMP_TYPE) {
+        throw new ConnectException(
+            "Message has no timestamp type, cannot use message timestamp to partition.");
+      }
+      result.put(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, record.timestamp());
+    } else {
+      // Provide a value for this column even if it's not used for partitioning in the destination
+      // table, so that it can be used to deduplicate rows during merge flushes
+      result.put(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, System.currentTimeMillis() / 1000);
+    }
+
+    return result;
+  }
+
+  private Map<String, Object> getRegularRow(SinkRecord record) {
+    Map<String, Object> result = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
+
+    config.getKafkaDataFieldName().ifPresent(
+        fieldName -> result.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record))
+    );
+
+    config.getKafkaKeyFieldName().ifPresent(fieldName -> {
+      Map<String, Object> keyData = recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY);
+      result.put(fieldName, keyData);
+    });
+
+    return result;
   }
 
   private String getRowId(SinkRecord record) {
@@ -183,21 +276,31 @@ public class BigQuerySinkTask extends SinkTask {
         record.kafkaOffset());
   }
 
+  private void recordLastSeenSchemas(TableId table, SinkRecord record) {
+    if (schemaRetriever != null) {
+      schemaRetriever.setLastSeenSchema(
+          table, record.topic(), record.keySchema(), KafkaSchemaRecordType.KEY);
+      schemaRetriever.setLastSeenSchema(
+          table, record.topic(), record.valueSchema(), KafkaSchemaRecordType.VALUE);
+    }
+  }
+
   @Override
   public void put(Collection<SinkRecord> records) {
-    logger.info("Putting {} records in the sink.", records.size());
+    if (upsertDelete) {
+      // Periodically poll for errors here instead of doing a stop-the-world check in flush()
+      executor.maybeThrowEncounteredErrors();
+    }
+
+    logger.debug("Putting {} records in the sink.", records.size());
 
     // create tableWriters
     Map<PartitionedTableId, TableWriterBuilder> tableWriterBuilders = new HashMap<>();
 
     for (SinkRecord record : records) {
-      if (record.value() != null) {
+      if (record.value() != null || config.getBoolean(config.DELETE_ENABLED_CONFIG)) {
         PartitionedTableId table = getRecordTable(record);
-        if (schemaRetriever != null) {
-          schemaRetriever.setLastSeenSchema(table.getBaseTableId(),
-                                            record.topic(),
-                                            record.valueSchema());
-        }
+        recordLastSeenSchemas(table.getBaseTableId(), record);
 
         if (!tableWriterBuilders.containsKey(table)) {
           TableWriterBuilder tableWriterBuilder;
@@ -213,15 +316,19 @@ public class BigQuerySinkTask extends SinkTask {
                 table.getBaseTableId(),
                 config.getString(config.GCS_BUCKET_NAME_CONFIG),
                 gcsBlobName,
-                topic,
-                recordConverter);
+                topic);
           } else {
-            tableWriterBuilder =
-                new TableWriter.Builder(bigQueryWriter, table, record.topic(), recordConverter);
+            TableWriter.Builder simpleTableWriterBuilder =
+                new TableWriter.Builder(bigQueryWriter, table, record.topic());
+            if (upsertDelete) {
+              simpleTableWriterBuilder.onFinish(rows ->
+                  mergeBatches.onRowWrites(table.getBaseTableId(), rows));
+            }
+            tableWriterBuilder = simpleTableWriterBuilder;
           }
           tableWriterBuilders.put(table, tableWriterBuilder);
         }
-        tableWriterBuilders.get(table).addRow(getRecordRow(record));
+        tableWriterBuilders.get(table).addRow(getRecordRow(record, table.getBaseTableId()));
       }
     }
 
@@ -231,6 +338,18 @@ public class BigQuerySinkTask extends SinkTask {
     }
 
     // check if we should pause topics
+    checkQueueSize();
+  }
+
+  // Important: this method is only safe to call during put(), flush(), or preCommit(); otherwise,
+  // a ConcurrentModificationException may be triggered if the Connect framework is in the middle of
+  // a method invocation on the consumer for this task. This becomes especially likely if all topics
+  // have been paused as the framework will most likely be in the middle of a poll for that consumer
+  // which, because all of its topics have been paused, will not return until it's time for the next
+  // offset commit. Invoking context.requestCommit() won't wake up the consumer in that case, so we
+  // really have no choice but to wait for the framework to call a method on this task that implies
+  // that it's safe to pause or resume partitions on the consumer.
+  private void checkQueueSize() {
     long queueSoftLimit = config.getLong(BigQuerySinkTaskConfig.QUEUE_SIZE_CONFIG);
     if (queueSoftLimit != -1) {
       int currentQueueSize = executor.getQueue().size();
@@ -251,16 +370,24 @@ public class BigQuerySinkTask extends SinkTask {
     if (testBigQuery != null) {
       return testBigQuery;
     }
+    return bigQuery.updateAndGet(bq -> bq != null ? bq : newBigQuery());
+  }
+
+  private BigQuery newBigQuery() {
     String projectName = config.getString(config.PROJECT_CONFIG);
     String keyFile = config.getKeyFile();
     String keySource = config.getString(config.KEY_SOURCE_CONFIG);
     return new BigQueryHelper().setKeySource(keySource).connect(projectName, keyFile);
   }
 
-  private SchemaManager getSchemaManager(BigQuery bigQuery) {
+  private SchemaManager getSchemaManager() {
     if (testSchemaManager != null) {
       return testSchemaManager;
     }
+    return schemaManager.updateAndGet(sm -> sm != null ? sm : newSchemaManager());
+  }
+
+  private SchemaManager newSchemaManager() {
     schemaRetriever = config.getSchemaRetriever();
     SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter =
         config.getSchemaConverter();
@@ -268,7 +395,7 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
     Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldName();
-    return new SchemaManager(schemaRetriever, schemaConverter, bigQuery, kafkaKeyFieldName,
+    return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(), kafkaKeyFieldName,
                              kafkaDataFieldName, timestampPartitionFieldName, clusteringFieldName);
   }
 
@@ -278,9 +405,17 @@ public class BigQuerySinkTask extends SinkTask {
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
     BigQuery bigQuery = getBigQuery();
-    if (autoUpdateSchemas || autoCreateTables) {
+    if (upsertDelete) {
+      return new UpsertDeleteBigQueryWriter(bigQuery,
+                                            getSchemaManager(),
+                                            retry,
+                                            retryWait,
+                                            autoUpdateSchemas,
+                                            autoCreateTables,
+                                            mergeBatches.intermediateToDestinationTables());
+    } else if (autoUpdateSchemas || autoCreateTables) {
       return new AdaptiveBigQueryWriter(bigQuery,
-                                        getSchemaManager(bigQuery),
+                                        getSchemaManager(),
                                         retry,
                                         retryWait,
                                         autoUpdateSchemas,
@@ -308,7 +443,7 @@ public class BigQuerySinkTask extends SinkTask {
     boolean autoCreateTables = config.getBoolean(config.TABLE_CREATE_CONFIG);
     // schemaManager shall only be needed for creating table hence do not fetch instance if not
     // needed.
-    SchemaManager schemaManager = autoCreateTables ? getSchemaManager(bigQuery) : null;
+    SchemaManager schemaManager = autoCreateTables ? getSchemaManager() : null;
     return new GCSToBQWriter(getGcs(),
                          bigQuery,
                          schemaManager,
@@ -330,6 +465,22 @@ public class BigQuerySinkTask extends SinkTask {
           err
       );
     }
+    upsertDelete = config.getBoolean(config.UPSERT_ENABLED_CONFIG)
+        || config.getBoolean(config.DELETE_ENABLED_CONFIG);
+
+    bigQuery = new AtomicReference<>();
+    schemaManager = new AtomicReference<>();
+
+    if (upsertDelete) {
+      String intermediateTableSuffix = String.format("_%s_%d_%s_%d",
+          config.getString(config.INTERMEDIATE_TABLE_SUFFIX_CONFIG),
+          config.getInt(config.TASK_ID_CONFIG),
+          uuid,
+          Instant.now().toEpochMilli()
+      );
+      mergeBatches = new MergeBatches(intermediateTableSuffix);
+      mergeRecordsThreshold = config.getLong(config.MERGE_RECORDS_THRESHOLD_CONFIG);
+    }
 
     bigQueryWriter = getBigQueryWriter();
     gcsToBQWriter = getGcsWriter();
@@ -343,12 +494,16 @@ public class BigQuerySinkTask extends SinkTask {
             config.getBoolean(config.BIGQUERY_PARTITION_DECORATOR_CONFIG);
     if (hasGCSBQTask) {
       startGCSToBQLoadTask();
+    } else if (upsertDelete) {
+      mergeQueries =
+          new MergeQueries(config, mergeBatches, executor, getBigQuery(), getSchemaManager(), context);
+      maybeStartMergeFlushTask();
     }
   }
 
   private void startGCSToBQLoadTask() {
     logger.info("Attempting to start GCS Load Executor.");
-    gcsLoadExecutor = Executors.newScheduledThreadPool(1);
+    loadExecutor = Executors.newScheduledThreadPool(1);
     String bucketName = config.getString(config.GCS_BUCKET_NAME_CONFIG);
     Storage gcs = getGcs();
     // get the bucket, or create it if it does not exist.
@@ -362,29 +517,53 @@ public class BigQuerySinkTask extends SinkTask {
     GCSToBQLoadRunnable loadRunnable = new GCSToBQLoadRunnable(getBigQuery(), bucket);
 
     int intervalSec = config.getInt(BigQuerySinkConfig.BATCH_LOAD_INTERVAL_SEC_CONFIG);
-    gcsLoadExecutor.scheduleAtFixedRate(loadRunnable, intervalSec, intervalSec, TimeUnit.SECONDS);
+    loadExecutor.scheduleAtFixedRate(loadRunnable, intervalSec, intervalSec, TimeUnit.SECONDS);
+  }
+
+  private void maybeStartMergeFlushTask() {
+    long intervalMs = config.getLong(config.MERGE_INTERVAL_MS_CONFIG);
+    if (intervalMs == -1) {
+      logger.info("{} is set to -1; periodic merge flushes are disabled", config.MERGE_INTERVAL_MS_CONFIG);
+      return;
+    }
+    logger.info("Attempting to start upsert/delete load executor");
+    loadExecutor = Executors.newScheduledThreadPool(1);
+    loadExecutor.scheduleAtFixedRate(
+        mergeQueries::mergeFlushAll, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
   }
 
   @Override
   public void stop() {
+    maybeStopExecutor(loadExecutor, "load executor");
+    maybeStopExecutor(executor, "table write executor");
+    if (upsertDelete) {
+      mergeBatches.intermediateTables().forEach(table -> {
+        logger.debug("Deleting {}", intTable(table));
+        getBigQuery().delete(table);
+      });
+    }
+
+    logger.trace("task.stop()");
+  }
+
+  private void maybeStopExecutor(ExecutorService executor, String executorName) {
+    if (executor == null) {
+      return;
+    }
+
     try {
-      executor.shutdown();
-      executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
-      if (gcsLoadExecutor != null) {
-        try {
-          logger.info("Attempting to shut down GCS Load Executor.");
-          gcsLoadExecutor.shutdown();
-          gcsLoadExecutor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
-        } catch (InterruptedException ex) {
-          logger.warn("Could not shut down GCS Load Executor within {}s.",
-                      EXECUTOR_SHUTDOWN_TIMEOUT_SEC);
-        }
+      if (upsertDelete) {
+        logger.trace("Forcibly shutting down {}", executorName);
+        executor.shutdownNow();
+      } else {
+        logger.trace("Requesting shutdown for {}", executorName);
+        executor.shutdown();
       }
-    } catch (InterruptedException ex) {
-      logger.warn("{} active threads are still executing tasks {}s after shutdown is signaled.",
-          executor.getActiveCount(), EXECUTOR_SHUTDOWN_TIMEOUT_SEC);
-    } finally {
-      logger.trace("task.stop()");
+      logger.trace("Awaiting termination of {}", executorName);
+      executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SEC, TimeUnit.SECONDS);
+      logger.trace("Shut down {} successfully", executorName);
+    } catch (Exception e) {
+      logger.warn("Failed to shut down {}", executorName, e);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -1,0 +1,461 @@
+package com.wepay.kafka.connect.bigquery;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import com.google.common.annotations.VisibleForTesting;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
+import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.destTable;
+import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.intTable;
+
+public class MergeQueries {
+  public static final String INTERMEDIATE_TABLE_KEY_FIELD_NAME = "key";
+  public static final String INTERMEDIATE_TABLE_VALUE_FIELD_NAME = "value";
+  public static final String INTERMEDIATE_TABLE_ITERATION_FIELD_NAME = "i";
+  public static final String INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME = "partitionTime";
+  public static final String INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD = "batchNumber";
+
+  private static final Logger logger = LoggerFactory.getLogger(MergeQueries.class);
+
+  private final String keyFieldName;
+  private final boolean insertPartitionTime;
+  private final boolean upsertEnabled;
+  private final boolean deleteEnabled;
+  private final MergeBatches mergeBatches;
+  private final KCBQThreadPoolExecutor executor;
+  private final BigQuery bigQuery;
+  private final SchemaManager schemaManager;
+  private final SinkTaskContext context;
+
+  public MergeQueries(BigQuerySinkTaskConfig config,
+                      MergeBatches mergeBatches,
+                      KCBQThreadPoolExecutor executor,
+                      BigQuery bigQuery,
+                      SchemaManager schemaManager,
+                      SinkTaskContext context) {
+    this(
+      config.getKafkaKeyFieldName().orElseThrow(() ->
+          new ConnectException("Kafka key field must be configured when upsert/delete is enabled")
+      ),
+      config.getBoolean(config.BIGQUERY_PARTITION_DECORATOR_CONFIG),
+      config.getBoolean(config.UPSERT_ENABLED_CONFIG),
+      config.getBoolean(config.DELETE_ENABLED_CONFIG),
+      mergeBatches,
+      executor,
+      bigQuery,
+      schemaManager,
+      context
+    );
+  }
+
+  @VisibleForTesting
+  MergeQueries(String keyFieldName,
+               boolean insertPartitionTime,
+               boolean upsertEnabled,
+               boolean deleteEnabled,
+               MergeBatches mergeBatches,
+               KCBQThreadPoolExecutor executor,
+               BigQuery bigQuery,
+               SchemaManager schemaManager,
+               SinkTaskContext context) {
+    this.keyFieldName = keyFieldName;
+    this.insertPartitionTime = insertPartitionTime;
+    this.upsertEnabled = upsertEnabled;
+    this.deleteEnabled = deleteEnabled;
+    this.mergeBatches = mergeBatches;
+    this.executor = executor;
+    this.bigQuery = bigQuery;
+    this.schemaManager = schemaManager;
+    this.context = context;
+  }
+
+  public void mergeFlushAll() {
+    logger.debug("Triggering merge flush for all tables");
+    mergeBatches.intermediateTables().forEach(this::mergeFlush);
+  }
+
+  public void mergeFlush(TableId intermediateTable) {
+    final TableId destinationTable = mergeBatches.destinationTableFor(intermediateTable);
+    final int batchNumber = mergeBatches.incrementBatch(intermediateTable);
+    logger.trace("Triggering merge flush from {} to {} for batch {}",
+        intTable(intermediateTable), destTable(destinationTable), batchNumber);
+
+    executor.execute(() -> {
+      try {
+        mergeFlush(intermediateTable, destinationTable, batchNumber);
+      } catch (InterruptedException e) {
+        throw new ExpectedInterruptException(String.format(
+            "Interrupted while performing merge flush of batch %d from %s to %s",
+            batchNumber, intTable(intermediateTable), destTable(destinationTable)));
+      }
+    });
+  }
+
+  private void mergeFlush(
+      TableId intermediateTable, TableId destinationTable, int batchNumber
+  ) throws InterruptedException{
+    // If there are rows to flush in this batch, flush them
+    if (mergeBatches.prepareToFlush(intermediateTable, batchNumber)) {
+      logger.debug("Running merge query on batch {} from {}",
+          batchNumber, intTable(intermediateTable));
+      String mergeFlushQuery = mergeFlushQuery(intermediateTable, destinationTable, batchNumber);
+      logger.trace(mergeFlushQuery);
+      bigQuery.query(QueryJobConfiguration.of(mergeFlushQuery));
+      logger.trace("Merge from {} to {} completed",
+          intTable(intermediateTable), destTable(destinationTable));
+
+      logger.debug("Recording flush success for batch {} from {}",
+          batchNumber, intTable(intermediateTable));
+      mergeBatches.recordSuccessfulFlush(intermediateTable, batchNumber);
+
+      // Commit those offsets ASAP
+      context.requestCommit();
+
+      logger.info("Completed merge flush of batch {} from {} to {}",
+          batchNumber, intTable(intermediateTable), destTable(destinationTable));
+    }
+
+    // After, regardless of whether we flushed or not, clean up old batches from the intermediate
+    // table. Some rows may be several batches old but still in the table if they were in the
+    // streaming buffer during the last purge.
+    logger.trace("Clearing batches from {} on back from {}", batchNumber, intTable(intermediateTable));
+    String batchClearQuery = batchClearQuery(intermediateTable, batchNumber);
+    logger.trace(batchClearQuery);
+    bigQuery.query(QueryJobConfiguration.of(batchClearQuery));
+  }
+
+  @VisibleForTesting
+  String mergeFlushQuery(TableId intermediateTable, TableId destinationTable, int batchNumber) {
+    Schema intermediateSchema = schemaManager.cachedSchema(intermediateTable);
+
+    if (upsertEnabled && deleteEnabled) {
+      return upsertDeleteMergeFlushQuery(intermediateTable, destinationTable, batchNumber, intermediateSchema);
+    } else if (upsertEnabled) {
+      return upsertMergeFlushQuery(intermediateTable, destinationTable, batchNumber, intermediateSchema);
+    } else if (deleteEnabled) {
+      return deleteMergeFlushQuery(intermediateTable, destinationTable, batchNumber, intermediateSchema);
+    } else {
+      throw new IllegalStateException("At least one of upsert or delete must be enabled for merge flushing to occur.");
+    }
+  }
+
+  /*
+      MERGE `<dataset>`.`<destinationTable>`
+      USING (
+        SELECT * FROM (
+          SELECT ARRAY_AGG(
+            x ORDER BY i DESC LIMIT 1
+          )[OFFSET(0)] src
+          FROM `<dataset>`.`<intermediateTable>` x
+          WHERE batchNumber=<batchNumber>
+          GROUP BY key.<field>[, key.<field>...]
+        )
+      )
+      ON `<destinationTable>`.<keyField>=src.key
+      WHEN MATCHED AND src.value IS NOT NULL
+        THEN UPDATE SET <valueField>=src.value.<field>[, <valueField>=src.value.<field>...]
+      WHEN MATCHED AND src.value IS NULL
+        THEN DELETE
+      WHEN NOT MATCHED AND src.value IS NOT NULL
+        THEN INSERT (<keyField>, [_PARTITIONTIME, ]<valueField>[, <valueField>])
+        VALUES (
+          src.key,
+          [CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP),]
+          src.value.<field>[, src.value.<field>...]
+        );
+   */
+  private String upsertDeleteMergeFlushQuery(
+      TableId intermediateTable, TableId destinationTable, int batchNumber, Schema intermediateSchema
+  ) {
+    List<String> keyFields = listFields(
+        intermediateSchema.getFields().get(INTERMEDIATE_TABLE_KEY_FIELD_NAME).getSubFields(),
+        INTERMEDIATE_TABLE_KEY_FIELD_NAME + "."
+    );
+
+    List<String> valueColumns = valueColumns(intermediateSchema);
+
+    final String key = INTERMEDIATE_TABLE_KEY_FIELD_NAME;
+    final String i = INTERMEDIATE_TABLE_ITERATION_FIELD_NAME;
+    final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
+    final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
+
+    return "MERGE " + table(destinationTable) + " "
+        + "USING ("
+          + "SELECT * FROM ("
+            + "SELECT ARRAY_AGG("
+              + "x ORDER BY " + i + " DESC LIMIT 1"
+            + ")[OFFSET(0)] src "
+            + "FROM " + table(intermediateTable) + " x "
+            + "WHERE " + batch + "=" + batchNumber + " "
+            + "GROUP BY " + String.join(", ", keyFields)
+          + ")"
+        + ") "
+        + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
+        + "WHEN MATCHED AND src." + value + " IS NOT NULL "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> col + "=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+        + "WHEN MATCHED AND src." + value + " IS NULL "
+          + "THEN DELETE "
+        + "WHEN NOT MATCHED AND src." + value + " IS NOT NULL "
+          + "THEN INSERT ("
+            + keyFieldName + ", "
+            + partitionTimePseudoColumn()
+            + String.join(", ", valueColumns) + ") "
+          + "VALUES ("
+            + "src." + key + ", "
+            + partitionTimeValue()
+            + valueColumns.stream().map(col -> "src." + value + "." + col).collect(Collectors.joining(", "))
+        + ");";
+  }
+
+  /*
+      MERGE `<dataset>`.`<destinationTable>`
+      USING (
+        SELECT * FROM (
+          SELECT ARRAY_AGG(
+            x ORDER BY i DESC LIMIT 1
+          )[OFFSET(0)] src
+          FROM `<dataset>`.`<intermediateTable>` x
+          WHERE batchNumber=<batchNumber>
+          GROUP BY key.<field>[, key.<field>...]
+        )
+      )
+      ON `<destinationTable>`.<keyField>=src.key
+      WHEN MATCHED
+        THEN UPDATE SET <valueField>=src.value.<field>[, <valueField=`src.value.<field>...]
+      WHEN NOT MATCHED
+        THEN INSERT (<keyField, [_PARTITIONTIME, ]<valueField[, <valueField])
+        VALUES (
+          src.key,
+          [CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP),]
+          src.value.<field>[, src.value.<field>...]
+        );
+   */
+  private String upsertMergeFlushQuery(
+      TableId intermediateTable, TableId destinationTable, int batchNumber, Schema intermediateSchema
+  ) {
+    List<String> keyFields = listFields(
+        intermediateSchema.getFields().get(INTERMEDIATE_TABLE_KEY_FIELD_NAME).getSubFields(),
+        INTERMEDIATE_TABLE_KEY_FIELD_NAME + "."
+    );
+
+    List<String> valueColumns = valueColumns(intermediateSchema);
+
+    final String key = INTERMEDIATE_TABLE_KEY_FIELD_NAME;
+    final String i = INTERMEDIATE_TABLE_ITERATION_FIELD_NAME;
+    final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
+    final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
+
+    return "MERGE " + table(destinationTable) + " "
+        + "USING ("
+          + "SELECT * FROM ("
+            + "SELECT ARRAY_AGG("
+              + "x ORDER BY " + i + " DESC LIMIT 1"
+            + ")[OFFSET(0)] src "
+            + "FROM " + table(intermediateTable) + " x "
+            + "WHERE " + batch + "=" + batchNumber + " "
+            + "GROUP BY " + String.join(", ", keyFields)
+          + ")"
+        + ") "
+        + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
+        + "WHEN MATCHED "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> col + "=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+        + "WHEN NOT MATCHED "
+          + "THEN INSERT ("
+            + keyFieldName + ", "
+            + partitionTimePseudoColumn()
+            + String.join(", ", valueColumns) + ") "
+          + "VALUES ("
+            + "src." + key + ", "
+            + partitionTimeValue()
+            + valueColumns.stream().map(col -> "src." + value + "." + col).collect(Collectors.joining(", "))
+          + ");";
+  }
+
+  /*
+        Delete-only is the trickiest mode. Naively, we could just run a MERGE using the intermediate
+      table as a source and sort in ascending order of iteration. However, this would miss an edge
+      case where, for a given key, a non-tombstone record is sent and then followed by a tombstone,
+      and would result in all rows with that key being deleted from the table, followed by an
+      insertion of a row for the initial non-tombstone record. This is incorrect; any and all
+      records with a given key that precede a tombstone should either never make it into BigQuery or
+      be deleted once the tombstone record is merge flushed.
+        So instead, we have to try to filter out rows from the source (i.e., intermediate) table
+      that precede tombstone records for their keys. We do this by:
+        - Finding the latest tombstone row for each key in the current batch and extracting the
+          iteration number for each, referring to this as the "deletes" table
+        - Joining that with the current batch from the intermediate table on the row key, keeping
+          both tables' iteration numbers (a RIGHT JOIN is used so that rows whose keys don't have
+          any tombstones present are included with a NULL iteration number for the "deletes" table)
+        - Filtering out all rows where the "delete" table's iteration number is non-null, and their
+          iteration number is less than the "delete" table's iteration number
+        This gives us only rows from the most recent tombstone onward, and works in both cases where
+      the most recent row for a key is or is not a tombstone.
+
+      MERGE `<dataset>`.`<destinationTable>`
+      USING (
+        SELECT batch.key AS key, [partitionTime, ]value
+         FROM (
+          SELECT src.i, src.key FROM (
+            SELECT ARRAY_AGG(
+              x ORDER BY i DESC LIMIT 1
+            )[OFFSET(0)] src
+            FROM (
+              SELECT * FROM `<dataset>`.`<intermediateTable>`
+              WHERE batchNumber=<batchNumber>
+            ) x
+            WHERE x.value IS NULL
+            GROUP BY key.<field>[, key.<field>...])) AS deletes
+          RIGHT JOIN (
+            SELECT * FROM `<dataset>`.`<intermediateTable`
+            WHERE batchNumber=<batchNumber>
+          ) AS batch
+          USING (key)
+        WHERE deletes.i IS NULL OR batch.i >= deletes.i
+        ORDER BY batch.i ASC) AS src
+      ON `<destinationTable>`.<keyField>=src.key AND src.value IS NULL
+      WHEN MATCHED
+        THEN DELETE
+      WHEN NOT MATCHED AND src.value IS NOT NULL
+      THEN INSERT (<keyField>, [_PARTITIONTIME, ]<valueField>[, <valueField>])
+      VALUES (
+        src.key,
+        [CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP),]
+        src.value.<field>[, src.value.<field>...]
+      );
+   */
+  private String deleteMergeFlushQuery(
+      TableId intermediateTable, TableId destinationTable, int batchNumber, Schema intermediateSchema
+  ) {
+    List<String> keyFields = listFields(
+        intermediateSchema.getFields().get(INTERMEDIATE_TABLE_KEY_FIELD_NAME).getSubFields(),
+        INTERMEDIATE_TABLE_KEY_FIELD_NAME + "."
+    );
+
+    List<String> valueColumns = valueColumns(intermediateSchema);
+
+    final String key = INTERMEDIATE_TABLE_KEY_FIELD_NAME;
+    final String i = INTERMEDIATE_TABLE_ITERATION_FIELD_NAME;
+    final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
+    final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
+
+    return "MERGE " + table(destinationTable) + " "
+        + "USING ("
+          + "SELECT batch." + key + " AS " + key + ", " + partitionTimeColumn() + value + " "
+            + "FROM ("
+              + "SELECT src." + i + ", src." + key + " FROM ("
+                + "SELECT ARRAY_AGG("
+                  + "x ORDER BY " + i + " DESC LIMIT 1"
+                + ")[OFFSET(0)] src "
+                + "FROM ("
+                  + "SELECT * FROM " + table(intermediateTable) + " "
+                  + "WHERE " + batch + "=" + batchNumber
+                + ") x "
+                + "WHERE x." + value + " IS NULL "
+                + "GROUP BY " + String.join(", ", keyFields) + ")) AS deletes "
+            + "RIGHT JOIN ("
+              + "SELECT * FROM " + table(intermediateTable) + " "
+              + "WHERE " + batch + "=" + batchNumber
+            + ") AS batch "
+            + "USING (" + key + ") "
+          + "WHERE deletes." + i + " IS NULL OR batch." + i + " >= deletes." + i + " "
+          + "ORDER BY batch." + i + " ASC) AS src "
+        + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " AND src." + value + " IS NULL "
+        + "WHEN MATCHED "
+          + "THEN DELETE "
+        + "WHEN NOT MATCHED AND src." + value + " IS NOT NULL "
+          + "THEN INSERT ("
+            + keyFieldName + ", "
+            + partitionTimePseudoColumn()
+            + String.join(", ", valueColumns) + ") "
+          + "VALUES ("
+            + "src." + key + ", "
+            + partitionTimeValue()
+            + valueColumns.stream().map(col -> "src." + value + "." + col).collect(Collectors.joining(", "))
+          + ");";
+  }
+
+  private String table(TableId tableId) {
+    return String.format("`%s`.`%s`", tableId.getDataset(), tableId.getTable());
+  }
+
+  private List<String> valueColumns(Schema intermediateTableSchema) {
+    return intermediateTableSchema.getFields().get(INTERMEDIATE_TABLE_VALUE_FIELD_NAME).getSubFields()
+        .stream()
+        .map(Field::getName)
+        .collect(Collectors.toList());
+  }
+
+  private String partitionTimePseudoColumn() {
+    return insertPartitionTime ? "_PARTITIONTIME, " : "";
+  }
+
+  private String partitionTimeValue() {
+    return insertPartitionTime
+        ? "CAST(CAST(DATE(src." + INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME + ") AS DATE) AS TIMESTAMP), "
+        : "";
+  }
+
+  private String partitionTimeColumn() {
+    return insertPartitionTime
+        ? INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME + ", "
+        : "";
+  }
+
+  // DELETE FROM `<dataset>`.`<intermediateTable>` WHERE batchNumber <= <batchNumber> AND _PARTITIONTIME IS NOT NULL;
+  @VisibleForTesting
+  static String batchClearQuery(TableId intermediateTable, int batchNumber) {
+    return new StringBuilder("DELETE FROM `").append(intermediateTable.getDataset()).append("`.`").append(intermediateTable.getTable()).append("` ")
+        .append("WHERE ")
+          .append(INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD).append(" <= ").append(batchNumber).append(" ")
+          // Use this clause to filter out rows that are still in the streaming buffer, which should
+          // not be subjected to UPDATE or DELETE operations or the query will FAIL
+          .append("AND _PARTITIONTIME IS NOT NULL")
+        .append(";")
+        .toString();
+  }
+
+  private static List<String> listFields(FieldList keyFields, String prefix) {
+    return keyFields.stream()
+        .flatMap(field -> {
+          String fieldName = prefix + field.getName();
+          FieldList subFields = field.getSubFields();
+          if (subFields == null) {
+            return Stream.of(fieldName);
+          }
+          return listFields(subFields, fieldName + ".").stream();
+        }).collect(Collectors.toList());
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -2,6 +2,7 @@ package com.wepay.kafka.connect.bigquery;
 
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.StandardTableDefinition;
@@ -12,9 +13,12 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +26,14 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Class for managing Schemas of BigQuery tables (creating and updating).
  */
 public class SchemaManager {
+
   private static final Logger logger = LoggerFactory.getLogger(SchemaManager.class);
 
   private final SchemaRetriever schemaRetriever;
@@ -36,6 +43,10 @@ public class SchemaManager {
   private final Optional<String> kafkaDataFieldName;
   private final Optional<String> timestampPartitionFieldName;
   private final Optional<List<String>> clusteringFieldName;
+  private final boolean intermediateTables;
+  private final ConcurrentMap<TableId, Object> tableCreateLocks;
+  private final ConcurrentMap<TableId, Object> tableUpdateLocks;
+  private final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache;
 
   /**
    * @param schemaRetriever Used to determine the Kafka Connect Schema that should be used for a
@@ -43,9 +54,14 @@ public class SchemaManager {
    * @param schemaConverter Used to convert Kafka Connect Schemas into BigQuery format.
    * @param bigQuery Used to communicate create/update requests to BigQuery.
    * @param kafkaKeyFieldName The name of kafka key field to be used in BigQuery.
-   *                         If set to null, Kafka Key Field will not be included in BigQuery.
+   *                          If set to null, Kafka Key Field will not be included in BigQuery.
    * @param kafkaDataFieldName The name of kafka data field to be used in BigQuery.
    *                           If set to null, Kafka Data Field will not be included in BigQuery.
+   * @param timestampPartitionFieldName The name of the field to use for column-based time
+   *                                    partitioning in BigQuery.
+   *                                    If set to null, ingestion time-based partitioning will be
+   *                                    used instead.
+   * @param clusteringFieldName
    */
   public SchemaManager(
       SchemaRetriever schemaRetriever,
@@ -55,6 +71,32 @@ public class SchemaManager {
       Optional<String> kafkaDataFieldName,
       Optional<String> timestampPartitionFieldName,
       Optional<List<String>> clusteringFieldName) {
+    this(
+        schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        kafkaKeyFieldName,
+        kafkaDataFieldName,
+        timestampPartitionFieldName,
+        clusteringFieldName,
+        false,
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>());
+  }
+
+  private SchemaManager(
+      SchemaRetriever schemaRetriever,
+      SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter,
+      BigQuery bigQuery,
+      Optional<String> kafkaKeyFieldName,
+      Optional<String> kafkaDataFieldName,
+      Optional<String> timestampPartitionFieldName,
+      Optional<List<String>> clusteringFieldName,
+      boolean intermediateTables,
+      ConcurrentMap<TableId, Object> tableCreateLocks,
+      ConcurrentMap<TableId, Object> tableUpdateLocks,
+      ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache) {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
@@ -62,17 +104,91 @@ public class SchemaManager {
     this.kafkaDataFieldName = kafkaDataFieldName;
     this.timestampPartitionFieldName = timestampPartitionFieldName;
     this.clusteringFieldName = clusteringFieldName;
+    this.intermediateTables = intermediateTables;
+    this.tableCreateLocks = tableCreateLocks;
+    this.tableUpdateLocks = tableUpdateLocks;
+    this.schemaCache = schemaCache;
+  }
+
+  public SchemaManager forIntermediateTables() {
+    return new SchemaManager(
+        schemaRetriever,
+        schemaConverter,
+        bigQuery,
+        kafkaKeyFieldName,
+        kafkaDataFieldName,
+        timestampPartitionFieldName,
+        clusteringFieldName,
+        true,
+        tableCreateLocks,
+        tableUpdateLocks,
+        schemaCache
+    );
+  }
+
+  /**
+   * Fetch the most recent schema for the given table, assuming it has been created and/or updated
+   * over the lifetime of this schema manager.
+   * @param table the table to fetch the schema for; may be null
+   * @return the latest schema for that table; may be null if the table does not exist or has not
+   * been created or updated by this schema manager
+   */
+  public com.google.cloud.bigquery.Schema cachedSchema(TableId table) {
+    return schemaCache.get(table);
+  }
+
+  /**
+   * Create a new table in BigQuery, if it doesn't already exist. Otherwise, update the existing
+   * table to use the most-current schema.
+   * @param table The BigQuery table to create,
+   * @param topic The Kafka topic used to determine the schema.
+   */
+  public void createOrUpdateTable(TableId table, String topic) {
+    synchronized (lock(tableCreateLocks, table)) {
+      if (bigQuery.getTable(table) == null) {
+        logger.debug("{} doesn't exist; creating instead of updating", table(table));
+        if (createTable(table, topic)) {
+          return;
+        }
+      }
+    }
+
+    // Table already existed; attempt to update instead
+    logger.debug("{} already exists; updating instead of creating", table(table));
+    updateSchema(table, topic);
   }
 
   /**
    * Create a new table in BigQuery.
    * @param table The BigQuery table to create.
    * @param topic The Kafka topic used to determine the schema.
+   * @return whether the table had to be created; if the table already existed, will return false
    */
-  public void createTable(TableId table, String topic) {
-    Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
-    Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
-    bigQuery.create(constructTableInfo(table, kafkaKeySchema, kafkaValueSchema));
+  public boolean createTable(TableId table, String topic) {
+    synchronized (lock(tableCreateLocks, table)) {
+      if (schemaCache.containsKey(table)) {
+        // Table already exists; noop
+        logger.debug("Skipping create of {} as it should already exist or appear very soon", table(table));
+        return false;
+      }
+
+      TableInfo tableInfo = constructTableInfo(table, topic);
+      logger.info("Attempting to create {} with schema {}",
+          table(table), tableInfo.getDefinition().getSchema());
+      try {
+        bigQuery.create(tableInfo);
+        logger.debug("Successfully created {}", table(table));
+        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        return true;
+      } catch (BigQueryException e) {
+        if (e.getCode() == 409) {
+          logger.debug("Failed to create {} as it already exists (possibly created by another task)", table(table));
+          schemaCache.put(table, readTableSchema(table));
+          return false;
+        }
+        throw e;
+      }
+    }
   }
 
   /**
@@ -81,58 +197,161 @@ public class SchemaManager {
    * @param topic The Kafka topic used to determine the schema.
    */
   public void updateSchema(TableId table, String topic) {
+    synchronized (tableUpdateLocks.computeIfAbsent(table, t -> new Object())) {
+      TableInfo tableInfo = constructTableInfo(table, topic);
+  
+      if (!schemaCache.containsKey(table)) {
+        schemaCache.put(table, readTableSchema(table));
+      }
+  
+      if (!schemaCache.get(table).equals(tableInfo.getDefinition().getSchema())) {
+        logger.info("Attempting to update {} with schema {}",
+            table(table), tableInfo.getDefinition().getSchema());
+        bigQuery.update(tableInfo);
+        logger.debug("Successfully updated {}", table(table));
+        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+      } else {
+        logger.debug("Skipping update of {} since current schema should be compatible", table(table));
+      }
+    }
+  }
+
+  private TableInfo constructTableInfo(TableId table, String topic) {
     Schema kafkaValueSchema = schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.VALUE);
     Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveSchema(table, topic, KafkaSchemaRecordType.KEY) : null;
-    TableInfo tableInfo = constructTableInfo(table, kafkaKeySchema, kafkaValueSchema);
-    logger.info("Attempting to update table `{}` with schema {}",
-        table, tableInfo.getDefinition().getSchema());
-    bigQuery.update(tableInfo);
+    return constructTableInfo(table, kafkaKeySchema, kafkaValueSchema);
   }
 
   // package private for testing.
   TableInfo constructTableInfo(TableId table, Schema kafkaKeySchema, Schema kafkaValueSchema) {
-    com.google.cloud.bigquery.Schema bigQuerySchema = getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
-
-    TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
-    if (timestampPartitionFieldName.isPresent()) {
-      timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName.get()).build();
-    }
+    com.google.cloud.bigquery.Schema bigQuerySchema =
+        getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
 
     StandardTableDefinition.Builder builder = StandardTableDefinition.newBuilder()
-        .setSchema(bigQuerySchema)
-        .setTimePartitioning(timePartitioning);
+        .setSchema(bigQuerySchema);
 
-    if (timestampPartitionFieldName.isPresent() && clusteringFieldName.isPresent()) {
-      Clustering clustering = Clustering.newBuilder()
-          .setFields(clusteringFieldName.get())
-          .build();
-      builder.setClustering(clustering);
+    if (intermediateTables) {
+      // Shameful hack: make the table ingestion time-partitioned here so that the _PARTITIONTIME
+      // pseudocolumn can be queried to filter out rows that are still in the streaming buffer
+      builder.setTimePartitioning(TimePartitioning.of(Type.DAY));
+    } else {
+      TimePartitioning timePartitioning = TimePartitioning.of(Type.DAY);
+      if (timestampPartitionFieldName.isPresent()) {
+        timePartitioning = timePartitioning.toBuilder().setField(timestampPartitionFieldName.get()).build();
+      }
+  
+      builder.setTimePartitioning(timePartitioning);
+
+      if (timestampPartitionFieldName.isPresent() && clusteringFieldName.isPresent()) {
+        Clustering clustering = Clustering.newBuilder()
+            .setFields(clusteringFieldName.get())
+            .build();
+        builder.setClustering(clustering);
+      }
     }
 
     StandardTableDefinition tableDefinition = builder.build();
     TableInfo.Builder tableInfoBuilder =
         TableInfo.newBuilder(table, tableDefinition);
-    if (kafkaValueSchema.doc() != null) {
+    
+    if (intermediateTables) {
+      tableInfoBuilder.setDescription("Temporary table");
+    } else if (kafkaValueSchema.doc() != null) {
       tableInfoBuilder.setDescription(kafkaValueSchema.doc());
     }
     return tableInfoBuilder.build();
   }
 
   private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
-      List<Field> allFields = new ArrayList<> ();
-      com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
-      allFields.addAll(valueSchema.getFields());
-      if (kafkaKeyFieldName.isPresent()) {
-          com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
-          Field kafkaKeyField = Field.newBuilder(kafkaKeyFieldName.get(), LegacySQLTypeName.RECORD, keySchema.getFields())
-                  .setMode(Field.Mode.NULLABLE).build();
-          allFields.add(kafkaKeyField);
-      }
-      if (kafkaDataFieldName.isPresent()) {
-          Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
-          allFields.add(kafkaDataField);
-      }
-      return com.google.cloud.bigquery.Schema.of(allFields);
+    com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
+
+    List<Field> schemaFields = intermediateTables
+        ? getIntermediateSchemaFields(valueSchema, kafkaKeySchema)
+        : getRegularSchemaFields(valueSchema, kafkaKeySchema);
+
+    return com.google.cloud.bigquery.Schema.of(schemaFields);
   }
 
+  private List<Field> getIntermediateSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+    if (kafkaKeySchema == null) {
+      throw new BigQueryConnectException(String.format(
+          "Cannot create intermediate table without specifying a value for '%s'",
+          BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG
+      ));
+    }
+
+    List<Field> result = new ArrayList<>();
+
+    List<Field> valueFields = new ArrayList<>(valueSchema.getFields());
+    if (kafkaDataFieldName.isPresent()) {
+      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
+      valueFields.add(kafkaDataField);
+    }
+
+    // Wrap the sink record value (and possibly also its Kafka data) in a struct in order to support deletes
+    Field wrappedValueField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueFields.toArray(new Field[0]))
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    result.add(wrappedValueField);
+
+    com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
+    Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keySchema.getFields())
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    result.add(kafkaKeyField);
+
+    Field iterationField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_ITERATION_FIELD_NAME, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    result.add(iterationField);
+
+    Field partitionTimeField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    result.add(partitionTimeField);
+
+    Field batchNumberField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    result.add(batchNumberField);
+
+    return result;
+  }
+
+  private List<Field> getRegularSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+    List<Field> result = new ArrayList<>(valueSchema.getFields());
+
+    if (kafkaDataFieldName.isPresent()) {
+      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName.get());
+      result.add(kafkaDataField);
+    }
+
+    if (kafkaKeyFieldName.isPresent()) {
+      com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
+      Field kafkaKeyField = Field.newBuilder(kafkaKeyFieldName.get(), LegacySQLTypeName.RECORD, keySchema.getFields())
+          .setMode(Field.Mode.NULLABLE).build();
+      result.add(kafkaKeyField);
+    }
+
+    return result;
+  }
+
+  private String table(TableId table) {
+    return intermediateTables
+        ? TableNameUtils.intTable(table)
+        : TableNameUtils.table(table);
+  }
+
+  private com.google.cloud.bigquery.Schema readTableSchema(TableId table) {
+    logger.trace("Reading schema for {}", table(table));
+    return bigQuery.getTable(table).getDefinition().getSchema();
+  }
+
+  private Object lock(ConcurrentMap<TableId, Object> locks, TableId table) {
+    return locks.computeIfAbsent(table, t -> new Object());
+  }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -32,7 +32,6 @@ import java.util.Map;
  * Class for task-specific configuration properties.
  */
 public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
-  private static final ConfigDef config;
   private static final Logger logger = LoggerFactory.getLogger(BigQuerySinkTaskConfig.class);
 
   public static final String SCHEMA_UPDATE_CONFIG =                     "autoUpdateSchemas";
@@ -62,7 +61,7 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
       "The maximum size (or -1 for no maximum size) of the worker queue for bigQuery write "
       + "requests before all topics are paused. This is a soft limit; the size of the queue can "
       + "go over this before topics are paused. All topics will be resumed once a flush is "
-      + "requested or the size of the queue drops under half of the maximum size.";
+      + "triggered or the size of the queue drops under half of the maximum size.";
 
   public static final String BIGQUERY_RETRY_CONFIG =                    "bigQueryRetry";
   private static final ConfigDef.Type BIGQUERY_RETRY_TYPE =             ConfigDef.Type.INT;
@@ -127,8 +126,18 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_CLUSTERING_FIELD_NAMES_DOC =
       "List of fields on which data should be clustered by in BigQuery, separated by commas";
 
-  static {
-    config = BigQuerySinkConfig.getConfig()
+  public static final String TASK_ID_CONFIG =                   "taskId";
+  private static final ConfigDef.Type TASK_ID_TYPE =            ConfigDef.Type.INT;
+  public static final ConfigDef.Importance TASK_ID_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String TASK_ID_DOC =                     "A unique for each task created by the connector";
+
+  /**
+   * Return a ConfigDef object used to define this config's fields.
+   *
+   * @return A ConfigDef object used to define this config's fields.
+   */
+  public static ConfigDef getConfig() {
+    return BigQuerySinkConfig.getConfig()
         .define(
             SCHEMA_UPDATE_CONFIG,
             SCHEMA_UPDATE_TYPE,
@@ -187,6 +196,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
             BIGQUERY_CLUSTERING_FIELD_NAMES_DEFAULT,
             BIGQUERY_CLUSTERING_FIELD_NAMES_IMPORTANCE,
             BIGQUERY_CLUSTERING_FIELD_NAMES_DOC
+        ).define(
+            TASK_ID_CONFIG,
+            TASK_ID_TYPE,
+            TASK_ID_IMPORTANCE,
+            TASK_ID_DOC
         );
   }
 
@@ -253,15 +267,11 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
     }
   }
 
-  public static ConfigDef getConfig() {
-    return config;
-  }
-
   /**
    * @param properties A Map detailing configuration properties and their respective values.
    */
   public BigQuerySinkTaskConfig(Map<String, String> properties) {
-    super(config, properties);
+    super(getConfig(), properties);
     checkAutoUpdateSchemas();
     checkPartitionConfigs();
     checkClusteringConfigs();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -103,10 +103,9 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       return convertBytes(value);
     }
     if (value instanceof List) {
-      return
-          ((List) value).stream().map(
-                  v -> convertSchemalessRecord(v)
-          ).collect(Collectors.toList());
+      return ((List<?>) value).stream()
+          .map(this::convertSchemalessRecord)
+          .collect(Collectors.toList());
     }
     if (value instanceof Map) {
       return
@@ -128,7 +127,6 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         " found in schemaless record data. Can't convert record to bigQuery format");
   }
 
-  @SuppressWarnings("unchecked")
   private Object convertObject(Object kafkaConnectObject, Schema kafkaConnectSchema) {
     if (kafkaConnectObject == null) {
       if (kafkaConnectSchema.isOptional()) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -97,6 +97,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
    *         existing one.
    */
   public com.google.cloud.bigquery.Schema convertSchema(Schema kafkaConnectSchema) {
+    // TODO: Permit non-struct keys
     if (kafkaConnectSchema.type() != Schema.Type.STRUCT) {
       throw new
           ConversionConnectException("Top-level Kafka Connect schema must be of type 'struct'");

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/ExpectedInterruptException.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/ExpectedInterruptException.java
@@ -1,0 +1,28 @@
+package com.wepay.kafka.connect.bigquery.exception;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+public class ExpectedInterruptException extends ConnectException {
+
+  public ExpectedInterruptException(String message) {
+    super(message);
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TableNameUtils.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/TableNameUtils.java
@@ -1,0 +1,36 @@
+package com.wepay.kafka.connect.bigquery.utils;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.TableId;
+
+public class TableNameUtils {
+
+  public static String table(TableId table) {
+    return String.format("table `%s`.`%s`", table.getDataset(), table.getTable());
+  }
+
+  public static String intTable(TableId table) {
+    return "intermediate " + table(table);
+  }
+
+  public static String destTable(TableId table) {
+    return "destination " + table(table);
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -21,8 +21,6 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.TableId;
 
-import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
-
 import com.wepay.kafka.connect.bigquery.write.row.GCSToBQWriter;
 import org.apache.kafka.connect.errors.ConnectException;
 
@@ -31,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Batch Table Writer that uploads records to GCS as a blob
@@ -95,7 +92,6 @@ public class GCSBatchTableWriter implements Runnable {
     private final TableId tableId;
 
     private List<RowToInsert> rows;
-    private final RecordConverter<Map<String, Object>> recordConverter;
     private final GCSToBQWriter writer;
 
     /**
@@ -106,29 +102,19 @@ public class GCSBatchTableWriter implements Runnable {
      * @param gcsBucketName The GCS bucket to write to.
      * @param gcsBlobName The name of the GCS blob to write.
      * @param topic Kafka record topic
-     * @param recordConverter the {@link RecordConverter} to use.
      */
     public Builder(GCSToBQWriter writer,
                    TableId tableId,
                    String gcsBucketName,
                    String gcsBlobName,
-                   String topic,
-                   RecordConverter<Map<String, Object>> recordConverter) {
-
+                   String topic) {
+      this.writer = writer;
+      this.tableId = tableId;
       this.bucketName = gcsBucketName;
       this.blobName = gcsBlobName;
       this.topic = topic;
 
-      this.tableId = tableId;
-
       this.rows = new ArrayList<>();
-      this.recordConverter = recordConverter;
-      this.writer = writer;
-    }
-
-    public Builder setBlobName(String blobName) {
-      this.blobName = blobName;
-      return this;
     }
 
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KCBQThreadPoolExecutor.java
@@ -20,15 +20,16 @@ package com.wepay.kafka.connect.bigquery.write.batch;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -64,7 +65,8 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
   protected void afterExecute(Runnable runnable, Throwable throwable) {
     super.afterExecute(runnable, throwable);
 
-    if (throwable != null) {
+    // Skip interrupted exceptions, as they are thrown by design on task shutdown
+    if (throwable != null && !(throwable instanceof ExpectedInterruptException)) {
       logger.error("Task failed with {} error: {}",
                    throwable.getClass().getName(),
                    throwable.getMessage());
@@ -91,19 +93,27 @@ public class KCBQThreadPoolExecutor extends ThreadPoolExecutor {
       execute(new CountDownRunnable(countDownLatch));
     }
     countDownLatch.await();
+    maybeThrowEncounteredErrors();
+  }
+
+  /**
+   * Immediately throw an exception if any unrecoverable errors were encountered by any of the write
+   * tasks.
+   *
+   * @throws BigQueryConnectException if any of the tasks failed.
+   */
+  public void maybeThrowEncounteredErrors() {
     if (encounteredErrors.size() > 0) {
       String errorString = createErrorString(encounteredErrors);
       encounteredErrors.clear();
       throw new BigQueryConnectException("Some write threads encountered unrecoverable errors: "
-                                         + errorString + "; See logs for more detail");
+          + errorString + "; See logs for more detail");
     }
   }
 
   private static String createErrorString(Collection<Throwable> errors) {
-    List<String> exceptionTypeStrings = new ArrayList<>(errors.size());
-    exceptionTypeStrings.addAll(errors.stream()
-                        .map(throwable -> throwable.getClass().getName())
-                        .collect(Collectors.toList()));
-    return String.join(", ", exceptionTypeStrings);
+    return errors.stream()
+                 .map(Objects::toString)
+                 .collect(Collectors.joining(", "));
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -1,0 +1,350 @@
+package com.wepay.kafka.connect.bigquery.write.batch;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.TableId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+import com.wepay.kafka.connect.bigquery.MergeQueries;
+import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
+import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static com.wepay.kafka.connect.bigquery.utils.TableNameUtils.intTable;
+
+public class MergeBatches {
+  private static final Logger logger = LoggerFactory.getLogger(MergeBatches.class);
+  private static final long STREAMING_BUFFER_AVAILABILITY_WAIT_MS = 10_000L;
+
+  private static long streamingBufferAvailabilityWaitMs = STREAMING_BUFFER_AVAILABILITY_WAIT_MS;
+
+  private final String intermediateTableSuffix;
+  private final BiMap<TableId, TableId> intermediateToDestinationTables;
+  private final ConcurrentMap<TableId, AtomicInteger> batchNumbers;
+  private final ConcurrentMap<TableId, ConcurrentMap<Integer, Batch>> batches;
+  private final Map<TopicPartition, Long> offsets;
+
+  @VisibleForTesting
+  public static void setStreamingBufferAvailabilityWait(long waitMs) {
+    streamingBufferAvailabilityWaitMs = waitMs;
+  }
+
+  @VisibleForTesting
+  public static void resetStreamingBufferAvailabilityWait() {
+    streamingBufferAvailabilityWaitMs = STREAMING_BUFFER_AVAILABILITY_WAIT_MS;
+  }
+
+  public MergeBatches(String intermediateTableSuffix) {
+    this.intermediateTableSuffix = intermediateTableSuffix;
+
+    this.intermediateToDestinationTables = Maps.synchronizedBiMap(HashBiMap.create());
+    this.batchNumbers = new ConcurrentHashMap<>();
+    this.batches = new ConcurrentHashMap<>();
+    this.offsets = new HashMap<>();
+  }
+
+  /**
+   * Get the latest safe-to-commit offsets for every topic partition that has had at least one
+   * record make its way to a destination table.
+   * @return the offsets map which can be used in
+   * {@link org.apache.kafka.connect.sink.SinkTask#preCommit(Map)}; never null
+   */
+  public Map<TopicPartition, OffsetAndMetadata> latestOffsets() {
+    synchronized (offsets) {
+      return offsets.entrySet().stream().collect(Collectors.toMap(
+          Map.Entry::getKey,
+          entry -> new OffsetAndMetadata(entry.getValue())
+      ));
+    }
+  }
+
+  /**
+   * @return a thread-safe map from intermediate tables to destination tables; never null
+   */
+  public Map<TableId, TableId> intermediateToDestinationTables() {
+    return intermediateToDestinationTables;
+  }
+
+  /**
+   * @return a collection of all currently-in-use intermediate tables; never null
+   */
+  public Collection<TableId> intermediateTables() {
+    return intermediateToDestinationTables.keySet();
+  }
+
+  /**
+   * Get the intermediate table for a given destination table, computing a new one if necessary
+   * @param destinationTable the destination table to fetch an intermediate table for
+   * @return the {@link TableId} of the intermediate table; never null
+   */
+  public TableId intermediateTableFor(TableId destinationTable) {
+    return intermediateToDestinationTables.inverse()
+        .computeIfAbsent(destinationTable, this::newIntermediateTable);
+  }
+
+  private TableId newIntermediateTable(TableId destinationTable) {
+    String tableName = FieldNameSanitizer.sanitizeName(
+        destinationTable.getTable() + intermediateTableSuffix
+    );
+    TableId result = TableId.of(
+        destinationTable.getDataset(),
+        tableName
+    );
+
+    batchNumbers.put(result, new AtomicInteger());
+    batches.put(result, new ConcurrentHashMap<>());
+
+    return result;
+  }
+
+  public TableId destinationTableFor(TableId intermediateTable) {
+    return intermediateToDestinationTables.get(intermediateTable);
+  }
+
+  /**
+   * Find a batch number for the record, insert that number into the converted value, record the
+   * offset for that record, and return the total size of that batch.
+   * @param record the record for the batch
+   * @param intermediateTable the intermediate table the record will be streamed into
+   * @param convertedRecord the converted record that will be passed to the BigQuery client
+   * @return the total number of records in the batch that this record is added to
+   */
+  public long addToBatch(SinkRecord record, TableId intermediateTable, Map<String, Object> convertedRecord) {
+    AtomicInteger batchCount = batchNumbers.get(intermediateTable);
+    // Synchronize here to ensure that the batch number isn't bumped in the middle of this method.
+    // On its own, that wouldn't be such a bad thing, but since a merge flush is supposed to
+    // immediately follow that bump, it might cause some trouble if we want to add this row to the
+    // batch but a merge flush on that batch has already started. This way, either the batch number
+    // is bumped before we add the row to the batch (in which case, the row is added to the fresh
+    // batch), or the row is added to the batch before preparation for the flush takes place and it
+    // is safely counted and tracked there.
+    synchronized (batchCount) {
+      int batchNumber = batchCount.get();
+      convertedRecord.put(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, batchNumber);
+
+      Batch batch = batches.get(intermediateTable).computeIfAbsent(batchNumber, n -> new Batch());
+      batch.recordOffsetFor(record);
+
+      long pendingBatchSize = batch.increment();
+      logger.trace("Added record to batch {} for {}; {} rows are currently pending",
+          batchNumber, intTable(intermediateTable), pendingBatchSize);
+      return batch.total();
+    }
+  }
+
+  /**
+   * Record a successful write of a list of rows to the given intermediate table, and decrease the
+   * pending record counts for every applicable batch accordingly.
+   * @param intermediateTable the intermediate table
+   * @param rows the rows
+   */
+  public void onRowWrites(TableId intermediateTable, List<InsertAllRequest.RowToInsert> rows) {
+    Map<Integer, Long> rowsByBatch = rows.stream().collect(Collectors.groupingBy(
+        row -> (Integer) row.getContent().get(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD),
+        Collectors.counting()
+    ));
+
+    rowsByBatch.forEach((batchNumber, batchSize) -> {
+      Batch batch = batch(intermediateTable, batchNumber);
+      synchronized (batch) {
+        long remainder = batch.recordWrites(batchSize);
+        batch.notifyAll();
+        logger.trace("Notified merge flush executor of successful write of {} rows "
+                + "for batch {} for {}; {} rows remaining",
+            batchSize, batchNumber, intTable(intermediateTable), remainder);
+      }
+    });
+  }
+
+  /**
+   * Increment the batch number for the given table, and return the old batch number.
+   * @param intermediateTable the table whose batch number should be incremented
+   * @return the batch number for the table, pre-increment
+   */
+  public int incrementBatch(TableId intermediateTable) {
+    AtomicInteger batchCount = batchNumbers.get(intermediateTable);
+    // See addToBatch for an explanation of the synchronization here
+    synchronized (batchCount) {
+      return batchCount.getAndIncrement();
+    }
+  }
+
+  /**
+   * Prepare to merge the batch for the given table, by ensuring that all prior batches for that
+   * table have completed and that all rows for the batch itself have been written.
+   * @param intermediateTable the table for the batch
+   * @param batchNumber the batch number to prepare to flush
+   * @return whether a flush is necessary (will be false if no rows were present in the given batch)
+   */
+  public boolean prepareToFlush(TableId intermediateTable, int batchNumber) {
+    final ConcurrentMap<Integer, Batch> allBatchesForTable = batches.get(intermediateTable);
+    if (batchNumber != 0) {
+      final int priorBatchNumber = batchNumber - 1;
+      synchronized (allBatchesForTable) {
+        logger.debug("Ensuring batch {} is completed for {} before flushing batch {}",
+            priorBatchNumber, intTable(intermediateTable), batchNumber);
+        while (allBatchesForTable.containsKey(priorBatchNumber)) {
+          try {
+            allBatchesForTable.wait();
+          } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for batch {} to complete for {}",
+                batchNumber, intTable(intermediateTable));
+            throw new ExpectedInterruptException(String.format(
+                "Interrupted while waiting for batch %d to complete for %s",
+                batchNumber, intTable(intermediateTable)
+            ));
+          }
+        }
+      }
+    } else {
+      logger.debug("Flushing first batch for {}", intTable(intermediateTable));
+    }
+
+    final Batch currentBatch = allBatchesForTable.get(batchNumber);
+    if (currentBatch == null) {
+      logger.trace("No rows to write in batch {} for {}", batchNumber, intTable(intermediateTable));
+      return false;
+    }
+
+    synchronized (currentBatch) {
+      logger.debug("{} rows currently remaining for batch {} for {}",
+          currentBatch.pending(), batchNumber, intTable(intermediateTable));
+      while (currentBatch.pending() != 0) {
+        logger.trace("Waiting for all rows for batch {} from {} to be written before flushing; {} remaining",
+            batchNumber, intTable(intermediateTable), currentBatch.pending());
+        try {
+          currentBatch.wait();
+        } catch (InterruptedException e) {
+          logger.warn("Interrupted while waiting for all rows for batch {} from {} to be written",
+              batchNumber, intTable(intermediateTable));
+          throw new ExpectedInterruptException(String.format(
+              "Interrupted while waiting for all rows for batch %d from %s to be written",
+              batchNumber, intTable(intermediateTable)
+          ));
+        }
+      }
+    }
+
+    try {
+      logger.trace(
+          "Waiting {}ms before running merge query on batch {} from {} "
+              + "in order to ensure that all rows are available in the streaming buffer",
+          streamingBufferAvailabilityWaitMs, batchNumber, intTable(intermediateTable));
+      Thread.sleep(streamingBufferAvailabilityWaitMs);
+    } catch (InterruptedException e) {
+      logger.warn("Interrupted while waiting before merge flushing batch {} for {}",
+          batchNumber, intTable(intermediateTable));
+      throw new ExpectedInterruptException(String.format(
+          "Interrupted while waiting before merge flushing batch %d for %s",
+          batchNumber, intTable(intermediateTable)
+      ));
+    }
+    return true;
+  }
+
+  /**
+   * Record a successful merge flush of all of the rows for the given batch in the intermediate
+   * table, alert any waiting merge flushes that are predicated on the completion of this merge
+   * flush, and marke the offsets for all of those rows as safe to commit.
+   * @param intermediateTable the source of the merge flush
+   * @param batchNumber the batch for the merge flush
+   */
+  public void recordSuccessfulFlush(TableId intermediateTable, int batchNumber) {
+    logger.trace("Successfully merge flushed batch {} for {}",
+        batchNumber, intTable(intermediateTable));
+    final ConcurrentMap<Integer, Batch> allBatchesForTable = batches.get(intermediateTable);
+    Batch batch = allBatchesForTable.remove(batchNumber);
+
+    synchronized (allBatchesForTable) {
+      allBatchesForTable.notifyAll();
+    }
+
+    synchronized (offsets) {
+      offsets.putAll(batch.offsets());
+    }
+  }
+
+  private Batch batch(TableId intermediateTable, int batchNumber) {
+    return batches.get(intermediateTable).get(batchNumber);
+  }
+
+  private static class Batch {
+    private final AtomicLong pending;
+    private final AtomicLong total;
+    private final Map<TopicPartition, Long> offsets;
+
+    public Batch() {
+      this.total = new AtomicLong();
+      this.pending = new AtomicLong();
+      this.offsets = new HashMap<>();
+    }
+
+    public long pending() {
+      return pending.get();
+    }
+
+    public long total() {
+      return total.get();
+    }
+
+    public Map<TopicPartition, Long> offsets() {
+      return offsets;
+    }
+
+    public void recordOffsetFor(SinkRecord record) {
+      offsets.put(
+          new TopicPartition(record.topic(), record.kafkaPartition()),
+          // Use the offset of the record plus one here since that'll be the offset that we'll
+          // resume at if/when this record is the last-committed record and then the task is
+          // restarted
+          record.kafkaOffset() + 1);
+    }
+
+    /**
+     * Increment the total and pending number of records, and return the number of pending records
+     * @return the number of pending records for this batch
+     */
+    public long increment() {
+      total.incrementAndGet();
+      return pending.incrementAndGet();
+    }
+
+    public long recordWrites(long numRows) {
+      return pending.addAndGet(-numRows);
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
+import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter;
 
@@ -33,6 +34,11 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 /**
  * Simple Table Writer that attempts to write all the rows it is given at once.
@@ -48,21 +54,26 @@ public class TableWriter implements Runnable {
   private final PartitionedTableId table;
   private final List<RowToInsert> rows;
   private final String topic;
+  private final Consumer<List<RowToInsert>> onFinish;
 
   /**
    * @param writer the {@link BigQueryWriter} to use.
    * @param table the BigQuery table to write to.
    * @param rows the rows to write.
    * @param topic the kafka source topic of this data.
+   * @param onFinish a callback to invoke after all rows have been written successfully, which is
+   *                 called with all the rows written by the writer
    */
   public TableWriter(BigQueryWriter writer,
                      PartitionedTableId table,
                      List<RowToInsert> rows,
-                     String topic) {
+                     String topic,
+                     Consumer<List<RowToInsert>> onFinish) {
     this.writer = writer;
     this.table = table;
     this.rows = rows;
     this.topic = topic;
+    this.onFinish = onFinish;
   }
 
   @Override
@@ -89,7 +100,7 @@ public class TableWriter implements Runnable {
         }
       }
     } catch (InterruptedException err) {
-      throw new ConnectException("Thread interrupted while writing to BigQuery.", err);
+      throw new ExpectedInterruptException("Thread interrupted while writing to BigQuery.");
     }
 
     // Common case is 1 successful call and 0 failed calls:
@@ -102,6 +113,7 @@ public class TableWriter implements Runnable {
       logger.debug(logMessage, rows.size(), successCount, failureCount);
     }
 
+    onFinish.accept(rows);
   }
 
   private static int getNewBatchSize(int currentBatchSize) {
@@ -150,25 +162,21 @@ public class TableWriter implements Runnable {
     private final PartitionedTableId table;
     private final String topic;
 
+    private Consumer<List<RowToInsert>> onFinish;
     private List<RowToInsert> rows;
-
-    private RecordConverter<Map<String, Object>> recordConverter;
 
     /**
      * @param writer the BigQueryWriter to use
      * @param table the BigQuery table to write to.
      * @param topic the kafka source topic associated with the given table.
-     * @param recordConverter the record converter used to convert records to rows
      */
-    public Builder(BigQueryWriter writer, PartitionedTableId table, String topic,
-                   RecordConverter<Map<String, Object>> recordConverter) {
+    public Builder(BigQueryWriter writer, PartitionedTableId table, String topic) {
       this.writer = writer;
       this.table = table;
       this.topic = topic;
 
+      this.onFinish = null;
       this.rows = new ArrayList<>();
-
-      this.recordConverter = recordConverter;
     }
 
     /**
@@ -180,11 +188,24 @@ public class TableWriter implements Runnable {
     }
 
     /**
+     * Specify a callback to be invoked after all rows have been written. The callback will be
+     * invoked with the full list of rows written by this table writer.
+     * @param onFinish the callback to invoke; may not be null
+     * @throws IllegalStateException if invoked more than once on a single builder instance
+     */
+    public void onFinish(Consumer<List<RowToInsert>> onFinish) {
+      if (this.onFinish != null) {
+        throw new IllegalStateException("Cannot overwrite existing finish callback");
+      }
+      this.onFinish = Objects.requireNonNull(onFinish, "Finish callback cannot be null");
+    }
+
+    /**
      * Create a {@link TableWriter} from this builder.
      * @return a TableWriter containing the given writer, table, topic, and all added rows.
      */
     public TableWriter build() {
-      return new TableWriter(writer, table, rows, topic);
+      return new TableWriter(writer, table, rows, topic, onFinish != null ? onFinish : n -> { });
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -1,0 +1,94 @@
+package com.wepay.kafka.connect.bigquery.write.row;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
+
+  private final SchemaManager schemaManager;
+  private final boolean autoCreateTables;
+  private final Map<TableId, TableId> intermediateToDestinationTables;
+
+  /**
+   * @param bigQuery Used to send write requests to BigQuery.
+   * @param schemaManager Used to update BigQuery tables.
+   * @param retry How many retries to make in the event of a 500/503 error.
+   * @param retryWait How long to wait in between retries.
+   * @param autoUpdateSchemas Whether destination table schemas should be automatically updated
+   * @param autoCreateTables Whether destination tables should be automatically created
+   * @param intermediateToDestinationTables A mapping used to determine the destination table for
+   *                                        given intermediate tables; used for create/update
+   *                                        operations in order to propagate them to the destination
+   *                                        table
+   */
+  public UpsertDeleteBigQueryWriter(BigQuery bigQuery,
+                                    SchemaManager schemaManager,
+                                    int retry,
+                                    long retryWait,
+                                    boolean autoUpdateSchemas,
+                                    boolean autoCreateTables,
+                                    Map<TableId, TableId> intermediateToDestinationTables) {
+    // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
+    // automatically created
+    // The super class will handle all of the logic for writing to, creating, and updating
+    // intermediate tables; this class will handle logic for creating/updating the destination table
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, autoUpdateSchemas, true);
+    this.schemaManager = schemaManager;
+    this.autoCreateTables = autoCreateTables;
+    this.intermediateToDestinationTables = intermediateToDestinationTables;
+  }
+
+  @Override
+  protected void attemptSchemaUpdate(PartitionedTableId tableId, String topic) {
+    // Update the intermediate table here...
+    super.attemptSchemaUpdate(tableId, topic);
+    try {
+      // ... and update the destination table here
+      schemaManager.updateSchema(intermediateToDestinationTables.get(tableId.getBaseTableId()), topic);
+    } catch (BigQueryException exception) {
+      throw new BigQueryConnectException(
+          "Failed to update destination table schema for: " + tableId.getBaseTableId(), exception);
+    }
+  }
+
+  @Override
+  protected void attemptTableCreate(TableId tableId, String topic) {
+    // Create the intermediate table here...
+    super.attemptTableCreate(tableId, topic);
+    if (autoCreateTables) {
+      try {
+        // ... and create or update the destination table here, if it doesn't already exist and auto
+        // table creation is enabled
+        schemaManager.createOrUpdateTable(intermediateToDestinationTables.get(tableId), topic);
+      } catch (BigQueryException exception) {
+        throw new BigQueryConnectException(
+            "Failed to create table " + tableId, exception);
+      }
+    }
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnectorTest.java
@@ -38,6 +38,7 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import org.apache.kafka.common.config.ConfigException;
@@ -101,6 +102,7 @@ public class BigQuerySinkConnectorTest {
       List<Map<String, String>> taskConfigs = testConnector.taskConfigs(i);
       assertEquals(i, taskConfigs.size());
       for (int j = 0; j < i; j++) {
+        expectedProperties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, Integer.toString(j));
         assertEquals(
             "Connector properties should match task configs",
             expectedProperties,
@@ -126,7 +128,7 @@ public class BigQuerySinkConnectorTest {
 
   @Test
   public void testConfig() {
-    assertEquals(BigQuerySinkConfig.getConfig(), new BigQuerySinkConnector().config());
+    assertNotNull(new BigQuerySinkConnector().config());
   }
 
   // Make sure that a config exception is properly translated into a SinkConfigConnectException

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -20,7 +20,9 @@ package com.wepay.kafka.connect.bigquery;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
@@ -31,16 +33,21 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.Storage;
 
+import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.apache.kafka.common.record.TimestampType;
@@ -51,15 +58,20 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class BigQuerySinkTaskTest {
   private static SinkTaskPropertiesFactory propertiesFactory;
@@ -67,6 +79,16 @@ public class BigQuerySinkTaskTest {
   @BeforeClass
   public static void initializePropertiesFactory() {
     propertiesFactory = new SinkTaskPropertiesFactory();
+  }
+
+  @Before
+  public void setUp() {
+    MergeBatches.setStreamingBufferAvailabilityWait(0);
+  }
+
+  @After
+  public void cleanUp() {
+    MergeBatches.resetStreamingBufferAvailabilityWait();
   }
 
   @Test
@@ -121,11 +143,15 @@ public class BigQuerySinkTaskTest {
     testTask.initialize(sinkTaskContext);
     testTask.start(properties);
 
-    testTask.put(Collections.singletonList(spoofSinkRecord(topic)));
+    SinkRecord spoofedRecord =
+        spoofSinkRecord(topic, "k", "key", "v", "value", TimestampType.NO_TIMESTAMP_TYPE, null);
+    testTask.put(Collections.singletonList(spoofedRecord));
     testTask.flush(Collections.emptyMap());
     verify(bigQuery, times(1)).insertAll(any(InsertAllRequest.class));
-    verify(schemaRetriever, times(1)).setLastSeenSchema(any(TableId.class),
-        any(String.class), any(Schema.class));
+    verify(schemaRetriever, times(1)).setLastSeenSchema(
+        any(TableId.class), any(String.class), any(Schema.class), eq(KafkaSchemaRecordType.KEY));
+    verify(schemaRetriever, times(1)).setLastSeenSchema(
+        any(TableId.class), any(String.class), any(Schema.class), eq(KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -166,8 +192,6 @@ public class BigQuerySinkTaskTest {
 
     testTask.put(Collections.singletonList(emptyRecord));
   }
-
-  @Captor ArgumentCaptor<InsertAllRequest> captor;
 
   @Test
   public void testPutWhenPartitioningOnMessageTime() {
@@ -298,7 +322,78 @@ public class BigQuerySinkTaskTest {
         TimestampType.NO_TIMESTAMP_TYPE, null)));
   }
 
-  // It's important that the buffer be completely wiped after a call to flush, since any execption
+  @Test
+  public void testPutWithUpsertDelete() throws Exception {
+    final String topic = "test-topic";
+    final String key = "kafkaKey";
+    final String value = "recordValue";
+
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
+    properties.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=scratch");
+    properties.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG, "-1");
+    properties.put(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG, "2");
+    properties.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, key);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Storage storage = mock(Storage.class);
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+    when(bigQuery.insertAll(anyObject())).thenReturn(insertAllResponse);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Field keyField = Field.of(key, LegacySQLTypeName.STRING);
+    Field valueField = Field.of(value, LegacySQLTypeName.STRING);
+    com.google.cloud.bigquery.Schema intermediateSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+            .setMode(Field.Mode.REQUIRED)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.NULLABLE)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keyField)
+            .setMode(Field.Mode.REQUIRED)
+            .build(),
+        Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueField)
+            .build()
+    );
+    when(schemaManager.cachedSchema(any())).thenReturn(intermediateSchema);
+
+    CountDownLatch executedMerges = new CountDownLatch(2);
+    CountDownLatch executedBatchClears = new CountDownLatch(2);
+
+    when(bigQuery.query(any(QueryJobConfiguration.class))).then(invocation -> {
+      String query = invocation.getArgument(0, QueryJobConfiguration.class).getQuery();
+      if (query.startsWith("MERGE")) {
+        executedMerges.countDown();
+      } else if (query.startsWith("DELETE")) {
+        executedBatchClears.countDown();
+      }
+      return null;
+    });
+
+    BigQuerySinkTask testTask = new BigQuerySinkTask(bigQuery, schemaRetriever, storage, schemaManager);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+
+    // Insert a few regular records and one tombstone record
+    testTask.put(Arrays.asList(
+        spoofSinkRecord(topic, key, "4761", "value", "message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "489", "value", "other message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "28980", "value", "more message text", TimestampType.NO_TIMESTAMP_TYPE, null),
+        spoofSinkRecord(topic, key, "4761", null, null, TimestampType.NO_TIMESTAMP_TYPE, null)
+    ));
+
+    assertTrue("Merge queries should be executed", executedMerges.await(5, TimeUnit.SECONDS));
+    assertTrue("Batch clears should be executed", executedBatchClears.await(1, TimeUnit.SECONDS));
+  }
+
+  // It's important that the buffer be completely wiped after a call to flush, since any exception
   // thrown during flush causes Kafka Connect to not commit the offsets for any records sent to the
   // task since the last flush
   @Test
@@ -548,38 +643,57 @@ public class BigQuerySinkTaskTest {
   }
 
   /**
-   * Utility method for spoofing InsertAllRequests that should be sent to a BigQuery object.
-   * @param table The table to write to.
-   * @param rows The rows to write.
-   * @return The spoofed InsertAllRequest.
+   * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
+   * @param topic The topic of the record.
+   * @param keyField The field name for the record key; may be null.
+   * @param key The content of the record key; may be null.
+   * @param valueField The field name for the record value; may be null
+   * @param value The content of the record value; may be null
+   * @param timestampType The type of timestamp embedded in the message
+   * @param timestamp The timestamp in milliseconds
+   * @return The spoofed SinkRecord.
    */
-  public static InsertAllRequest buildExpectedInsertAllRequest(
-      TableId table,
-      InsertAllRequest.RowToInsert... rows) {
-    return InsertAllRequest.newBuilder(table, rows)
-        .setIgnoreUnknownValues(false)
-        .setSkipInvalidRows(false)
-        .build();
+  public static SinkRecord spoofSinkRecord(String topic, String keyField, String key,
+                                           String valueField, String value,
+                                           TimestampType timestampType, Long timestamp) {
+    Schema basicKeySchema = null;
+    Struct basicKey = null;
+    if (keyField != null) {
+      basicKeySchema = SchemaBuilder
+          .struct()
+          .field(keyField, Schema.STRING_SCHEMA)
+          .build();
+      basicKey = new Struct(basicKeySchema);
+      basicKey.put(keyField, key);
+    }
+
+    Schema basicValueSchema = null;
+    Struct basicValue = null;
+    if (valueField != null) {
+      basicValueSchema = SchemaBuilder
+          .struct()
+          .field(valueField, Schema.STRING_SCHEMA)
+          .build();
+      basicValue = new Struct(basicValueSchema);
+      basicValue.put(valueField, value);
+    }
+
+    return new SinkRecord(topic, 0, basicKeySchema, basicKey,
+        basicValueSchema, basicValue, 0, timestamp, timestampType);
   }
 
   /**
    * Utility method for spoofing SinkRecords that should be passed to SinkTask.put()
    * @param topic The topic of the record.
-   * @param value The content of the record.
+   * @param field The field name for the record value.
+   * @param value The content of the record value.
    * @param timestampType The type of timestamp embedded in the message
    * @param timestamp The timestamp in milliseconds
    * @return The spoofed SinkRecord.
    */
   public static SinkRecord spoofSinkRecord(String topic, String field, String value,
                                            TimestampType timestampType, Long timestamp) {
-    Schema basicRowSchema = SchemaBuilder
-            .struct()
-            .field(field, Schema.STRING_SCHEMA)
-            .build();
-    Struct basicRowValue = new Struct(basicRowSchema);
-    basicRowValue.put(field, value);
-    return new SinkRecord(topic, 0, null, null,
-        basicRowSchema, basicRowValue, 0, timestamp, timestampType);
+    return spoofSinkRecord(topic, null, null, field, value, timestampType, timestamp);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
@@ -1,0 +1,296 @@
+package com.wepay.kafka.connect.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import com.wepay.kafka.connect.bigquery.write.batch.KCBQThreadPoolExecutor;
+import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MergeQueriesTest {
+
+  private static final String KEY = "kafkaKey";
+
+  private static final int BATCH_NUMBER = 42;
+  private static final TableId DESTINATION_TABLE = TableId.of("ds1", "t");
+  private static final TableId INTERMEDIATE_TABLE = TableId.of("ds1", "t_tmp_6_uuid_epoch");
+  private static final Schema INTERMEDIATE_TABLE_SCHEMA = constructIntermediateTable();
+
+  @Mock private MergeBatches mergeBatches;
+  @Mock private KCBQThreadPoolExecutor executor;
+  @Mock private BigQuery bigQuery;
+  @Mock private SchemaManager schemaManager;
+  @Mock private SinkTaskContext context;
+
+  @Before
+  public void setUp() {
+    when(schemaManager.cachedSchema(INTERMEDIATE_TABLE)).thenReturn(INTERMEDIATE_TABLE_SCHEMA);
+  }
+
+  private MergeQueries mergeQueries(boolean insertPartitionTime, boolean upsert, boolean delete) {
+    return new MergeQueries(
+        KEY, insertPartitionTime, upsert, delete, mergeBatches, executor, bigQuery, schemaManager, context
+    );
+  }
+
+  private static Schema constructIntermediateTable() {
+    List<Field> fields = new ArrayList<>();
+
+    List<Field> valueFields = Arrays.asList(
+        Field.of("f1", LegacySQLTypeName.STRING),
+        Field.of("f2", LegacySQLTypeName.RECORD,
+            Field.of("nested_f1", LegacySQLTypeName.INTEGER)
+        ),
+        Field.of("f3", LegacySQLTypeName.BOOLEAN),
+        Field.of("f4", LegacySQLTypeName.BYTES)
+    );
+    Field wrappedValueField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueFields.toArray(new Field[0]))
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    fields.add(wrappedValueField);
+
+    List<Field> keyFields = Arrays.asList(
+        Field.of("k1", LegacySQLTypeName.STRING),
+        Field.of("k2", LegacySQLTypeName.RECORD,
+            Field.of("nested_k1", LegacySQLTypeName.RECORD,
+                Field.of("doubly_nested_k", LegacySQLTypeName.BOOLEAN)
+            ),
+            Field.of("nested_k2", LegacySQLTypeName.INTEGER)
+        )
+    );
+    Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keyFields.toArray(new Field[0]))
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    fields.add(kafkaKeyField);
+
+    Field partitionTimeField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+        .setMode(Field.Mode.NULLABLE)
+        .build();
+    fields.add(partitionTimeField);
+
+    Field batchNumberField = Field
+        .newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
+        .setMode(Field.Mode.REQUIRED)
+        .build();
+    fields.add(batchNumberField);
+
+    return Schema.of(fields);
+  }
+
+  @Test
+  public void testUpsertQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "WHEN MATCHED "
+            + "THEN UPDATE SET f1=src.value.f1, f2=src.value.f2, f3=src.value.f3, f4=src.value.f4 "
+          + "WHEN NOT MATCHED "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "_PARTITIONTIME, "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "src.key, "
+              + "CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP), "
+              + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(true, true, false)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "WHEN MATCHED "
+            + "THEN UPDATE SET f1=src.value.f1, f2=src.value.f2, f3=src.value.f3, f4=src.value.f4 "
+          + "WHEN NOT MATCHED "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "src.key, "
+              + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(false, true, false)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testDeleteQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING ("
+            + "SELECT batch.key AS key, partitionTime, value "
+              + "FROM ("
+                + "SELECT src.i, src.key FROM ("
+                  + "SELECT ARRAY_AGG("
+                    + "x ORDER BY i DESC LIMIT 1"
+                  + ")[OFFSET(0)] src "
+                  + "FROM ("
+                    + "SELECT * FROM " + table(INTERMEDIATE_TABLE) + " "
+                      + "WHERE batchNumber=" + BATCH_NUMBER
+                  + ") x "
+                  + "WHERE x.value IS NULL "
+                  + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) AS deletes "
+                + "RIGHT JOIN ("
+                  + "SELECT * FROM " + table(INTERMEDIATE_TABLE) + " "
+                    + "WHERE batchNumber=" + BATCH_NUMBER
+                + ") AS batch "
+                + "USING (key) "
+              + "WHERE deletes.i IS NULL OR batch.i >= deletes.i "
+              + "ORDER BY batch.i ASC) AS src "
+            + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key AND src.value IS NULL "
+            + "WHEN MATCHED "
+              + "THEN DELETE "
+            + "WHEN NOT MATCHED AND src.value IS NOT NULL "
+              + "THEN INSERT ("
+                + KEY + ", "
+                + "_PARTITIONTIME, "
+                + "f1, f2, f3, f4) "
+              + "VALUES ("
+                + "src.key, "
+                + "CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP), "
+                + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(true, false, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testDeleteQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING ("
+            + "SELECT batch.key AS key, value "
+              + "FROM ("
+                + "SELECT src.i, src.key FROM ("
+                  + "SELECT ARRAY_AGG("
+                    + "x ORDER BY i DESC LIMIT 1"
+                  + ")[OFFSET(0)] src "
+                  + "FROM ("
+                    + "SELECT * FROM " + table(INTERMEDIATE_TABLE) + " "
+                      + "WHERE batchNumber=" + BATCH_NUMBER
+                  + ") x "
+                  + "WHERE x.value IS NULL "
+                  + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) AS deletes "
+                + "RIGHT JOIN ("
+                  + "SELECT * FROM " + table(INTERMEDIATE_TABLE) + " "
+                    + "WHERE batchNumber=" + BATCH_NUMBER
+                + ") AS batch "
+                + "USING (key) "
+              + "WHERE deletes.i IS NULL OR batch.i >= deletes.i "
+              + "ORDER BY batch.i ASC) AS src "
+            + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key AND src.value IS NULL "
+            + "WHEN MATCHED "
+              + "THEN DELETE "
+            + "WHEN NOT MATCHED AND src.value IS NOT NULL "
+              + "THEN INSERT ("
+                + KEY + ", "
+                + "f1, f2, f3, f4) "
+              + "VALUES ("
+                + "src.key, "
+                + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(false, false, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertDeleteQueryWithPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "WHEN MATCHED AND src.value IS NOT NULL "
+            + "THEN UPDATE SET f1=src.value.f1, f2=src.value.f2, f3=src.value.f3, f4=src.value.f4 "
+          + "WHEN MATCHED AND src.value IS NULL "
+            + "THEN DELETE "
+          + "WHEN NOT MATCHED AND src.value IS NOT NULL "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "_PARTITIONTIME, "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "src.key, "
+              + "CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP), "
+              + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";
+    String actualQuery = mergeQueries(true, true, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testUpsertDeleteQueryWithoutPartitionTime() {
+    String expectedQuery =
+        "MERGE " + table(DESTINATION_TABLE) + " "
+          + "USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src "
+            + "FROM " + table(INTERMEDIATE_TABLE) + " x "
+            + "WHERE batchNumber=" + BATCH_NUMBER + " "
+            + "GROUP BY key.k1, key.k2.nested_k1.doubly_nested_k, key.k2.nested_k2)) "
+          + "ON `" + DESTINATION_TABLE.getTable() + "`." + KEY + "=src.key "
+          + "WHEN MATCHED AND src.value IS NOT NULL "
+            + "THEN UPDATE SET f1=src.value.f1, f2=src.value.f2, f3=src.value.f3, f4=src.value.f4 "
+          + "WHEN MATCHED AND src.value IS NULL "
+            + "THEN DELETE "
+          + "WHEN NOT MATCHED AND src.value IS NOT NULL "
+            + "THEN INSERT ("
+              + KEY + ", "
+              + "f1, f2, f3, f4) "
+            + "VALUES ("
+              + "src.key, "
+              + "src.value.f1, src.value.f2, src.value.f3, src.value.f4"
+            + ");";    String actualQuery = mergeQueries(false, true, true)
+        .mergeFlushQuery(INTERMEDIATE_TABLE, DESTINATION_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  @Test
+  public void testBatchClearQuery() {
+    String expectedQuery =
+        "DELETE FROM " + table(INTERMEDIATE_TABLE)
+          + " WHERE batchNumber <= " + BATCH_NUMBER
+          + " AND _PARTITIONTIME IS NOT NULL;";
+    // No difference in batch clearing between upsert, delete, and both, or with or without partition time
+    String actualQuery = MergeQueries.batchClearQuery(INTERMEDIATE_TABLE, BATCH_NUMBER);
+    assertEquals(expectedQuery, actualQuery);
+  }
+
+  private String table(TableId table) {
+    return String.format("`%s`.`%s`", table.getDataset(), table.getTable());
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkTaskPropertiesFactory.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SinkTaskPropertiesFactory.java
@@ -30,6 +30,7 @@ public class SinkTaskPropertiesFactory extends SinkPropertiesFactory {
 
     properties.put(BigQuerySinkTaskConfig.SCHEMA_UPDATE_CONFIG, "false");
     properties.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "4");
 
     return properties;
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -1,0 +1,352 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableResult;
+import com.wepay.kafka.connect.bigquery.BigQueryHelper;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.cloud.bigquery.LegacySQLTypeName.BOOLEAN;
+import static com.google.cloud.bigquery.LegacySQLTypeName.BYTES;
+import static com.google.cloud.bigquery.LegacySQLTypeName.DATE;
+import static com.google.cloud.bigquery.LegacySQLTypeName.FLOAT;
+import static com.google.cloud.bigquery.LegacySQLTypeName.INTEGER;
+import static com.google.cloud.bigquery.LegacySQLTypeName.STRING;
+import static com.google.cloud.bigquery.LegacySQLTypeName.TIMESTAMP;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertTrue;
+
+@Category(IntegrationTest.class)
+public abstract class BaseConnectorIT {
+  private static final Logger logger = LoggerFactory.getLogger(BaseConnectorIT.class);
+
+  private static final String KEYFILE_ENV_VAR = "KCBQ_TEST_KEYFILE";
+  private static final String PROJECT_ENV_VAR = "KCBQ_TEST_PROJECT";
+  private static final String DATASET_ENV_VAR = "KCBQ_TEST_DATASET";
+  private static final String KEYSOURCE_ENV_VAR = "KCBQ_TEST_KEYSOURCE";
+
+  protected static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
+  protected static final long COMMIT_MAX_DURATION_MS = TimeUnit.MINUTES.toMillis(5);
+  protected static final long OFFSETS_READ_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+  protected static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.SECONDS.toMillis(60);
+
+  protected EmbeddedConnectCluster connect;
+  private Admin kafkaAdminClient;
+
+  protected void startConnect() {
+    Map<String, String> workerProps = new HashMap<>();
+    workerProps.put(
+        WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG, Long.toString(OFFSET_COMMIT_INTERVAL_MS));
+    // Allow per-connector consumer configuration for throughput testing
+    workerProps.put(
+        WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, "All");
+
+    connect = new EmbeddedConnectCluster.Builder()
+        .name("kcbq-connect-cluster")
+        .workerProps(workerProps)
+        .build();
+
+    // start the clusters
+    connect.start();
+
+    kafkaAdminClient = connect.kafka().createAdminClient();
+
+    // the exception handler installed by the embedded zookeeper instance is noisy and unnecessary
+    Thread.setDefaultUncaughtExceptionHandler((t, e) -> { });
+  }
+
+  protected void stopConnect() {
+    if (kafkaAdminClient !=  null) {
+      kafkaAdminClient.close();
+      kafkaAdminClient = null;
+    }
+
+    // stop all Connect, Kafka and Zk threads.
+    if (connect != null) {
+      connect.stop();
+      connect = null;
+    }
+  }
+
+  protected Map<String, String> baseConnectorProps(int tasksMax) {
+    Map<String, String> result = new HashMap<>();
+
+    result.put(CONNECTOR_CLASS_CONFIG, "BigQuerySinkConnector");
+    result.put(TASKS_MAX_CONFIG, Integer.toString(tasksMax));
+
+    result.put(BigQuerySinkConfig.PROJECT_CONFIG, project());
+    result.put(BigQuerySinkConfig.DATASETS_CONFIG, ".*=" + dataset());
+    result.put(BigQuerySinkConfig.KEYFILE_CONFIG, keyFile());
+    result.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, keySource());
+
+    return result;
+  }
+
+  protected BigQuery newBigQuery() {
+    return new BigQueryHelper()
+        .setKeySource(keySource())
+        .connect(project(), keyFile());
+  }
+
+  protected void clearPriorTable(BigQuery bigQuery, String table) {
+    boolean deleted = bigQuery.delete(TableId.of(dataset(), table));
+    if (deleted) {
+      logger.info("Deleted existing test table `{}`.`{}`", dataset(), table);
+    }
+  }
+
+  protected void waitForCommittedRecords(
+      String connector, String topic, long numRecords, int numTasks
+  ) throws InterruptedException {
+    waitForCommittedRecords(connector, topic, numRecords, numTasks, COMMIT_MAX_DURATION_MS);
+  }
+
+  protected void waitForCommittedRecords(
+      String connector, String topic, long numRecords, int numTasks, long timeoutMs) throws InterruptedException {
+    waitForCondition(
+        () -> {
+          long totalCommittedRecords = totalCommittedRecords(connector, topic);
+          if (totalCommittedRecords >= numRecords) {
+            return true;
+          } else {
+            // Check to make sure the connector is still running. If not, fail fast
+            assertTrue(
+                "Connector or one of its tasks failed during testing",
+                assertConnectorAndTasksRunning(connector, numTasks).orElse(false));
+            logger.debug("Connector has only committed {} records for topic {} so far; {} expected",
+                totalCommittedRecords, topic, numRecords);
+            // Sleep here so as not to spam Kafka with list-offsets requests
+            Thread.sleep(OFFSET_COMMIT_INTERVAL_MS / 2);
+            return false;
+          }
+        },
+        timeoutMs,
+        "Either the connector failed, or the message commit duration expired without all expected messages committed");
+  }
+
+  protected synchronized long totalCommittedRecords(String connector, String topic) throws TimeoutException, ExecutionException, InterruptedException {
+    // See https://github.com/apache/kafka/blob/f7c38d83c727310f4b0678886ba410ae2fae9379/connect/runtime/src/main/java/org/apache/kafka/connect/util/SinkUtils.java
+    // for how the consumer group ID is constructed for sink connectors
+    Map<TopicPartition, OffsetAndMetadata> offsets = kafkaAdminClient
+        .listConsumerGroupOffsets("connect-" + connector)
+        .partitionsToOffsetAndMetadata()
+        .get(OFFSETS_READ_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+    logger.trace("Connector {} has so far committed offsets {}", connector, offsets);
+
+    return offsets.entrySet().stream()
+        .filter(entry -> topic.equals(entry.getKey().topic()))
+        .mapToLong(entry -> entry.getValue().offset())
+        .sum();
+  }
+
+  /**
+   * Read all rows from the given table.
+   * @param bigQuery used to connect to BigQuery
+   * @param tableName the table to read
+   * @param sortColumn a column to sort rows by (can use dot notation to refer to nested fields)
+   * @return a list of all rows from the table, in random order.
+   */
+  protected List<List<Object>> readAllRows(
+      BigQuery bigQuery, String tableName, String sortColumn) throws InterruptedException {
+
+    Table table = bigQuery.getTable(dataset(), tableName);
+    Schema schema = table.getDefinition().getSchema();
+
+    TableResult tableResult = bigQuery.query(QueryJobConfiguration.of(String.format(
+        "SELECT * FROM `%s`.`%s` ORDER BY %s ASC",
+        dataset(),
+        tableName,
+        sortColumn
+    )));
+
+    return StreamSupport.stream(tableResult.iterateAll().spliterator(), false)
+        .map(fieldValues -> convertRow(schema.getFields(), fieldValues))
+        .collect(Collectors.toList());
+  }
+
+  private static List<Byte> boxByteArray(byte[] bytes) {
+    Byte[] result = new Byte[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      result[i] = bytes[i];
+    }
+    return Arrays.asList(result);
+  }
+
+  private Object convertField(Field fieldSchema, FieldValue field) {
+    if (field.isNull()) {
+      return null;
+    }
+    switch (field.getAttribute()) {
+      case PRIMITIVE:
+        if (fieldSchema.getType().equals(BOOLEAN)) {
+          return field.getBooleanValue();
+        } else if (fieldSchema.getType().equals(BYTES)) {
+          // Do this in order for assertEquals() to work when this is an element of two compared
+          // lists
+          return boxByteArray(field.getBytesValue());
+        } else if (fieldSchema.getType().equals(DATE)) {
+          DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+          return LocalDate.parse(field.getStringValue(), dateFormatter)
+              .atStartOfDay(ZoneOffset.UTC)
+              .toInstant()
+              .toEpochMilli();
+        } else if (fieldSchema.getType().equals(FLOAT)) {
+          return field.getDoubleValue();
+        } else if (fieldSchema.getType().equals(INTEGER)) {
+          return field.getLongValue();
+        } else if (fieldSchema.getType().equals(STRING)) {
+          return field.getStringValue();
+        } else if (fieldSchema.getType().equals(TIMESTAMP)) {
+          return field.getTimestampValue();
+        } else {
+          throw new RuntimeException("Cannot convert primitive field type "
+              + fieldSchema.getType());
+        }
+      case REPEATED:
+        List<Object> result = new ArrayList<>();
+        for (FieldValue arrayField : field.getRepeatedValue()) {
+          result.add(convertField(fieldSchema, arrayField));
+        }
+        return result;
+      case RECORD:
+        List<Field> recordSchemas = fieldSchema.getSubFields();
+        List<FieldValue> recordFields = field.getRecordValue();
+        return convertRow(recordSchemas, recordFields);
+      default:
+        throw new RuntimeException("Unknown field attribute: " + field.getAttribute());
+    }
+  }
+
+  private List<Object> convertRow(List<Field> rowSchema, List<FieldValue> row) {
+    List<Object> result = new ArrayList<>();
+    assert (rowSchema.size() == row.size());
+
+    for (int i = 0; i < rowSchema.size(); i++) {
+      result.add(convertField(rowSchema.get(i), row.get(i)));
+    }
+
+    return result;
+  }
+
+  /**
+   * Wait up to {@link #CONNECTOR_STARTUP_DURATION_MS maximum time limit} for the connector with the given
+   * name to start the specified number of tasks.
+   *
+   * @param name the name of the connector
+   * @param numTasks the minimum number of tasks that are expected
+   * @return the time this method discovered the connector has started, in milliseconds past epoch
+   * @throws InterruptedException if this was interrupted
+   */
+  protected long waitForConnectorToStart(String name, int numTasks) throws InterruptedException {
+    TestUtils.waitForCondition(
+        () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
+        CONNECTOR_STARTUP_DURATION_MS,
+        "Connector tasks did not start in time."
+    );
+    return System.currentTimeMillis();
+  }
+
+  /**
+   * Confirm that a connector with an exact number of tasks is running.
+   *
+   * @param connectorName the connector
+   * @param numTasks the minimum number of tasks
+   * @return true if the connector and tasks are in RUNNING state; false otherwise
+   */
+  protected Optional<Boolean> assertConnectorAndTasksRunning(String connectorName, int numTasks) {
+    try {
+      ConnectorStateInfo info = connect.connectorStatus(connectorName);
+      boolean result = info != null
+                       && info.tasks().size() >= numTasks
+                       && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
+                       && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
+      return Optional.of(result);
+    } catch (Exception e) {
+      logger.error("Could not check connector state info.", e);
+      return Optional.empty();
+    }
+  }
+
+  private String readEnvVar(String var) {
+    String result = System.getenv(var);
+    if (result == null) {
+      throw new IllegalStateException(String.format(
+          "Environment variable '%s' must be supplied to run integration tests",
+          var));
+    }
+    return result;
+  }
+
+  private String readEnvVar(String var, String defaultVal) {
+    return System.getenv().getOrDefault(var, defaultVal);
+  }
+
+  protected String keyFile() {
+    return readEnvVar(KEYFILE_ENV_VAR);
+  }
+
+  protected String project() {
+    return readEnvVar(PROJECT_ENV_VAR);
+  }
+
+  protected String dataset() {
+    return readEnvVar(DATASET_ENV_VAR);
+  }
+
+  protected String keySource() {
+    return readEnvVar(KEYSOURCE_ENV_VAR, BigQuerySinkConfig.KEY_SOURCE_DEFAULT);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/UpsertDeleteBigQuerySinkConnectorIT.java
@@ -1,0 +1,408 @@
+package com.wepay.kafka.connect.bigquery.integration;
+
+/*
+ * Copyright 2016 WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import com.google.cloud.bigquery.BigQuery;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.retrieve.MemorySchemaRetriever;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.Assert.assertEquals;
+
+@Category(IntegrationTest.class)
+public class UpsertDeleteBigQuerySinkConnectorIT extends BaseConnectorIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(UpsertDeleteBigQuerySinkConnectorIT.class);
+
+  private static final String CONNECTOR_NAME = "kcbq-sink-connector";
+  private static final long NUM_RECORDS_PRODUCED = 20;
+  private static final int TASKS_MAX = 3;
+  private static final String KAFKA_FIELD_NAME = "kafkaKey";
+
+  private BigQuery bigQuery;
+
+  @Before
+  public void setup() {
+    bigQuery = newBigQuery();
+    startConnect();
+  }
+
+  @After
+  public void close() {
+    bigQuery = null;
+    stopConnect();
+  }
+
+  private Map<String, String> upsertDeleteProps(
+      boolean upsert,
+      boolean delete,
+      long mergeRecordsThreshold) {
+    if (!upsert && !delete) {
+      throw new IllegalArgumentException("At least one of upsert or delete must be enabled");
+    }
+
+    Map<String, String> result = new HashMap<>();
+
+    // use the JSON converter with schemas enabled
+    result.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    result.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    if (upsert) {
+      result.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    }
+    if (delete) {
+      result.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+    }
+
+    // Hardcode merge flushes to just use number of records for now, as it's more deterministic and
+    // faster to test
+    result.put(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG, "-1");
+    result.put(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG, Long.toString(mergeRecordsThreshold));
+
+    result.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, KAFKA_FIELD_NAME);
+
+    return result;
+  }
+
+  @Test
+  public void testUpsert() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-upsert";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_upsert";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable only upsert and not delete, and merge flush every other record
+    props.putAll(upsertDeleteProps(true, false, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      String kafkaValue = value(valueConverter, topic, i, false);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED / 2)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            (i - 1) % 3 == 0,
+            (i * 2 + 1) / 0.69,
+            Collections.singletonList(i)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  public void testDelete() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-delete";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_delete";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable only delete and not upsert, and merge flush every other record
+    props.putAll(upsertDeleteProps(false, true, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Because upsert is not enabled, no deduplication will take place
+      // and, unless a tombstone is written for that key, both will be inserted
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED)
+        .filter(i -> i % 4 < 2)
+        .mapToObj(i -> Arrays.asList(
+            i % 4 == 0 ? "a string" : "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  public void testUpsertDelete() throws Throwable {
+    // create topic in Kafka
+    final String topic = "test-upsert-delete";
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = "test_upsert_delete";
+    clearPriorTable(bigQuery, table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable upsert and delete, and merge flush every other record
+    props.putAll(upsertDeleteProps(true, true, 2));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  @Ignore("Skipped during regular testing; comment-out annotation to run")
+  public void testUpsertDeleteHighThroughput() throws Throwable {
+    final long numRecords = 1_000_000L;
+    final int numPartitions = 10;
+    final int tasksMax = 1;
+
+    // create topic in Kafka
+    final String topic = "test-upsert-delete-throughput";
+    connect.kafka().createTopic(topic, numPartitions);
+
+    final String table = "test_upsert_delete_throughput";
+    clearPriorTable(bigQuery, table);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka. Pre-populate Kafka before starting the connector as we want to measure
+    // the connector's throughput cleanly
+    logger.info("Pre-populating Kafka with test data");
+    for (int i = 0; i < numRecords; i++) {
+      if (i % 10000 == 0) {
+        logger.info("{} records produced so far", i);
+      }
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will
+      // be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // setup props for the sink connector
+    // use a single task
+    Map<String, String> props = baseConnectorProps(tasksMax);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+    // Allow for at most 10,000 records per call to poll
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+        "10000");
+    // Try to get at least 1 MB per partition with each request
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
+        Integer.toString(ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES * numPartitions));
+    // Wait up to one second for each batch to reach the requested size
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+        + ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG,
+        "1000"
+    );
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, MemorySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable upsert and delete, and schedule ten total flushes
+    props.putAll(upsertDeleteProps(true, true, numRecords / 10));
+
+    logger.info("Pre-population complete; creating connector");
+    long start = System.currentTimeMillis();
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, tasksMax);
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, numRecords, tasksMax, TimeUnit.MINUTES.toMillis(10));
+    long time = System.currentTimeMillis() - start;
+    logger.info("All records have been read and committed by the connector; "
+        + "total time from start to finish: {} seconds", time / 1000.0);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, KAFKA_FIELD_NAME + ".k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, numRecords)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  private Converter converter(boolean isKey) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, true);
+    Converter result = new JsonConverter();
+    result.configure(props, isKey);
+    return result;
+  }
+
+  private String key(Converter converter, String topic, long iteration) {
+    final Schema schema = SchemaBuilder.struct()
+        .field("k1", Schema.INT64_SCHEMA)
+        .build();
+
+    final Struct struct = new Struct(schema)
+        .put("k1", iteration);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String value(Converter converter, String topic, long iteration, boolean tombstone) {
+    final Schema schema = SchemaBuilder.struct()
+        .optional()
+        .field("f1", Schema.STRING_SCHEMA)
+        .field("f2", Schema.BOOLEAN_SCHEMA)
+        .field("f3", Schema.FLOAT64_SCHEMA)
+        .build();
+
+    if (tombstone) {
+      return new String(converter.fromConnectData(topic, schema, null));
+    }
+
+    final Struct struct = new Struct(schema)
+        .put("f1", iteration % 2 == 0 ? "a string" : "another string")
+        .put("f2", iteration % 3 == 0)
+        .put("f3", iteration / 0.69);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/retrieve/MemorySchemaRetrieverTest.java
@@ -26,7 +26,7 @@ public class MemorySchemaRetrieverTest {
     final TableId tableId = getTableId("testTable", "testDataset");
     SchemaRetriever retriever = new MemorySchemaRetriever();
     retriever.configure(new HashMap<>());
-    Assert.assertEquals(retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE), SchemaBuilder.struct().build());
+    Assert.assertEquals(SchemaBuilder.struct().build(), retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -39,7 +39,7 @@ public class MemorySchemaRetrieverTest {
     Schema expectedSchema = Schema.OPTIONAL_FLOAT32_SCHEMA;
     retriever.setLastSeenSchema(tableId, topic, expectedSchema);
 
-    Assert.assertEquals(retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.KEY), expectedSchema);
+    Assert.assertEquals(expectedSchema, retriever.retrieveSchema(tableId, topic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -56,9 +56,10 @@ public class MemorySchemaRetrieverTest {
     retriever.setLastSeenSchema(floatTableId, floatSchemaTopic, expectedFloatSchema);
     retriever.setLastSeenSchema(intTableId, intSchemaTopic, expectedIntSchema);
 
-    Assert.assertEquals(
-        retriever.retrieveSchema(floatTableId, floatSchemaTopic, KafkaSchemaRecordType.KEY), expectedFloatSchema);
-    Assert.assertEquals(retriever.retrieveSchema(intTableId, intSchemaTopic, KafkaSchemaRecordType.KEY), expectedIntSchema);
+    Assert.assertEquals(expectedFloatSchema,
+        retriever.retrieveSchema(floatTableId, floatSchemaTopic, KafkaSchemaRecordType.VALUE));
+    Assert.assertEquals(expectedIntSchema,
+        retriever.retrieveSchema(intTableId, intSchemaTopic, KafkaSchemaRecordType.VALUE));
   }
 
   @Test
@@ -73,6 +74,25 @@ public class MemorySchemaRetrieverTest {
     retriever.setLastSeenSchema(tableId, intSchemaTopic, firstSchema);
     retriever.setLastSeenSchema(tableId, intSchemaTopic, secondSchema);
 
-    Assert.assertEquals(retriever.retrieveSchema(tableId, intSchemaTopic, KafkaSchemaRecordType.VALUE), secondSchema);
+    Assert.assertEquals(secondSchema,
+        retriever.retrieveSchema(tableId, intSchemaTopic, KafkaSchemaRecordType.VALUE));
+  }
+
+  @Test
+  public void testRetrieveKeyAndValueSchema() {
+    final String schemaTopic = "test-key-and-value";
+    final TableId tableId = getTableId("testTable", "testDataset");
+    SchemaRetriever retriever = new MemorySchemaRetriever();
+    retriever.configure(new HashMap<>());
+
+    Schema keySchema = Schema.STRING_SCHEMA;
+    Schema valueSchema = Schema.OPTIONAL_BOOLEAN_SCHEMA;
+    retriever.setLastSeenSchema(tableId, schemaTopic, keySchema, KafkaSchemaRecordType.KEY);
+    retriever.setLastSeenSchema(tableId, schemaTopic, valueSchema, KafkaSchemaRecordType.VALUE);
+
+    Assert.assertEquals(keySchema,
+        retriever.retrieveSchema(tableId, schemaTopic, KafkaSchemaRecordType.KEY));
+    Assert.assertEquals(valueSchema,
+        retriever.retrieveSchema(tableId, schemaTopic, KafkaSchemaRecordType.VALUE));
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -287,6 +287,7 @@ public class BigQueryWriterTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "6");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
     return properties;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GCSToBQWriterTest.java
@@ -163,6 +163,7 @@ public class GCSToBQWriterTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_CONFIG, bigqueryRetry);
     properties.put(BigQuerySinkTaskConfig.BIGQUERY_RETRY_WAIT_CONFIG, bigqueryRetryWait);
+    properties.put(BigQuerySinkTaskConfig.TASK_ID_CONFIG, "9");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DATASETS_CONFIG, String.format(".*=%s", dataset));
     // gcs config

--- a/kcbq-connector/src/test/resources/log4j.properties
+++ b/kcbq-connector/src/test/resources/log4j.properties
@@ -1,0 +1,20 @@
+log4j.rootLogger=INFO, stdout
+
+# Send the logs to the console.
+#
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
+
+# These are used in the log4j properties file that ships by default with Connect
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.reflections=ERROR
+
+# We see a lot of WARN-level messages from this class when a table is created by the connector and
+# then written to shortly after. No need for that much noise during routine tests
+log4j.logger.com.wepay.kafka.connect.bigquery.write.batch.TableWriter=ERROR
+# Logs a message at INFO on every http request
+log4j.logger.org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster=WARN


### PR DESCRIPTION
Addresses #264

Implements upsert/delete functionality as proposed in the [collaborative design doc](https://docs.google.com/document/d/1p8_rLQqR9GIALIruB3-MjqR8EgYdaEw2rlFF1fxRJf0/edit#), fixes some bugs in the connector, and adds an embedded integration test framework and tests for upsert/delete.

Some notes:

- The README is updated to include instructions on running the new embedded integration tests. It should be fairly straightforward to run these if you're used to running the existing Docker-based integration tests as the same environment variables are used and, beyond that, all that's required is a Gradle one-liner.
- The integration testing framework added here can be expanded to include new tests and possibly address #285
- The `SchemaRetriever` API has been updated to differentiate between key and value schemas when invoking `setLastSeen`; this is done in a backwards-compatible fashion, so existing implementations of that interface should work with the updated API seamlessly.
- The `MemorySchemaRetriever` is updated to use that new API correctly (the existing one didn't differentiate between key and value schemas, which led to some buggy behavior that was unearthed during integration testing)
- The `SchemaManager` class is optimized to avoid redundant operations (which is useful in general but also specifically with upsert/delete enabled as create/update requests are much more likely in that case and the likelihood of them being redundant is fairly high)
- `BigQuerySinkTask` is tweaked to avoid creating multiple `BigQuery` and `SchemaManager` instances; both classes are thread-safe, so this should be fine
- Existing unit tests are modified to reflect some of these tweaks
- New unit tests are added for other changes