### PR TITLE
Add config option to ignore insert ids

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -211,7 +211,11 @@ public class BigQuerySinkTask extends SinkTask {
           }
           tableWriterBuilders.put(table, tableWriterBuilder);
         }
-        tableWriterBuilders.get(table).addRow(record);
+
+        if (config.getBoolean(BigQuerySinkTaskConfig.BIGQUERY_IGNORE_INSERT_ID_CONFIG))
+          tableWriterBuilders.get(table).addRowWithoutId(record);
+        else
+          tableWriterBuilders.get(table).addRow(record);
       }
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -120,6 +120,14 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
   private static final String BIGQUERY_CLUSTERING_FIELD_NAMES_DOC =
       "List of fields on which data should be clustered by in BigQuery, separated by commas";
 
+  public static final String BIGQUERY_IGNORE_INSERT_ID_CONFIG =                 "bigQueryIgnoreInsertId";
+  private static final ConfigDef.Type BIGQUERY_IGNORE_INSERT_ID_TYPE =           ConfigDef.Type.BOOLEAN;
+  private static final Boolean BIGQUERY_IGNORE_INSERT_ID_DEFAULT =               false;
+  private static final ConfigDef.Importance BIGQUERY_IGNORE_INSERT_ID_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String BIGQUERY_IGNORE_INSERT_ID_DOC =
+          "If true, rows are not deduplicated by BigQuery. This is the recommended way to " +
+                  " get higher streaming ingest quotas in certain regions.";
+
   static {
     config = BigQuerySinkConfig.getConfig()
         .define(
@@ -174,6 +182,12 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
             BIGQUERY_CLUSTERING_FIELD_NAMES_DEFAULT,
             BIGQUERY_CLUSTERING_FIELD_NAMES_IMPORTANCE,
             BIGQUERY_CLUSTERING_FIELD_NAMES_DOC
+        ).define(
+            BIGQUERY_IGNORE_INSERT_ID_CONFIG,
+            BIGQUERY_IGNORE_INSERT_ID_TYPE,
+            BIGQUERY_IGNORE_INSERT_ID_DEFAULT,
+            BIGQUERY_IGNORE_INSERT_ID_IMPORTANCE,
+            BIGQUERY_IGNORE_INSERT_ID_DOC
         );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -42,7 +42,7 @@ public class SinkRecordConverter {
         this.kafkaDataFieldName = kafkaDataFieldName;
     }
 
-    public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record) {
+    public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record, boolean ignoreRecordId) {
         Map<String, Object> convertedRecord = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
         if (kafkaKeyFieldName.isPresent()) {
             convertedRecord.put(kafkaKeyFieldName.get(), recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY));
@@ -53,7 +53,12 @@ public class SinkRecordConverter {
         if (sanitizeFieldName) {
             convertedRecord = FieldNameSanitizer.replaceInvalidKeys(convertedRecord);
         }
-        return InsertAllRequest.RowToInsert.of(getRowId(record), convertedRecord);
+
+        String rowId = getRowId(record);
+        if(ignoreRecordId)
+            rowId = null;
+
+        return InsertAllRequest.RowToInsert.of(rowId, convertedRecord);
     }
 
     private String getRowId(SinkRecord record) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/GCSBatchTableWriter.java
@@ -129,7 +129,16 @@ public class GCSBatchTableWriter implements Runnable {
      * @param record the row to add
      */
     public void addRow(SinkRecord record) {
-      rows.put(record, recordConverter.getRecordRow(record));
+      rows.put(record, recordConverter.getRecordRow(record, false));
+    }
+
+    /**
+     * Add a record to the builder ignoring the id of the row.
+     *
+     * @param record the row to add
+     */
+    public void addRowWithoutId(SinkRecord record) {
+      rows.put(record, recordConverter.getRecordRow(record, true));
     }
 
     public GCSBatchTableWriter build() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -172,7 +172,16 @@ public class TableWriter implements Runnable {
      * @param record the row to add
      */
     public void addRow(SinkRecord record) {
-      rows.put(record, recordConverter.getRecordRow(record));
+      rows.put(record, recordConverter.getRecordRow(record, false));
+    }
+
+    /**
+     * Add a record to the builder ignoring the id of the row.
+     *
+     * @param record the row to add
+     */
+    public void addRowWithoutId(SinkRecord record) {
+      rows.put(record, recordConverter.getRecordRow(record, true));
     }
 
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriterBuilder.java
@@ -32,6 +32,13 @@ public interface TableWriterBuilder {
   void addRow(SinkRecord sinkRecord);
 
   /**
+   * Add a record to the builder ignoring the id of the row.
+   *
+   * @param record the row to add
+   */
+  void addRowWithoutId(SinkRecord record);
+
+  /**
    * Create a {@link TableWriter} from this builder.
    * @return a TableWriter containing the given writer, table, topic, and all added rows.
    */

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -18,9 +18,7 @@ package com.wepay.kafka.connect.bigquery;
  */
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfigTest.java
@@ -172,4 +172,12 @@ public class BigQuerySinkTaskConfigTest {
 
     new BigQuerySinkTaskConfig(badConfigProperties);
   }
+
+  /** Test that the default setting for ignore row id is false */
+  @Test
+  public void testDefaultIgnoreIdSetting() {
+    Map<String, String> properties = propertiesFactory.getProperties();
+    BigQuerySinkTaskConfig config = new BigQuerySinkTaskConfig(properties);
+    assertFalse(config.getBoolean(BigQuerySinkTaskConfig.BIGQUERY_IGNORE_INSERT_ID_CONFIG));
+  }
 }


### PR DESCRIPTION
When inserting in streaming in BigQuery, if you set insert ids (default option with the connector), BigQuery will deduplicate the insertions and the quotas (number of rows per second, size in bytes per second) will be much lower than without deduplication.

Currently, there is no option in the connector to disable this deduplication. This pull request adds a configuration option to ignore insert ids, and insert all rows with `null` id. This will disable the deduplication in BigQuery (risking duplicates insertions) and the applicable quotas will be much higher (millions of rows per second, GBs per second).

The documentation of BigQuery contains a mention to this option in the Apache Beam connector. I am working with customers who are missing a similar configuration option in this connector.

With this pull request, you can set the option `bigQueryIgnoreInsertId` to `true` to insert without deduplication and with higher qutoas.

More info:

- https://cloud.google.com/bigquery/streaming-data-into-bigquery#disabling_best_effort_de-duplication
- https://cloud.google.com/bigquery/quotas#streaming_inserts